### PR TITLE
windsurf sse support

### DIFF
--- a/Source/VibeUE/Public/MCP/MCPServer.h
+++ b/Source/VibeUE/Public/MCP/MCPServer.h
@@ -149,8 +149,8 @@ private:
     /** Handle MCP JSON-RPC request */
     FString HandleMCPRequest(const FString& JsonBody, FString& InOutSessionId, bool& bOutIsNotification);
     
-    /** Handle SSE GET request - opens event stream */
-    bool HandleSSERequest(FSocket* ClientSocket, const TMap<FString, FString>& Headers);
+    /** Handle SSE GET request - opens event stream. bSendEndpointEvent=true for legacy /sse transport (Windsurf). */
+    bool HandleSSERequest(FSocket* ClientSocket, const TMap<FString, FString>& Headers, bool bSendEndpointEvent = false);
     
     /** Send SSE event to a client */
     bool SendSSEEvent(FSocket* ClientSocket, const FString& Data, int32 EventId = -1);
@@ -213,6 +213,10 @@ private:
     /** Active SSE connections */
     TArray<TSharedPtr<FMCPSSEConnection>> SSEConnections;
     FCriticalSection SSELock;
+
+    /** Pending responses queued before SSE connection opened (legacy SSE transport) */
+    TArray<FString> PendingSSEResponses;
+    FCriticalSection PendingSSELock;
     
     /** Next SSE event ID for resumability */
     TAtomic<int32> NextEventId;


### PR DESCRIPTION
Files modified across this session:

Source/VibeUE/Private/MCP/MCPServer.cpp

SSE event data collapsed to single line (root fix) SSE connection kept alive after endpoint event (keep-alive loop) Queue-and-wait for POST arriving before SSE opens
Connection: keep-alive in HTTP responses
Mcp-Session-Id header in 202 responses
bIsSessionless captured before HandleMCPRequest
Stale SSE socket detection and retry
Source/VibeUE/Public/MCP/MCPServer.h

Added PendingSSEResponses and PendingSSELock members

--------------
\.codeium\windsurf\mcp_config.json

{
  "mcpServers": {
    "VibeMCP": {
      "url": "http://127.0.0.1:8088/sse"
    }
  }
}