### PR TITLE
fix: change default MCP server port from 8080 to 8088 everywhere

### DIFF
--- a/Source/VibeUE/Private/MCP/MCPServer.cpp
+++ b/Source/VibeUE/Private/MCP/MCPServer.cpp
@@ -1421,7 +1421,7 @@ void FMCPServer::SaveEnabledToConfig(bool bEnabled)
 
 int32 FMCPServer::GetPortFromConfig()
 {
-    int32 Port = 8080; // Default port
+    int32 Port = 8088; // Default port
     GConfig->GetInt(TEXT("VibeUE.MCPServer"), TEXT("Port"), Port, GEditorPerProjectIni);
     return Port;
 }

--- a/Source/VibeUE/Private/UI/SAIChatWindow.cpp
+++ b/Source/VibeUE/Private/UI/SAIChatWindow.cpp
@@ -2245,7 +2245,7 @@ FReply SAIChatWindow::OnSettingsClicked()
             [
                 SNew(STextBlock)
                 .Text(FText::FromString(TEXT("Port:")))
-                .ToolTipText(FText::FromString(TEXT("Port for the MCP HTTP server. Default: 8080")))
+                .ToolTipText(FText::FromString(TEXT("Port for the MCP HTTP server. Default: 8088")))
             ]
             + SHorizontalBox::Slot()
             .FillWidth(0.6f)

--- a/Source/VibeUE/Public/Chat/ChatSession.h
+++ b/Source/VibeUE/Public/Chat/ChatSession.h
@@ -379,7 +379,7 @@ public:
     static bool GetMCPServerEnabledFromConfig();
     static void SaveMCPServerEnabledToConfig(bool bEnabled);
     
-    /** Get/Set MCP Server port (default: 8080) */
+    /** Get/Set MCP Server port (default: 8088) */
     static int32 GetMCPServerPortFromConfig();
     static void SaveMCPServerPortToConfig(int32 Port);
     
@@ -390,7 +390,7 @@ public:
     static void SaveMCPServerApiKeyToConfig(const FString& ApiKey);
     
     /** Default MCP Server port */
-    static constexpr int32 DefaultMCPServerPort = 8080;
+    static constexpr int32 DefaultMCPServerPort = 8088;
 
     // Delegates
     FOnMessageAdded OnMessageAdded;

--- a/Source/VibeUE/Public/MCP/MCPServer.h
+++ b/Source/VibeUE/Public/MCP/MCPServer.h
@@ -28,7 +28,7 @@ struct FMCPHostConfig
     bool bEnabled = true;
     
     /** Port to listen on */
-    int32 Port = 8080;
+    int32 Port = 8088;
     
     /** API key for authentication (empty = no auth required) */
     FString ApiKey;


### PR DESCRIPTION
## Summary

Fixes #283 — Ensures the default MCP server port is consistently `8088` across all code, comments, and UI tooltips.

## Changes

- `MCPServer.h` — `FMCPHostConfig::Port` default value → `8088`
- `MCPServer.cpp` — `GetPortFromConfig()` fallback default → `8088`
- `ChatSession.h` — `DefaultMCPServerPort` constexpr + doc comment → `8088`
- `SAIChatWindow.cpp` — settings panel port tooltip text → `8088`