### PR TITLE
Merge 5-7 to master: Port fix + Auto-scroll fix

### DIFF
--- a/Source/VibeUE/Public/UI/SAIChatWindow.h
+++ b/Source/VibeUE/Public/UI/SAIChatWindow.h
@@ -200,11 +200,14 @@ private:
     // ============ Auto-Scroll ============
 
     /**
-     * Whether the chat should auto-scroll to the bottom as new content arrives.
-     * Set to false when the user manually scrolls up to read earlier content.
-     * Restored to true when the user scrolls back to the bottom, or sends a message.
+     * Set to true when the user manually scrolls up (away from the bottom).
+     * When true, ScrollToBottom() becomes a no-op (unless bForce is passed).
+     * Cleared when the user scrolls back to the bottom, or when we force-scroll.
      */
-    bool bAutoScrollEnabled = true;
+    bool bUserHasScrolledUp = false;
+
+    /** Guard: true while we are performing a programmatic ScrollToEnd(). */
+    bool bIsProgrammaticScroll = false;
 
     /** Called when the user scrolls the message scroll box */
     void OnScrollBoxUserScrolled(float ScrollOffset);
@@ -278,8 +281,8 @@ private:
     /** Add a system notification to the chat UI (not stored in conversation history) */
     void AddSystemNotification(const FString& Message);
     
-    /** Scroll to the bottom of the message list */
-    void ScrollToBottom();
+    /** Scroll to the bottom of the message list. If bForce is false, won't scroll if user has scrolled up. */
+    void ScrollToBottom(bool bForce = false);
     
     /** Handle send button clicked */
     FReply OnSendClicked();


### PR DESCRIPTION
## Changes

### Fix #283: Default MCP server port changed from 8080 to 8088
- Updated default port across MCPServer.h, MCPServer.cpp, ChatSession.h, and SAIChatWindow.cpp
- Avoids conflicts with common services already using port 8080

### Fix #282: Chat no longer auto-scrolls when user has scrolled up
- Added `bUserHasScrolledUp` flag tracked via `OnUserScrolled` callback
- `ScrollToBottom()` respects user scroll position unless `bForce=true` (only on Send)
- `bIsProgrammaticScroll` guard prevents `ScrollToEnd()` from resetting the user's scroll state
- Tool call approval no longer force-scrolls, respecting user reading position

### Fix #287: Bulk asset operations batching (issue created, fix pending)