### PR TITLE
feat: add project MCP config and proxy launcher

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "VibeUE": {
+      "type": "http",
+      "url": "http://127.0.0.1:8089/mcp"
+    }
+  }
+}

--- a/start-vibeue-proxy.bat
+++ b/start-vibeue-proxy.bat
@@ -1,0 +1,27 @@
+@echo off
+:: VibeUE MCP Proxy Launcher
+:: Starts the proxy in the background (no console window).
+:: Add this to Windows startup: Win+R -> shell:startup -> paste shortcut here.
+
+set SCRIPT=%~dp0Content\Python\vibeue-proxy.py
+
+:: Kill any existing proxy running on port 8089 before restarting
+for /f "tokens=5" %%a in ('netstat -ano 2^>nul ^| findstr ":8089 "') do (
+    taskkill /PID %%a /F >nul 2>&1
+)
+
+:: Check Python is available
+where pythonw >nul 2>&1
+if %ERRORLEVEL% EQU 0 (
+    start "" /B pythonw "%SCRIPT%"
+    echo VibeUE proxy started on port 8089
+) else (
+    where python >nul 2>&1
+    if %ERRORLEVEL% EQU 0 (
+        start "" /B /MIN python "%SCRIPT%"
+        echo VibeUE proxy started on port 8089
+    ) else (
+        echo ERROR: Python not found. Install Python 3 and ensure it is on PATH.
+        pause
+    )
+)


### PR DESCRIPTION
## Summary

- Adds `.mcp.json` to configure Claude Code to use the VibeUE proxy (port 8089) for MCP tool access
- Adds `start-vibeue-proxy.bat` for launching the always-running proxy on Windows

## Details

The proxy sits between Claude Code and the UE MCP server (port 8088), allowing tool discovery to work even when Unreal Editor is not running. The `.mcp.json` points Claude Code at the proxy on port 8089.

## Test plan

- [ ] Ensure `start-vibeue-proxy.bat` launches the proxy silently
- [ ] Confirm Claude Code picks up VibeUE tools via `.mcp.json` in the project root
- [ ] Verify tool calls forward correctly to UE when the editor is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)