### PR TITLE
Fix Mac compilation error in UStateTreeService.cpp

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/UStateTreeService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UStateTreeService.cpp
@@ -1019,7 +1019,7 @@ bool UStateTreeService::CreateStateTree(const FString& AssetPath, const FString&
 	UClass* SchemaClass = nullptr;
 	for (TObjectIterator<UClass> It; It; ++It)
 	{
-		if (*It && It->IsChildOf(UStateTreeSchema::StaticClass()) && !It->HasAnyClassFlags(CLASS_Abstract))
+		if (It->IsChildOf(UStateTreeSchema::StaticClass()) && !It->HasAnyClassFlags(CLASS_Abstract))
 		{
 			if (It->GetName() == SchemaName)
 			{
@@ -1034,7 +1034,7 @@ bool UStateTreeService::CreateStateTree(const FString& AssetPath, const FString&
 		UE_LOG(LogStateTreeService, Warning, TEXT("CreateStateTree: Schema class not found: %s. Available schemas:"), *SchemaName);
 		for (TObjectIterator<UClass> It; It; ++It)
 		{
-			if (*It && It->IsChildOf(UStateTreeSchema::StaticClass()) && !It->HasAnyClassFlags(CLASS_Abstract))
+			if (It->IsChildOf(UStateTreeSchema::StaticClass()) && !It->HasAnyClassFlags(CLASS_Abstract))
 			{
 				UE_LOG(LogStateTreeService, Warning, TEXT("  - %s"), *It->GetName());
 			}


### PR DESCRIPTION
Removes redundant null checks on `TObjectIterator` dereference in `UStateTreeService.cpp` (lines 1022 and 1037) that cause compilation failure on Mac with Clang's `-Werror,-Wpointer-bool-conversion`.

`TObjectIterator::operator*` is declared `returns_nonnull`, so `*It` can never be null. Clang on macOS (Apple Clang / Xcode 16+) promotes this to a hard error. MSVC on Windows does not, which is likely why this wasn't caught during development.

## Changes

- Line 1022: `if (*It && It->IsChildOf(...))` → `if (It->IsChildOf(...))`
- Line 1037: same pattern

## Test environment

- macOS 26.3.1, Xcode 16.3 (Apple Clang)
- Unreal Engine 5.7
- M4 Max MacBook Pro