### PR TITLE
fix: proxy reliability improvements and connection docs overhaul

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,161 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 VibeUE is an Unreal Engine 5.7+ editor plugin that provides AI-powered development capabilities through an In-Editor Chat Client and Model Context Protocol (MCP) integration. The plugin exposes 14 multi-action tools with 177 total actions for manipulating Blueprints, UMG widgets, materials, assets, and more through natural language.
 
+## Connecting Claude Code to VibeUE (External MCP Clients)
+
+This section is for **any Claude Code session** working in a project that has VibeUE installed as a plugin.
+
+### Architecture
+
+There are two ways to connect — direct or via the optional proxy:
+
+```
+# Direct (simpler, requires UE to be running)
+Claude Code  →  Unreal Engine (port 8088)
+
+# Via proxy (optional, recommended for persistent setups)
+Claude Code  →  VibeUE Proxy (port 8089)  →  Unreal Engine (port 8088)
+```
+
+- **UE MCP server** (port 8088): available when the editor is running with VibeUE enabled
+- **Proxy** (port 8089, optional): serves tool definitions even when UE is closed; injects the bearer token so MCP clients don't need to handle auth
+- **Proxy script**: `<PluginRoot>/Content/Python/vibeue-proxy.py` (stdlib only, no pip dependencies)
+- **Tool manifest**: written by UE on startup to `%APPDATA%\VibeUE\tools-manifest.json` (Windows) or `~/Library/Application Support/VibeUE/tools-manifest.json` (Mac)
+
+### Option A — Direct Connection (no proxy)
+
+Point your MCP client straight at UE. UE must be running for any tool calls to work.
+
+**`~/.claude/mcp.json`:**
+```json
+{
+  "mcpServers": {
+    "VibeUE": {
+      "type": "http",
+      "url": "http://127.0.0.1:8088/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-token>"
+      }
+    }
+  }
+}
+```
+
+The token must match Project Settings → Plugins → VibeUE → API Key. If no API Key is set in UE, omit the `headers` block.
+
+### Option B — Via Proxy (recommended)
+
+The proxy adds two benefits: tool definitions are available even when UE is closed, and it handles bearer token injection so MCP clients need no auth config.
+
+**1. Set the bearer token**
+
+Create `vibeue-proxy.json` in the plugin root (next to the `.uplugin` file):
+
+```json
+{
+  "bearer_token": "<your-token>"
+}
+```
+
+This must match Project Settings → Plugins → VibeUE → API Key. If `vibeue-proxy.json` is missing or `bearer_token` is empty, the proxy warns on startup and forwards requests without auth.
+
+**2. Start the proxy**
+
+```powershell
+# Windows — runs silently in background
+Start-Process -FilePath 'pythonw.exe' -ArgumentList '<PluginRoot>\Content\Python\vibeue-proxy.py' -WindowStyle Hidden
+
+# Mac / Linux
+python3 <PluginRoot>/Content/Python/vibeue-proxy.py &
+```
+
+**Optional — auto-start on Windows login:** add a shortcut to `<PluginRoot>\Content\Python\start-vibeue-proxy.bat` in `shell:startup` (Win+R → `shell:startup`). The bat file kills any existing instance before starting, so duplicates are not an issue.
+
+**3. Point your MCP client at the proxy**
+
+**`~/.claude/mcp.json`:**
+```json
+{
+  "mcpServers": {
+    "VibeUE": {
+      "type": "http",
+      "url": "http://127.0.0.1:8089/mcp"
+    }
+  }
+}
+```
+
+No `Authorization` header needed — the proxy injects the token from `vibeue-proxy.json`.
+
+**4. Launch Unreal Engine** with your project and VibeUE plugin enabled.
+
+### Diagnosing and Fixing Connection Problems
+
+**Direct connection (Option A):**
+
+```bash
+curl -s -X POST http://127.0.0.1:8088/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <your-token>" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"test","version":"1.0"},"capabilities":{}}}'
+```
+- ✅ Got JSON with `"VibeUE"` → connected
+- ❌ `Connection refused` → UE is not running
+- ❌ `Invalid or missing API key` → token mismatch — check `~/.claude/mcp.json` vs Project Settings → VibeUE → API Key
+
+**Proxy connection (Option B) — run checks in order:**
+
+**Check 1 — Is the proxy running?**
+```bash
+curl -s -X POST http://127.0.0.1:8089/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"test","version":"1.0"},"capabilities":{}}}'
+```
+- ✅ Got JSON with `"VibeUE-Proxy"` → proxy is running, continue to Check 2
+- ❌ `Connection refused` → proxy is not running → start it (see Option B above)
+
+**Check 2 — Does the proxy have tools?**
+```bash
+curl -s -X POST http://127.0.0.1:8089/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'{len(d[\"result\"][\"tools\"])} tools loaded')"
+```
+- ✅ `N tools loaded` (N > 0) → manifest exists, continue to Check 3
+- ❌ `0 tools loaded` → manifest is missing → launch UE with VibeUE at least once to generate it
+
+**Check 3 — Is UE reachable through the proxy?**
+```bash
+curl -s -X POST http://127.0.0.1:8089/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"execute_python_code","arguments":{"code":"print(1)"}}}'
+```
+- ✅ Got `"success": true` → full stack working
+- ❌ `"Unreal Engine is not running"` → launch the Unreal Editor with VibeUE enabled
+- ❌ `"Unreal Engine rejected the request: Invalid or missing API key"` → token mismatch — check `vibeue-proxy.json` vs Project Settings → VibeUE → API Key, then restart the proxy
+
+**Check 4 — Stale proxy instance?**
+
+If the proxy fails to start because port 8089 is already in use:
+```powershell
+# Windows — find and kill stale proxy
+Get-NetTCPConnection -LocalPort 8089 -State Listen | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }
+# Then start the proxy again
+```
+
+Note: if Claude Code is diagnosing connection problems, also check `memory/MEMORY.md` — a stale token cached there can cause misleading curl test results.
+
+### Verifying the Full Stack
+
+```bash
+curl -s -X POST http://127.0.0.1:8089/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/list","params":{}}' \
+  | python3 -c "import sys,json; tools=json.load(sys.stdin)['result']['tools']; print('\n'.join(t['name'] for t in tools))"
+```
+
+---
+
 ## Essential Commands
 
 ### Building the Plugin

--- a/Content/Python/vibeue-proxy.py
+++ b/Content/Python/vibeue-proxy.py
@@ -26,6 +26,7 @@ import pathlib
 import sys
 import urllib.request
 import urllib.error
+import socket
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from datetime import datetime, timezone
 
@@ -40,8 +41,15 @@ UE_URL     = f"http://127.0.0.1:{UE_PORT}/mcp"
 APPDATA = os.environ.get("APPDATA", str(pathlib.Path.home()))
 MANIFEST_PATH = pathlib.Path(APPDATA) / "VibeUE" / "tools-manifest.json"
 
-# Bearer token is passed through from the incoming MCP client request
-# to UE, so no separate config is needed.
+# Load bearer token from vibeue-proxy.json (same directory as this script).
+# This token is injected into every outbound request to UE, so the MCP client
+# does not need to send auth — UE is still protected.
+_PROXY_CONFIG_PATH = pathlib.Path(__file__).parent.parent.parent / "vibeue-proxy.json"
+try:
+    with open(_PROXY_CONFIG_PATH) as _f:
+        _UE_BEARER_TOKEN = json.load(_f).get("bearer_token", "")
+except Exception:
+    _UE_BEARER_TOKEN = ""
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -69,13 +77,25 @@ def load_manifest() -> list:
 
 
 def forward_to_ue(body_bytes: bytes, headers: dict) -> tuple[bool, bytes]:
-    """Try to forward a raw request body to UE. Returns (success, response_bytes)."""
+    """Try to forward a raw request body to UE. Returns (success, response_bytes).
+
+    success=True  → UE returned a 2xx; response_bytes is valid JSON-RPC to forward as-is.
+    success=False → UE unreachable OR returned an error; response_bytes is a plain-text
+                    description of the problem (may be empty if connection failed outright).
+                    Caller must wrap this in a proper JSON-RPC error envelope.
+    """
     forward_headers = {
         "Content-Type": "application/json",
         "Accept": "application/json",
     }
-    # Pass through Authorization and MCP headers from the incoming request
-    for key in ("authorization", "mcp-protocol-version", "mcp-session-id"):
+    # Inject the UE bearer token directly from vibeue-proxy.json — do not rely on
+    # the MCP client forwarding it, as some clients (e.g. Claude Code) omit auth headers.
+    if _UE_BEARER_TOKEN:
+        forward_headers["Authorization"] = f"Bearer {_UE_BEARER_TOKEN}"
+    # Pass through MCP protocol version from the incoming request.
+    # Do NOT forward mcp-session-id — the proxy answers initialize itself and has no
+    # session with UE, so a client session ID forwarded verbatim would be rejected by UE.
+    for key in ("mcp-protocol-version",):
         if key in headers:
             forward_headers[key] = headers[key]
 
@@ -88,25 +108,34 @@ def forward_to_ue(body_bytes: bytes, headers: dict) -> tuple[bool, bytes]:
         )
         with urllib.request.urlopen(req, timeout=10) as resp:
             return True, resp.read()
-    except Exception:
+    except urllib.error.HTTPError as e:
+        # UE responded but rejected the request (e.g. 401 bad token, 404 unknown session).
+        # Return failure with the UE error text so the caller can surface it clearly.
+        body = e.read()
+        log(f"UE returned HTTP {e.code}: {body[:200]}")
+        return False, body
+    except (urllib.error.URLError, socket.timeout, OSError):
         return False, b""
 
 
-def ue_error_response(req_id, tool_name: str) -> dict:
+def ue_error_response(req_id, tool_name: str, ue_message: str = "") -> dict:
+    if ue_message:
+        text = (
+            f"Unreal Engine rejected the request: {ue_message}\n"
+            f"Check that the API token in ~/.claude/mcp.json matches "
+            f"Project Settings → Plugins → VibeUE → API Key."
+        )
+    else:
+        text = (
+            f"Unreal Engine is not running.\n"
+            f"Please launch UE with the VibeUE plugin enabled, "
+            f"then retry '{tool_name}'."
+        )
     return {
         "jsonrpc": "2.0",
         "id": req_id,
         "result": {
-            "content": [
-                {
-                    "type": "text",
-                    "text": (
-                        f"Unreal Engine is not running.\n"
-                        f"Please launch UE with the VibeUE plugin enabled, "
-                        f"then retry '{tool_name}'."
-                    ),
-                }
-            ],
+            "content": [{"type": "text", "text": text}],
             "isError": True,
         },
     }
@@ -116,6 +145,8 @@ def ue_error_response(req_id, tool_name: str) -> dict:
 # ---------------------------------------------------------------------------
 
 class ProxyHandler(BaseHTTPRequestHandler):
+
+    protocol_version = "HTTP/1.1"
 
     def log_message(self, fmt, *args):
         # Suppress default access log; we do our own
@@ -201,10 +232,11 @@ class ProxyHandler(BaseHTTPRequestHandler):
             self.wfile.write(response_bytes)
             log(f"{method} -> forwarded to UE")
         else:
-            log(f"{method} -> UE not running")
+            ue_msg = response_bytes.decode(errors="replace").strip() if response_bytes else ""
+            log(f"{method} -> UE error: {ue_msg or '(no response — UE not running or unreachable)'}")
             if method == "tools/call":
                 tool_name = (rpc.get("params") or {}).get("name", "unknown")
-                self._raw_json(ue_error_response(req_id, tool_name))
+                self._raw_json(ue_error_response(req_id, tool_name, ue_msg))
             else:
                 # ping, resources/list, etc. — return empty success
                 self._jsonrpc(req_id, {})
@@ -242,6 +274,15 @@ class ProxyHandler(BaseHTTPRequestHandler):
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
+    if not _PROXY_CONFIG_PATH.exists():
+        log(f"WARNING: vibeue-proxy.json not found at {_PROXY_CONFIG_PATH}")
+        log("Create it with {\"bearer_token\": \"<your-token>\"} to match UE Project Settings → VibeUE → API Key.")
+        log("Without it, requests to UE will be sent without auth and will fail if an API Key is set.")
+    elif not _UE_BEARER_TOKEN:
+        log(f"WARNING: vibeue-proxy.json exists but 'bearer_token' is empty — UE requests will be unauthenticated.")
+    else:
+        log(f"Bearer token loaded from vibeue-proxy.json")
+
     if not MANIFEST_PATH.exists():
         log(f"Note: manifest not found at {MANIFEST_PATH}")
         log("Launch Unreal Engine with VibeUE once to generate it.")


### PR DESCRIPTION
## Summary

Fixes several reliability issues with the MCP proxy that were causing AI clients to see "Unreal Engine is not running" even when UE was running, and documents the proxy as optional with clear setup instructions.

### vibeue-proxy.py

- **HTTPError handling** — auth failures (401) were being swallowed as connection errors, surfacing as "Unreal Engine is not running" instead of "Invalid or missing API key". Now caught separately and passed through as a proper JSON-RPC error response
- **Session ID stripping** — `mcp-session-id` was being forwarded from the MCP client to UE, causing rejections when the client had a stale session ID. Stripped from forwarded headers — the proxy handles its own sessions
- **Bearer token injection** — proxy now reads token from `vibeue-proxy.json` (plugin root) and injects it on every outbound request to UE. MCP clients no longer need to send auth headers, removing a common misconfiguration vector
- **HTTP/1.1** — switched from HTTP/1.0 default
- **Startup warnings** — proxy logs a clear warning if `vibeue-proxy.json` is missing or `bearer_token` is empty
- **JSON-RPC error envelope** — all error responses are now wrapped in valid JSON-RPC so MCP clients can always parse them

### CLAUDE.md

- Rewrote the connection section — proxy is now documented as optional
- Direct connection (port 8088) presented as Option A for simplicity
- Proxy (port 8089) presented as Option B with clear explanation of when it's worth using
- Diagnostics updated to reflect new token flow and improved error messages

## Related issues

- Relates to #315 (security: no warning when running without API key)
- Relates to #314 (first-run nudge for direct connections)