### PR TITLE
StateTree per-instance component parameter override API

### DIFF
--- a/Content/Skills/state-trees/skill.md
+++ b/Content/Skills/state-trees/skill.md
@@ -605,6 +605,64 @@ unreal.StateTreeService.remove_root_parameter(path, "my_float")
 unreal.StateTreeService.rename_root_parameter(path, "old_name", "new_name")
 ```
 
+### Per-Instance Parameter Overrides (Level Actors)
+
+StateTree parameters defined on the asset are the *defaults*. Placed actors have their own
+`StateTreeComponent` instance that can override each parameter value independently.
+
+**⚠️ LOAD THIS SKILL FIRST** — Do not attempt raw discovery of StateTreeComponent parameters.
+`set_component_parameter_override` handles type resolution automatically.
+
+#### Full Discovery Workflow
+
+When the user asks to set StateTree parameters on placed actors, follow this order:
+
+```python
+import unreal
+
+# Step 1: Find the exact actor names in the level
+actors = unreal.ActorService.list_level_actors()
+for a in actors:
+    print(f"{a.name}: {a.class_name}")
+# Look for actors whose class_name contains your Blueprint (e.g. "BP_Cube_C")
+
+# Step 2: Find the linked StateTree asset path for the actor
+st_path = unreal.StateTreeService.get_component_state_tree_path("bp_cube1")
+print(f"StateTree asset: {st_path}")
+# Returns something like: /Game/StateTree/ST_Cube
+
+# Step 3: Discover what parameters are available (names + types live in the asset)
+params = unreal.StateTreeService.get_root_parameters(st_path)
+for p in params:
+    print(f"{p.name}: {p.type} = {p.default_value!r}")
+# Output example: IdlingTime: Float = '2.0'   RotatingTime: Float = '1.0'
+
+# Step 4: Set per-instance overrides — type resolved automatically from the linked StateTree
+unreal.StateTreeService.set_component_parameter_override("bp_cube1", "IdlingTime", "3.0")
+unreal.StateTreeService.set_component_parameter_override("bp_cube1", "RotatingTime", "1.5")
+unreal.StateTreeService.set_component_parameter_override("bp_cube2", "IdlingTime", "1.0")
+unreal.StateTreeService.set_component_parameter_override("bp_cube2", "RotatingTime", "4.0")
+
+# Step 5: Save the level to persist overrides
+unreal.EditorLoadingAndSavingUtils.save_current_level()
+```
+
+#### Read Back Current Instance Values
+
+```python
+# Get current override values on a placed actor's StateTreeComponent
+overrides = unreal.StateTreeService.get_component_parameter_overrides("bp_cube1")
+for p in overrides:
+    print(f"{p.name}: {p.type} = {p.default_value!r}")
+```
+
+**Important notes:**
+- The actor name must match the in-level instance label (e.g. `bp_cube1`), NOT the Blueprint
+  class name. Use `ActorService.list_level_actors()` to discover exact names.
+- Parameter names are defined in the StateTree asset, NOT as Blueprint variables. Always use
+  `get_component_state_tree_path` + `get_root_parameters` to discover available names and types.
+- Value format is identical to `add_or_update_root_parameter`: `"3.14"`, `"true"`, `"Hello"`.
+
 ### Transition Editing
 
 ```python

--- a/Content/instructions/vibeue.instructions.md
+++ b/Content/instructions/vibeue.instructions.md
@@ -52,8 +52,28 @@ See the **Available Skills** section below for the full list.
 **Automatically load when:**
 - User mentions a domain ("create a blueprint", "add material parameter")
 - User asks to "see", "look at", or take a "screenshot"
-- User references asset prefixes (BP_, WBP_, IA_, IMC_, DT_, M_, MI_)
+- User references asset prefixes (BP_, WBP_, IA_, IMC_, DT_, M_, MI_, **ST_**)
 - You need service-specific API documentation
+- **You discover an actor has a `StateTreeComponent`** → load `state-trees` immediately
+- User mentions "state machine", "StateTree", "state transitions", or "parameters on an actor" where the actor has a StateTree
+
+**Quick Skill Mapping:**
+
+| Domain / Trigger | Skill to Load |
+|---|---|
+| BP_, Blueprint, Blueprint variables/functions/components | `blueprints` |
+| M_, MI_, Material, Material instance | `materials` |
+| DT_, DataTable, row | `data-tables` |
+| DA_, Data Asset | `data-assets` |
+| WBP_, Widget, UMG, HUD | `umg-widgets` |
+| IA_, IMC_, Input Action, Enhanced Input | `enhanced-input` |
+| Niagara, particle system, VFX | `niagara-systems` or `niagara-emitters` |
+| **ST_, StateTree, StateTreeComponent, state machine parameters** | **`state-trees`** |
+| Landscape, terrain | `landscape` |
+| Skeleton, skeleton asset | `skeleton` |
+| Level actor, place actor, spawn actor | `level-actors` |
+| Animation Blueprint | `animation-blueprint` |
+| Screenshot, capture, viewport | `screenshots` |
 
 **How to load:**
 ```python
@@ -75,6 +95,11 @@ manage_skills(action="load", skill_name="blueprints")
 User: "Create BP_Enemy with a Health variable"
 → Load "blueprints" skill
 → Use BlueprintService from skill docs
+
+User: "Set the IdlingTime parameter on bp_cube1 to 3.0"
+→ Recognise: actor + parameter → likely StateTree component parameter
+→ Load "state-trees" skill FIRST
+→ Use StateTreeService.set_component_parameter_override from skill docs
 ```
 
 ---

--- a/Source/VibeUE/Private/PythonAPI/UStateTreeService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UStateTreeService.cpp
@@ -16,6 +16,7 @@
 // StateTree core
 #include "StateTree.h"
 #include "StateTreeTypes.h"
+#include "StateTreeReference.h"
 #include "StateTreeTaskBase.h"
 #include "StateTreeEvaluatorBase.h"
 #include "StateTreeConditionBase.h"
@@ -31,6 +32,7 @@
 #include "UObject/UObjectIterator.h"
 
 #include "GameplayTagContainer.h"
+#include "PythonAPI/UActorService.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LogStateTreeService, Log, All);
 
@@ -1946,6 +1948,206 @@ bool UStateTreeService::RenameRootParameter(const FString& AssetPath, const FStr
 
 	SetPropertyBagValueFromString(Bag, NewFName, BagType, CurrentValue);
 	MarkStateTreeDirty(StateTree);
+	return true;
+#else
+	return false;
+#endif
+}
+
+// ============================================================
+// Component-level parameter overrides (level actor instances)
+// ============================================================
+
+namespace
+{
+	/** Find UStateTreeComponent class dynamically — avoids requiring GameplayStateTreeModule as a hard header dep. */
+	static UClass* GetStateTreeComponentClass()
+	{
+		static UClass* Cached = nullptr;
+		if (!Cached)
+		{
+			Cached = FindObject<UClass>(nullptr, TEXT("/Script/GameplayStateTreeModule.StateTreeComponent"));
+		}
+		return Cached;
+	}
+
+	/** Access the FStateTreeReference on a component via reflection (the property is protected). */
+	static FStateTreeReference* GetStateTreeRefFromComp(UActorComponent* Comp)
+	{
+		FStructProperty* Prop = FindFProperty<FStructProperty>(Comp->GetClass(), TEXT("StateTreeRef"));
+		if (!Prop || Prop->Struct != FStateTreeReference::StaticStruct())
+		{
+			return nullptr;
+		}
+		return Prop->ContainerPtrToValuePtr<FStateTreeReference>(Comp);
+	}
+} // anonymous namespace
+
+FString UStateTreeService::GetComponentStateTreePath(const FString& ActorNameOrLabel)
+{
+	AActor* Actor = UActorService::FindActorByIdentifier(ActorNameOrLabel);
+	if (!Actor) { return FString(); }
+
+	UClass* STCompClass = GetStateTreeComponentClass();
+	if (!STCompClass) { return FString(); }
+
+	UActorComponent* Comp = Actor->GetComponentByClass(STCompClass);
+	if (!Comp) { return FString(); }
+
+	FStateTreeReference* STRef = GetStateTreeRefFromComp(Comp);
+	if (!STRef || !STRef->IsValid()) { return FString(); }
+
+	const UStateTree* Tree = STRef->GetStateTree();
+	if (!Tree) { return FString(); }
+
+	// Convert object path to game content path (strip _C suffix, convert /Game/... format)
+	FString PackagePath = Tree->GetPackage()->GetName();
+	return PackagePath;
+}
+
+TArray<FStateTreeParameterInfo> UStateTreeService::GetComponentParameterOverrides(const FString& ActorNameOrLabel)
+{
+	TArray<FStateTreeParameterInfo> Result;
+
+	AActor* Actor = UActorService::FindActorByIdentifier(ActorNameOrLabel);
+	if (!Actor)
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("GetComponentParameterOverrides: Actor not found: %s"), *ActorNameOrLabel);
+		return Result;
+	}
+
+	UClass* STCompClass = GetStateTreeComponentClass();
+	if (!STCompClass)
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("GetComponentParameterOverrides: StateTreeComponent class not available"));
+		return Result;
+	}
+
+	UActorComponent* Comp = Actor->GetComponentByClass(STCompClass);
+	if (!Comp)
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("GetComponentParameterOverrides: Actor '%s' has no StateTreeComponent"), *ActorNameOrLabel);
+		return Result;
+	}
+
+	FStateTreeReference* STRef = GetStateTreeRefFromComp(Comp);
+	if (!STRef || !STRef->IsValid())
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("GetComponentParameterOverrides: StateTreeRef not set on actor '%s'"), *ActorNameOrLabel);
+		return Result;
+	}
+
+	const FInstancedPropertyBag& Bag = STRef->GetParameters();
+	const UPropertyBag* BagStruct = Bag.GetPropertyBagStruct();
+	if (!BagStruct)
+	{
+		return Result;
+	}
+
+	using namespace UStateTreeServiceHelpers;
+	for (const FPropertyBagPropertyDesc& Desc : BagStruct->GetPropertyDescs())
+	{
+		FStateTreeParameterInfo Info;
+		Info.Name = Desc.Name.ToString();
+		Info.Type = PropertyBagTypeToString(Desc.ValueType);
+		Info.DefaultValue = ExportPropertyBagValue(Bag, Desc.Name);
+		Result.Add(Info);
+	}
+	return Result;
+}
+
+bool UStateTreeService::SetComponentParameterOverride(const FString& ActorNameOrLabel,
+	const FString& ParameterName, const FString& Value)
+{
+	if (ParameterName.IsEmpty())
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("SetComponentParameterOverride: ParameterName is empty"));
+		return false;
+	}
+
+	AActor* Actor = UActorService::FindActorByIdentifier(ActorNameOrLabel);
+	if (!Actor)
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("SetComponentParameterOverride: Actor not found: %s"), *ActorNameOrLabel);
+		return false;
+	}
+
+	UClass* STCompClass = GetStateTreeComponentClass();
+	if (!STCompClass)
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("SetComponentParameterOverride: StateTreeComponent class not available"));
+		return false;
+	}
+
+	UActorComponent* Comp = Actor->GetComponentByClass(STCompClass);
+	if (!Comp)
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("SetComponentParameterOverride: Actor '%s' has no StateTreeComponent"), *ActorNameOrLabel);
+		return false;
+	}
+
+	FStateTreeReference* STRef = GetStateTreeRefFromComp(Comp);
+	if (!STRef || !STRef->IsValid())
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("SetComponentParameterOverride: StateTreeRef not set on actor '%s'"), *ActorNameOrLabel);
+		return false;
+	}
+
+#if WITH_EDITORONLY_DATA
+	// Resolve the parameter type from the linked StateTree asset's schema
+	UStateTree* LinkedTree = STRef->GetMutableStateTree();
+	UStateTreeEditorData* EditorData = GetEditorData(LinkedTree);
+	if (!EditorData)
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("SetComponentParameterOverride: Could not get editor data for linked StateTree on actor '%s'"), *ActorNameOrLabel);
+		return false;
+	}
+
+	const FInstancedPropertyBag& AssetBag = EditorData->GetRootParametersPropertyBag();
+	const FName ParamFName(*ParameterName);
+	const FPropertyBagPropertyDesc* AssetDesc = AssetBag.FindPropertyDescByName(ParamFName);
+	if (!AssetDesc)
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("SetComponentParameterOverride: Parameter '%s' not found in linked StateTree '%s'"),
+			*ParameterName, *LinkedTree->GetName());
+		return false;
+	}
+
+	const EPropertyBagPropertyType BagType = AssetDesc->ValueType;
+	const FGuid ParamGuid = AssetDesc->ID;  // Needed to mark as overridden
+
+	// Get (or lazily sync) the instance-level parameter bag
+	FInstancedPropertyBag& InstanceBag = STRef->GetMutableParameters();
+
+	// Ensure the instance bag has the property — sync with asset schema if stale
+	if (!InstanceBag.FindPropertyDescByName(ParamFName))
+	{
+		STRef->SetStateTree(LinkedTree); // triggers SyncParameters()
+		if (!InstanceBag.FindPropertyDescByName(ParamFName))
+		{
+			UE_LOG(LogStateTreeService, Warning, TEXT("SetComponentParameterOverride: Parameter '%s' not in instance bag after sync"), *ParameterName);
+			return false;
+		}
+	}
+
+	using namespace UStateTreeServiceHelpers;
+	if (!SetPropertyBagValueFromString(InstanceBag, ParamFName, BagType, Value))
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("SetComponentParameterOverride: Failed to set '%s' = '%s' on actor '%s'"),
+			*ParameterName, *Value, *ActorNameOrLabel);
+		return false;
+	}
+
+	// IMPORTANT: Mark this parameter as overridden so the instance value takes effect at runtime.
+	// Non-overridden parameters inherit from the StateTree asset defaults and ignore the bag value.
+	STRef->SetPropertyOverridden(ParamGuid, true);
+
+	// Mark dirty so the override is persisted when the level is saved
+	Comp->Modify();
+	Actor->Modify();
+
+	UE_LOG(LogStateTreeService, Log, TEXT("SetComponentParameterOverride: '%s' = '%s' on actor '%s'"),
+		*ParameterName, *Value, *ActorNameOrLabel);
 	return true;
 #else
 	return false;

--- a/Source/VibeUE/Public/PythonAPI/UActorService.h
+++ b/Source/VibeUE/Public/PythonAPI/UActorService.h
@@ -572,10 +572,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|Actors|Exists")
 	static bool ActorExistsByTag(const FString& Tag);
 
-private:
-	/** Helper: Find actor by name or label */
+	/** Find an actor in the current level by name or label (case-insensitive, falls back to contains-match). */
 	static AActor* FindActorByIdentifier(const FString& NameOrLabel);
 
+private:
 	/** Helper: Get the current editor world */
 	static UWorld* GetEditorWorld();
 

--- a/Source/VibeUE/Public/PythonAPI/UStateTreeService.h
+++ b/Source/VibeUE/Public/PythonAPI/UStateTreeService.h
@@ -505,6 +505,44 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
 	static bool RenameRootParameter(const FString& AssetPath, const FString& OldName, const FString& NewName);
 
+	// ---- Level Actor Component Parameter Overrides ----
+
+	/**
+	 * Get the game-content path of the StateTree asset linked to an actor's StateTreeComponent.
+	 * Use this to discover parameters available to override before calling set_component_parameter_override.
+	 * Then pass the returned path to get_root_parameters() to list all available parameter names and types.
+	 * @param ActorNameOrLabel  Name or label of the actor in the current level
+	 * @return Game path like "/Game/StateTrees/ST_Cube", or empty string if not found
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
+	static FString GetComponentStateTreePath(const FString& ActorNameOrLabel);
+
+	/**
+	 * Get the current parameter override values on a placed actor's StateTreeComponent.
+	 * Returns the same structure as get_root_parameters but reflects instance-level values.
+	 * Use this to inspect what values are set per-instance before or after calling set_component_parameter_override.
+	 * @param ActorNameOrLabel  Name or label of the actor in the current level
+	 * @return List of parameters with name, type, and current override value. Empty if actor or component not found.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
+	static TArray<FStateTreeParameterInfo> GetComponentParameterOverrides(const FString& ActorNameOrLabel);
+
+	/**
+	 * Set a per-instance parameter override on a placed actor's StateTreeComponent.
+	 * The parameter type is resolved from the linked StateTree asset — no type argument needed.
+	 * Supports all primitive types: Bool, Int32, Int64, Float, Double, Name, String, Text.
+	 * Value format matches add_or_update_root_parameter: "3.14", "true", "Hello", etc.
+	 * Call save_level (or use unreal.EditorLoadingAndSavingUtils) after setting overrides to persist.
+	 * @param ActorNameOrLabel  Name or label of the actor in the current level
+	 * @param ParameterName     Name of the root parameter to override (must exist in the linked StateTree)
+	 * @param Value             New value as a string (e.g. "3.14", "true", "Hello")
+	 * @return true if the override was applied successfully
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
+	static bool SetComponentParameterOverride(const FString& ActorNameOrLabel,
+	                                          const FString& ParameterName,
+	                                          const FString& Value);
+
 	// ---- Transition Editing ----
 
 	/**


### PR DESCRIPTION
## Summary

Adds a full per-instance StateTree parameter override API so the AI and Python scripts can set different parameter values on each placed actor's `StateTreeComponent` independently.

## New Methods on `UStateTreeService`

### `get_component_state_tree_path(actor_name_or_label)`
Returns the `/Game/...` asset path of the `StateTree` linked to an actor's `StateTreeComponent`. Use this to discover available parameter names via `get_root_parameters`.

### `get_component_parameter_overrides(actor_name_or_label)`
Returns the current instance-level bag values — same structure as `get_root_parameters` but reflects per-instance overrides.

### `set_component_parameter_override(actor_name_or_label, parameter_name, value)`
Sets a per-instance parameter value. Type is resolved automatically from the linked StateTree asset — no type argument needed. Supports all primitive types: Bool, Int32, Int64, Float, Double, Name, String, Text.

## Bug Fix

**Root cause of previous failures:** `FStateTreeReference` has a `TArray<FGuid> PropertyOverrides` array. Parameters whose GUID is not in this array are silently ignored at runtime and fall back to the asset default. The fix calls `STRef->SetPropertyOverridden(guid, true)` after writing the bag value so the override is actually applied.

## Other Changes

- `UActorService::FindActorByIdentifier` moved from `private` to `public` so `UStateTreeService` can call it
- `skill.md`: Full 5-step discovery workflow — list actors → get asset path → discover parameter names → set overrides → save level
- `vibeue.instructions.md`: Added `ST_` asset prefix trigger and a Quick Skill Mapping table so the AI automatically loads the `state-trees` skill when working with StateTree parameters on actors