### PR TITLE
fix: allocate default pins and normalise Branch pin aliases in ConnectNodes/GetNodePins

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -3078,13 +3078,34 @@ bool UBlueprintService::ConnectNodes(
 		return false;
 	}
 
+	// Ensure pins are allocated — default auto-placed K2Node_Event nodes (BeginPlay, Tick)
+	// may have an empty Pins array until AllocateDefaultPins() is called explicitly.
+	if (SourceNode->Pins.Num() == 0)
+	{
+		SourceNode->AllocateDefaultPins();
+	}
+	if (TargetNode->Pins.Num() == 0)
+	{
+		TargetNode->AllocateDefaultPins();
+	}
+
+	// Normalise Branch node pin name aliases: editor shows True/False, internal names are then/else.
+	auto NormalisePinName = [](const FString& Name) -> FString
+	{
+		if (Name.Equals(TEXT("True"), ESearchCase::IgnoreCase))  return TEXT("then");
+		if (Name.Equals(TEXT("False"), ESearchCase::IgnoreCase)) return TEXT("else");
+		return Name;
+	};
+	const FString ResolvedSourcePin = NormalisePinName(SourcePinName);
+	const FString ResolvedTargetPin = NormalisePinName(TargetPinName);
+
 	// Find source pin (output)
 	UEdGraphPin* SourcePin = nullptr;
 	for (UEdGraphPin* Pin : SourceNode->Pins)
 	{
 		if (Pin && Pin->Direction == EGPD_Output &&
-			(Pin->PinName.ToString().Equals(SourcePinName, ESearchCase::IgnoreCase) ||
-			 Pin->PinName == FName(*SourcePinName)))
+			(Pin->PinName.ToString().Equals(ResolvedSourcePin, ESearchCase::IgnoreCase) ||
+			 Pin->PinName == FName(*ResolvedSourcePin)))
 		{
 			SourcePin = Pin;
 			break;
@@ -3102,8 +3123,8 @@ bool UBlueprintService::ConnectNodes(
 	for (UEdGraphPin* Pin : TargetNode->Pins)
 	{
 		if (Pin && Pin->Direction == EGPD_Input &&
-			(Pin->PinName.ToString().Equals(TargetPinName, ESearchCase::IgnoreCase) ||
-			 Pin->PinName == FName(*TargetPinName)))
+			(Pin->PinName.ToString().Equals(ResolvedTargetPin, ESearchCase::IgnoreCase) ||
+			 Pin->PinName == FName(*ResolvedTargetPin)))
 		{
 			TargetPin = Pin;
 			break;
@@ -3575,6 +3596,12 @@ TArray<FBlueprintPinInfo> UBlueprintService::GetNodePins(
 	{
 		UE_LOG(LogTemp, Error, TEXT("GetNodePins: Node '%s' not found"), *NodeId);
 		return PinInfos;
+	}
+
+	// Default auto-placed event nodes may have an empty Pins array — allocate if needed.
+	if (Node->Pins.Num() == 0)
+	{
+		Node->AllocateDefaultPins();
 	}
 
 	for (UEdGraphPin* Pin : Node->Pins)


### PR DESCRIPTION
## Summary

- **`AllocateDefaultPins()` on empty pin arrays** — `connect_nodes` and `get_node_pins` were silently failing on default auto-placed `K2Node_Event` nodes (e.g. BeginPlay, Tick) because their `Pins` array is empty until explicitly allocated. Both methods now call `AllocateDefaultPins()` on any node with an empty array before attempting pin lookup.

- **Branch pin name aliases** — The Blueprint editor displays Branch output pins as `True` / `False`, but the internal pin names are `then` / `else`. `connect_nodes` now normalises `True → then` and `False → else` (case-insensitive) so callers can use the editor-visible names without knowing internal names.

## Fixes

Closes #324
Closes #323

## Test

Verified against UE 5.7.2 by creating a test Actor Blueprint via the Python API:
1. `get_node_pins` on the default BeginPlay event node — returns `OutputDelegate` + `then` correctly (was empty before)
2. `connect_nodes` from BeginPlay → Branch — succeeds (was failing silently before)
3. `connect_nodes` using `True`/`False` on Branch output pins — succeeds (was failing before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)