### PR TITLE
fix: proxy stability — ThreadingHTTPServer, protocol version echo, GET handler

### DIFF
--- a/Content/Python/vibeue-proxy.py
+++ b/Content/Python/vibeue-proxy.py
@@ -106,7 +106,7 @@ def forward_to_ue(body_bytes: bytes, headers: dict) -> tuple[bool, bytes]:
             headers=forward_headers,
             method="POST",
         )
-        with urllib.request.urlopen(req, timeout=10) as resp:
+        with urllib.request.urlopen(req, timeout=120) as resp:
             return True, resp.read()
     except urllib.error.HTTPError as e:
         # UE responded but rejected the request (e.g. 401 bad token, 404 unknown session).


### PR DESCRIPTION
## Summary

Four fixes to `vibeue-proxy.py` that together eliminate mid-session flakiness where the MCP tool would return "Unreal Engine is not running" while UE was actually processing a request.

- **`ThreadingHTTPServer` instead of `HTTPServer`** — the single-threaded server blocked all incoming requests behind a slow `tools/call` (UE execution takes 200–500ms). Claude Code sends concurrent pings/polls during that window; with a single-threaded server they timed out and dropped the connection, triggering the false "UE not running" error. `ThreadingHTTPServer` handles each request in its own thread.

- **UE forward timeout raised from 10s to 120s** — heavy Python calls in real projects (load_asset, property traversal on large BPs, auto-save before execution with many dirty packages) reliably exceeded the 10s limit. 120s matches UE's own request timeout.

- **`protocol_version = "HTTP/1.1"` removed from `ProxyHandler`** — setting this on the handler caused Claude Code's connection resets to abort the MCP handshake before `tools/list` completed, so tools never loaded in a new session.

- **`initialize` echoes client protocol version** — the hardcoded `protocolVersion: "2025-11-25"` in the `initialize` response was rejected by Claude Code. The proxy now echoes back whatever version the client sends.

- **`do_GET` fixed** — previously forwarded an empty body to UE as a POST (always failed). Now returns a simple health-check plaintext response, which is all a GET to this endpoint should do.

## Fixes

Relates to #325 — addresses the threading root cause of mid-session tool drops. Note: the session init limitation (tools only load at session start) described in #325 is a Claude Code behaviour and remains unchanged.

## Test

Verified by firing 5 concurrent requests (slow `tools/call` + 2× `tools/list` + `ping` + `initialize`) against the updated proxy — all returned `OK` with correct responses, with no blocking.

Relates to #327 (log hammering from frequent reconnects — separate issue, not addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)