### PR TITLE
fix: use TryGet variants to silence LogJson warnings on every tool response

### DIFF
--- a/Source/VibeUE/Private/MCP/MCPServer.cpp
+++ b/Source/VibeUE/Private/MCP/MCPServer.cpp
@@ -1058,9 +1058,12 @@ FString FMCPServer::HandleToolsCall(TSharedPtr<FJsonObject> Params, const FStrin
     TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(ToolResult);
     if (FJsonSerializer::Deserialize(Reader, ResultJson) && ResultJson.IsValid())
     {
-        // Check if success field is false, or if error field has content
-        bool bSuccess = ResultJson->GetBoolField(TEXT("success"));
-        FString ErrorMsg = ResultJson->GetStringField(TEXT("error"));
+        // Check if success field is false, or if error field has content.
+        // Use TryGet variants to avoid LogJson warnings when fields are absent.
+        bool bSuccess = true;
+        ResultJson->TryGetBoolField(TEXT("success"), bSuccess);
+        FString ErrorMsg;
+        ResultJson->TryGetStringField(TEXT("error"), ErrorMsg);
         bIsError = !bSuccess || !ErrorMsg.IsEmpty();
     }
     else


### PR DESCRIPTION
## Summary

`MCPServer.cpp` was calling `GetBoolField("success")` and `GetStringField("error")` unconditionally when parsing tool results. On every successful tool response the `error` field is absent, causing two log warnings per call:

```
LogJson: Warning: Field error was not found.
LogJson: Warning: Json Value of type 'Null' used as a 'String'.
```

Switched to `TryGetBoolField` / `TryGetStringField` so missing fields are handled silently. Logic is unchanged — `bSuccess` defaults to `true` and `ErrorMsg` defaults to empty, matching the previous behaviour for well-formed responses.

## Test

Verified against UE 5.7.2: fired multiple `execute_python_code` calls and confirmed no `LogJson` warnings appear in the output log post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)