### PR TITLE
fix: use GetFriendlyTypeName in ListVariables and GetVariableInfo

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -104,7 +104,7 @@ TArray<FBlueprintVariableInfo> UBlueprintService::ListVariables(const FString& B
 	{
 		FBlueprintVariableInfo VarInfo;
 		VarInfo.VariableName = VarDesc.VarName.ToString();
-		VarInfo.VariableType = VarDesc.VarType.PinCategory.ToString();
+		VarInfo.VariableType = FBlueprintTypeParser::GetFriendlyTypeName(VarDesc.VarType);
 		VarInfo.Category = VarDesc.Category.ToString();
 		VarInfo.bIsPublic = (VarDesc.PropertyFlags & CPF_DisableEditOnInstance) == 0;
 		VarInfo.bIsExposed = (VarDesc.PropertyFlags & CPF_ExposeOnSpawn) != 0;
@@ -1465,7 +1465,7 @@ bool UBlueprintService::GetVariableInfo(
 		if (VarDesc.VarName.ToString() == VariableName)
 		{
 			OutInfo.VariableName = VarDesc.VarName.ToString();
-			OutInfo.VariableType = VarDesc.VarType.PinCategory.ToString();
+			OutInfo.VariableType = FBlueprintTypeParser::GetFriendlyTypeName(VarDesc.VarType);
 			OutInfo.Category = VarDesc.Category.ToString();
 			OutInfo.DefaultValue = VarDesc.DefaultValue;
 


### PR DESCRIPTION
## Summary

`ListVariables` and `GetVariableInfo` were calling `VarDesc.VarType.PinCategory.ToString()` directly, which leaks UE internal pin category names instead of user-facing type names:

| Input type | Before | After |
|---|---|---|
| `float` | `real` | `float` |
| `double` | `real` | `double` |
| `FVector` | `struct` | `Vector` |
| `AActor` | `object` | `Actor` |
| `bool` | `bool` | `bool` |

`FBlueprintTypeParser::GetFriendlyTypeName` already existed and handles all cases correctly (PC_Real subcategory disambiguation, struct/object name from PinSubCategoryObject, container wrappers). This change just uses it consistently.

## Test

Verified against UE 5.7.2 — added variables of types `bool`, `float`, `int`, `string`, `vector` to a test blueprint and confirmed `list_variables` returns the correct friendly names for all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)