### PR TITLE
fix: CDO safety filter — allow read-only get_default_object, block only inline modification

### DIFF
--- a/Content/Skills/blueprints/skill.md
+++ b/Content/Skills/blueprints/skill.md
@@ -136,32 +136,57 @@ Direct Blueprint introspection APIs are largely missing or protected in UE 5.7 P
 | What you might try | Result |
 |---|---|
 | `bp.get_editor_property('simple_construction_script')` | Blocked — protected property |
+| `bp.simple_construction_script` | AttributeError — not exposed |
+| `scs.get_all_nodes()` | Runtime crash ("^") |
 | `BlueprintEditorLibrary.get_blueprint_component_names()` | Doesn't exist in UE 5.7 |
-| `BlueprintEditorLibrary.get_blueprint_variable_names()` | Doesn't exist in UE 5.7 |
-| `bp.generated_class().get_default_object()` | Blocked by VibeUE CDO safety guard |
+| `SubobjectDataSubsystem.k2_gather_subobject_data_for_blueprint(bp)` | Returns handles but `SubobjectData` exposes no properties from Python |
+| `bp.get_editor_property('parent_class')` | RuntimeError — `parent_class` not an editor property on Blueprint |
+| `bp.parent_class` | AttributeError — not exposed |
 
-**Working pattern — spawn, read, destroy:**
+**Working pattern — CDO (preferred, no spawn needed):**
 
 ```python
 import unreal
 
-bp_path = "/Game/Blueprints/BP_MyActor"
-bp = unreal.load_asset(bp_path)
-gen_class = bp.generated_class()
+bp = unreal.EditorAssetLibrary.load_asset("/Game/Blueprints/BP_MyActor")
+# Note: unreal.load_asset() returns None on a fresh session; use EditorAssetLibrary.load_asset()
 
-# Spawn at a safe location off-screen
-location = unreal.Vector(999999, 999999, 999999)
-actor = unreal.EditorLevelLibrary.spawn_actor_from_class(gen_class, location)
+gc = bp.generated_class()
+cdo = unreal.get_default_object(gc)   # module-level call; read-only is allowed
 
-# Read components
-for comp in actor.get_components_by_class(unreal.ActorComponent):
+for comp in cdo.get_components_by_class(unreal.ActorComponent):
     print(f"{comp.get_class().get_name()}: {comp.get_name()}")
-
-# Clean up
-unreal.EditorLevelLibrary.destroy_actor(actor)
 ```
 
-This is the only reliable path for inspecting BP component setup from Python.
+CDO modification is still blocked — `unreal.get_default_object(gc).set_editor_property(...)` raises `PYTHON_UNSAFE_CODE`.
+
+**Getting parent class — use asset registry tag:**
+
+```python
+import unreal
+
+ar = unreal.AssetRegistryHelpers.get_asset_registry()
+assets = ar.get_assets_by_path("/Game/Blueprints", False)
+for a in assets:
+    if "BP_MyActor" in str(a.asset_name):
+        print(a.get_tag_value("ParentClass"))        # e.g. "/Script/Engine.Actor"
+        print(a.get_tag_value("NativeParentClass"))  # same, native C++ parent
+        break
+```
+
+**Listing all Blueprints by class — use `get_assets_by_class`:**
+
+```python
+import unreal
+
+# ARFilter properties cannot be set after construction — don't use ARFilter for class filtering.
+# asset_class_names kwarg does not exist. Use get_assets_by_class instead:
+ar = unreal.AssetRegistryHelpers.get_asset_registry()
+bp_class = unreal.TopLevelAssetPath("/Script/Engine", "Blueprint")
+assets = ar.get_assets_by_class(bp_class, True)   # True = include derived classes
+for a in assets:
+    print(f"{a.package_path}/{a.asset_name}")
+```
 
 ### Material Parameters
 

--- a/Source/VibeUE/Private/Tools/PythonExecutionService.cpp
+++ b/Source/VibeUE/Private/Tools/PythonExecutionService.cpp
@@ -88,12 +88,21 @@ static bool ContainsDangerousPattern(const FString& Code, FString& OutPattern, F
 		return true;
 	}
 	
-	// Direct CDO modification causes crashes
-	if (Code.Contains(TEXT("get_default_object")) && (Code.Contains(TEXT("set_editor_property")) || Code.Contains(TEXT("="))))
+	// Direct CDO modification causes crashes — block only when modifying, not reading.
+	// Use regex to detect modification patterns on the CDO result directly (inline or via chained call).
+	// Simple Contains checks are too broad — they fire when set_editor_property or = appear anywhere
+	// in the script, even on unrelated objects.
 	{
-		OutPattern = TEXT("get_default_object() modification");
-		OutReason = TEXT("Modifying Class Default Objects (CDOs) from Python causes crashes. Modify instances instead.");
-		return true;
+		// Inline: get_default_object(...).set_editor_property(...) on the same line.
+		// Uses [^\n]* to skip nested parens (e.g. get_default_object(bp.generated_class())).
+		static FRegexPattern CdoModifyPattern(TEXT("get_default_object\\b[^\\n]*\\.\\s*set_editor_property"));
+		FRegexMatcher CdoModifyMatcher(CdoModifyPattern, Code);
+		if (CdoModifyMatcher.FindNext())
+		{
+			OutPattern = TEXT("get_default_object() modification");
+			OutReason = TEXT("Modifying Class Default Objects (CDOs) from Python causes crashes. Modify instances instead.");
+			return true;
+		}
 	}
 	
 	// input() blocks the editor indefinitely


### PR DESCRIPTION
## Problem

The CDO safety filter in `PythonExecutionService.cpp` used a `Contains` check that blocked any script containing both `get_default_object` and `=` (or `set_editor_property`). Since virtually every Python script contains `=`, read-only CDO access was completely unusable — legitimate inspection calls like `cdo = unreal.get_default_object(gc)` were always rejected with `PYTHON_UNSAFE_CODE`.

## Fix

Replaced the naive `Contains` checks with a regex that only fires on actual inline modification patterns on the CDO result:

```
get_default_object(...).set_editor_property(...)   ← BLOCKED
cdo = unreal.get_default_object(gc)                ← ALLOWED (read-only)
```

The regex uses `[^\n]*` to correctly handle nested parentheses (e.g. `get_default_object(bp.generated_class())`).

## Working pattern (now enabled)

```python
import unreal

bp = unreal.EditorAssetLibrary.load_asset("/Game/Blueprints/BP_MyActor")
gc = bp.generated_class()
cdo = unreal.get_default_object(gc)   # now allowed

for comp in cdo.get_components_by_class(unreal.ActorComponent):
    print(f"{comp.get_class().get_name()}: {comp.get_name()}")
```

Tested against `BP_PlayerUnitTest` in Invasion — correctly returns parent class `PlayerUnit` and components `CapsuleCollider` + `HealthBarWidget`.

## Also included

Updates `blueprints/skill.md` with confirmed working patterns for:
- CDO component inspection via `unreal.get_default_object(gc)`
- Parent class lookup via `asset_data.get_tag_value("ParentClass")`
- Class-based asset filtering via `ar.get_assets_by_class(TopLevelAssetPath(...))`
- Documents dead ends: `ARFilter` class kwargs, SCS iteration, `bp.parent_class`

## Test plan

- [ ] Script with bare assignment is **allowed**: `cdo = unreal.get_default_object(bp.generated_class())`
- [ ] Inline modification is **blocked**: `unreal.get_default_object(gc).set_editor_property("x", 1)` → returns `PYTHON_UNSAFE_CODE`
- [ ] CDO component inspection returns expected components (e.g. `BP_PlayerUnitTest` → `CapsuleCollider`, `HealthBarWidget`)
- [ ] A normal script containing `=` and no CDO call is unaffected