### PR TITLE
fix: guard GameplayTagsEditor module and includes behind WITH_EDITOR

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/UGameplayTagService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UGameplayTagService.cpp
@@ -4,7 +4,9 @@
 #include "GameplayTagsManager.h"
 #include "GameplayTagContainer.h"
 #include "GameplayTagsSettings.h"
+#if WITH_EDITOR
 #include "GameplayTagsEditorModule.h"
+#endif
 #include "Modules/ModuleManager.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LogGameplayTagService, Log, All);
@@ -138,6 +140,8 @@ TArray<FGameplayTagInfo> UGameplayTagService::GetChildren(const FString& ParentT
 // =================================================================
 // Add Operations
 // =================================================================
+
+#if WITH_EDITOR
 
 FGameplayTagResult UGameplayTagService::AddTag(const FString& TagName, const FString& Comment, const FString& TagSource)
 {
@@ -318,3 +322,5 @@ FGameplayTagResult UGameplayTagService::RenameTag(const FString& OldTagName, con
 
 	return Result;
 }
+
+#endif // WITH_EDITOR

--- a/Source/VibeUE/Public/PythonAPI/UGameplayTagService.h
+++ b/Source/VibeUE/Public/PythonAPI/UGameplayTagService.h
@@ -156,6 +156,7 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|GameplayTags")
 	static TArray<FGameplayTagInfo> GetChildren(const FString& ParentTag);
 
+#if WITH_EDITOR
 	// =================================================================
 	// Add Operations
 	// =================================================================
@@ -204,6 +205,7 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|GameplayTags")
 	static FGameplayTagResult RenameTag(const FString& OldTagName, const FString& NewTagName);
+#endif // WITH_EDITOR
 
 private:
 	/** Helper to populate FGameplayTagInfo from the tag manager */

--- a/Source/VibeUE/VibeUE.Build.cs
+++ b/Source/VibeUE/VibeUE.Build.cs
@@ -95,7 +95,6 @@ public class VibeUE : ModuleRules
 				"StateTreeEditorModule",  // For FStateTreeCompiler, UStateTreeState, StateTree editor types
 				"PropertyBindingUtils",    // For FPropertyBindingBindableStructDescriptor (base of FStateTreeBindableStructDesc)
 				"GameplayTags",           // For FGameplayTag (required by StateTree)
-				"GameplayTagsEditor",     // For IGameplayTagsEditorModule (add/remove/rename tags at editor time)
 				"AudioEditor",            // For SoundCue graph classes (USoundCueGraphNode, USoundCueGraph, USoundCueFactoryNew)
 				"MetasoundEngine",        // For UMetaSoundSource, UMetaSoundBuilderSubsystem, UMetaSoundSourceBuilder
 				"MetasoundFrontend",      // For FMetaSoundFrontendDocumentBuilder, FMetasoundFrontendClassName, ISearchEngine
@@ -118,6 +117,7 @@ public class VibeUE : ModuleRules
 					"StatusBar",           // For panel drawer integration
 					"ContentBrowser",      // For content browser selection queries
 					"MetasoundEditor",     // For UMetaSoundEditorSubsystem (FindOrBeginBuilding, BuildToAsset)
+				"GameplayTagsEditor",  // For IGameplayTagsEditorModule (add/remove/rename tags at editor time)
 				}
 			);
 		}


### PR DESCRIPTION
## Problem

`GameplayTagsEditor` was listed in the **unconditional** `PrivateDependencyModuleNames` block in `VibeUE.Build.cs`. This causes a hard compile error when building any non-editor (game/standalone) target:

```
[4/12] Compile [x64] UGameplayTagService.cpp
UGameplayTagService.cpp(7,1): Error C1083: Cannot open include file:
'GameplayTagsEditorModule.h': No such file or directory
```

`GameplayTagsEditor` is an **editor-only module** — it does not exist in non-editor builds. The error is silent on editor targets (e.g. `UnrealEditor`) because they satisfy the dependency, which is why it was never caught in a development-only setup. It only surfaces when building the standalone game target.

## Root Cause

Three things were wrong together:

1. `"GameplayTagsEditor"` in `Build.cs` was outside the `if (Target.bBuildEditor == true)` guard
2. `#include "GameplayTagsEditorModule.h"` was unconditional in the `.cpp`
3. `AddTag`, `AddTags`, `RemoveTag`, and `RenameTag` all call `IGameplayTagsEditorModule::Get()` — which is only valid inside the editor — with no `#if WITH_EDITOR` guard

## Fix

- Moved `"GameplayTagsEditor"` into the `if (Target.bBuildEditor == true)` block in `VibeUE.Build.cs`
- Wrapped `#include "GameplayTagsEditorModule.h"` in `#if WITH_EDITOR` in the `.cpp`
- Wrapped the four mutation function **declarations** (header) and **implementations** (cpp) in `#if WITH_EDITOR`

## Scope

Query-only functions — `ListTags`, `HasTag`, `GetTagInfo`, `GetChildren` — use only `UGameplayTagsManager` (runtime module, always available) and are **unaffected**. They continue to work in all build configurations.

Mutation functions (`AddTag`, `AddTags`, `RemoveTag`, `RenameTag`) inherently require the editor to persist changes to INI, so editor-only gating is semantically correct, not just a build workaround.

## Impact

Any project that includes VibeUE and builds a game target (packaging, standalone play, dedicated server) would fail to compile without this fix.