### PR TITLE
Fix array function wildcard pin type propagation and update skill docs

### DIFF
--- a/Content/Help/manage_asset/search.md
+++ b/Content/Help/manage_asset/search.md
@@ -11,7 +11,7 @@ Search for assets by partial name and optional asset type.
 
 ## Notes
 
-- Searches only `/Game/` content. For Engine content use `list` with `path="/Engine"`.
+- Searches all mounted content roots: `/Game/`, `/Engine/`, and all plugin content (e.g. `/VibeUE/`).
 - Returns up to all matching assets — filter with `asset_type` to narrow results.
 - Use the returned `object_path` or `package_name` as the `asset_path` for subsequent operations.
 

--- a/Content/Skills/blueprint-graphs/skill.md
+++ b/Content/Skills/blueprint-graphs/skill.md
@@ -20,6 +20,8 @@ keywords:
   - branch
   - math
   - execute
+  - array
+  - wildcard
 related_skills:
   - blueprints
 ---
@@ -591,10 +593,78 @@ For `add_function_call_node(path, graph, class, func, x, y)`:
 - **KismetMathLibrary** — Math (Add_DoubleDouble, Multiply_DoubleDouble, Sin, Sqrt)
 - **KismetSystemLibrary** — System (PrintString, Delay, K2_SetTimerDelegate)
 - **KismetStringLibrary** — String (Concat_StrStr, MakeLiteralString, Contains)
+- **KismetArrayLibrary** — Array operations (Array_Length, Array_Random, Array_Add, Array_Remove, Array_Clear)
 - **GameplayStatics** — Game (GetPlayerController, SpawnActor)
 - **Actor** — Actor functions, but discover the exact callable/spawner first for graph nodes like `Get Actor Location` and `Set Actor Location`
 - **PrimitiveComponent** — Physics (SetSimulatePhysics)
 - **SceneComponent** — Transform (AddRelativeRotation, SetRelativeLocation)
+
+---
+
+## Array Operations
+
+Array operations use **wildcard pins** — the `TargetArray` and element pins start with no type until a typed array is connected. The engine automatically propagates the array element type through all wildcard pins when you connect a typed array variable.
+
+### Available Array Functions (KismetArrayLibrary)
+
+| Function | Purpose | Key Pins |
+|----------|---------|----------|
+| `Array_Length` | Get array element count | TargetArray(in), ReturnValue(int) |
+| `Array_LastIndex` | Get last valid index | TargetArray(in), ReturnValue(int) |
+| `Array_IsEmpty` | Check if empty | TargetArray(in), ReturnValue(bool) |
+| `Array_Random` | Get random element | TargetArray(in), OutItem(out), OutIndex(int) |
+| `Array_Add` | Add element, returns index | TargetArray(in/out), NewItem(in), ReturnValue(int) |
+| `Array_Remove` | Remove by index | TargetArray(in/out), IndexToRemove(int) |
+| `Array_Clear` | Remove all elements | TargetArray(in/out) |
+| `Array_Contains` | Check if item exists | TargetArray(in), ItemToFind(in), ReturnValue(bool) |
+| `Array_Append` | Append another array | TargetArray(in/out), SourceArray(in) |
+
+### ⚠️ Array Get — Use `discover_nodes` First
+
+`Array_Get` is marked **BlueprintInternalUseOnly** and is replaced by the dedicated `K2Node_GetArrayItem` node in modern UE5. Do NOT try to call `Array_Get` directly.
+
+To get an element from an array by index:
+
+```python
+# 1. Discover the correct node key
+result = unreal.BlueprintService.discover_nodes(bp_path, "MyFunction", "get array")
+# Look for: "Get" with key "NODE K2Node_GetArrayItem"
+
+# 2. Create the node
+node_id = unreal.BlueprintService.create_node_by_key(bp_path, "MyFunction", "NODE K2Node_GetArrayItem", 400, 200)
+```
+
+### Wildcard Pin Type Propagation
+
+When you connect a typed array to an array function's `TargetArray` pin, the engine automatically resolves
+all wildcard pins on that node to the correct element type. This is handled by `UK2Node_CallArrayFunction`.
+
+**Pattern for array operations in `build_graph`:**
+
+```python
+result = unreal.BlueprintService.build_graph(bp_path, graph_name,
+    nodes=[
+        # Get the array variable
+        {"ref": "get_arr", "type": "variable_get", "params": {"variable": "MyTargetPoints"}},
+        # Get array length
+        {"ref": "arr_len", "type": "spawner_key", "params": {"key": "FUNC KismetArrayLibrary::Array_Length"}},
+        # Get random element
+        {"ref": "arr_rand", "type": "spawner_key", "params": {"key": "FUNC KismetArrayLibrary::Array_Random"}},
+    ],
+    connections=[
+        # Connect typed array to wildcard pins — type propagation happens automatically
+        ["get_arr.MyTargetPoints", "arr_len.TargetArray"],
+        ["get_arr.MyTargetPoints", "arr_rand.TargetArray"],
+    ],
+    auto_layout=True
+)
+```
+
+### Common Mistakes with Arrays
+
+1. **Using Array_Get directly** → Deprecated, use `NODE K2Node_GetArrayItem` instead
+2. **Not connecting the typed array source first** → Wildcard pins stay unresolved → compile error: "The type of Target Array is undetermined"
+3. **Guessing pin names** → Always use `get_node_pins()` to verify pin names after node creation
 
 ---
 

--- a/MakePlugin.ps1
+++ b/MakePlugin.ps1
@@ -88,6 +88,7 @@ $ExcludeDevFiles = @(
     "BuildAndLaunchGame.ps1", # Game-specific launch script not needed by end users
     "AddCopyrights.ps1",     # Development script not needed by end users
     "FAB-DESCRIPTION.md",    # Development file not needed by end users
+    "FAB_Tech_Details.md",   # FAB submission details not needed by end users
     "FAB-Checklist.md",      # Internal checklist not needed by end users
     ".gitignore",            # Git-specific file not needed by end users
     "vibeue-proxy.json"      # Local proxy config with bearer token (auto-generated at runtime)

--- a/Source/VibeUE/Private/Chat/AIChatCommands.cpp
+++ b/Source/VibeUE/Private/Chat/AIChatCommands.cpp
@@ -143,12 +143,27 @@ PRAGMA_ENABLE_DEPRECATION_WARNINGS
 
 TSharedRef<SDockTab> FAIChatCommands::SpawnAIChatTab(const FSpawnTabArgs& Args)
 {
-    return SNew(SDockTab)
+    TSharedPtr<SAIChatWindow> ChatWidget;
+
+    TSharedRef<SDockTab> NewTab = SNew(SDockTab)
         .TabRole(ETabRole::NomadTab)
         .Label(LOCTEXT("AIChatTabLabel", "VibeUE AI Chat"))
         [
-            SNew(SAIChatWindow)
+            SAssignNew(ChatWidget, SAIChatWindow)
         ];
+
+    // Focus the input text box whenever this tab becomes active (panel drawer opens, tab clicked, etc.)
+    NewTab->SetOnTabActivated(SDockTab::FOnTabActivatedCallback::CreateLambda(
+        [WeakChat = TWeakPtr<SAIChatWindow>(ChatWidget)](TSharedRef<SDockTab>, ETabActivationCause)
+        {
+            if (TSharedPtr<SAIChatWindow> Chat = WeakChat.Pin())
+            {
+                Chat->FocusInputTextBox();
+            }
+        }
+    ));
+
+    return NewTab;
 }
 
 PRAGMA_DISABLE_DEPRECATION_WARNINGS

--- a/Source/VibeUE/Private/PythonAPI/UAssetDiscoveryService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UAssetDiscoveryService.cpp
@@ -12,6 +12,7 @@
 #include "HAL/PlatformFileManager.h"
 #include "ContentBrowserModule.h"
 #include "IContentBrowserSingleton.h"
+#include "Misc/PackageName.h"
 
 namespace
 {
@@ -75,11 +76,18 @@ TArray<FAssetData> UAssetDiscoveryService::SearchAssets(const FString& SearchTer
 	}
 
 	TArray<FAssetData> AllAssets;
-	FARFilter Filter;
 
-	// Always scan /Game recursively. Without an explicit path + bRecursivePaths=true,
-	// GetAssets with an empty FARFilter returns nothing in UE5.
-	Filter.PackagePaths.Add(FName("/Game"));
+	// Collect all mounted content roots (/Game, /Engine, /PluginName, …)
+	// so we search Game, Engine and every plugin in one pass.
+	TArray<FString> RootPaths;
+	FPackageName::QueryRootContentPaths(RootPaths);
+
+	FARFilter Filter;
+	for (const FString& Root : RootPaths)
+	{
+		// QueryRootContentPaths returns paths with trailing '/' — FName handles both forms.
+		Filter.PackagePaths.Add(FName(*Root));
+	}
 	Filter.bRecursivePaths = true;
 
 	// Apply type filter if specified

--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -19,6 +19,8 @@
 #include "K2Node_VariableSet.h"
 #include "K2Node_IfThenElse.h"
 #include "K2Node_CallFunction.h"
+#include "K2Node_CallArrayFunction.h"   // For array library functions with wildcard pins
+#include "K2Node_GetArrayItem.h"        // For Array Get (replaces deprecated Array_Get)
 #include "K2Node_CreateDelegate.h"
 #include "K2Node_CustomEvent.h"
 #include "K2Node_DynamicCast.h"
@@ -3720,11 +3722,20 @@ bool UBlueprintService::ConnectNodes(
 	const UEdGraphSchema_K2* Schema = Cast<UEdGraphSchema_K2>(Graph->GetSchema());
 	if (Schema)
 	{
-		Schema->TryCreateConnection(SourcePin, TargetPin);
-		FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
-		UE_LOG(LogTemp, Log, TEXT("ConnectNodes: Connected '%s'.'%s' to '%s'.'%s'"),
-			*SourceNodeId, *SourcePinName, *TargetNodeId, *TargetPinName);
-		return true;
+		bool bConnected = Schema->TryCreateConnection(SourcePin, TargetPin);
+		if (bConnected)
+		{
+			FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+			UE_LOG(LogTemp, Log, TEXT("ConnectNodes: Connected '%s'.'%s' to '%s'.'%s'"),
+				*SourceNodeId, *SourcePinName, *TargetNodeId, *TargetPinName);
+			return true;
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("ConnectNodes: TryCreateConnection failed for '%s'.'%s' -> '%s'.'%s' (type mismatch or incompatible pins)"),
+				*SourceNodeId, *SourcePinName, *TargetNodeId, *TargetPinName);
+			return false;
+		}
 	}
 
 	UE_LOG(LogTemp, Error, TEXT("ConnectNodes: Failed to get schema for graph '%s'"), *GraphName);
@@ -5807,8 +5818,20 @@ FString UBlueprintService::CreateNodeByKey(
 			return FString();
 		}
 
-		// Create the function call node
-		UK2Node_CallFunction* FuncNode = NewObject<UK2Node_CallFunction>(Graph);
+		// Create the function call node - use the correct subclass for array functions
+		// Array library functions need UK2Node_CallArrayFunction for wildcard pin type propagation
+		bool bHasArrayPointerParms = Function->HasMetaData(FBlueprintMetadata::MD_ArrayParam);
+
+		UK2Node_CallFunction* FuncNode;
+		if (bHasArrayPointerParms)
+		{
+			FuncNode = NewObject<UK2Node_CallArrayFunction>(Graph);
+			UE_LOG(LogTemp, Log, TEXT("CreateNodeByKey: Creating array function node for '%s' (has ArrayParm metadata)"), *FunctionName);
+		}
+		else
+		{
+			FuncNode = NewObject<UK2Node_CallFunction>(Graph);
+		}
 		FuncNode->SetFromFunction(Function);
 		FuncNode->NodePosX = PosX;
 		FuncNode->NodePosY = PosY;
@@ -6848,7 +6871,16 @@ UEdGraphNode* UBlueprintService::CreateNodeFromDesc(
 			return nullptr;
 		}
 
-		UK2Node_CallFunction* FuncNode = NewObject<UK2Node_CallFunction>(Graph);
+		// Use correct subclass for array functions (wildcard pin type propagation)
+		UK2Node_CallFunction* FuncNode;
+		if (Function->HasMetaData(FBlueprintMetadata::MD_ArrayParam))
+		{
+			FuncNode = NewObject<UK2Node_CallArrayFunction>(Graph);
+		}
+		else
+		{
+			FuncNode = NewObject<UK2Node_CallFunction>(Graph);
+		}
 		FuncNode->SetFromFunction(Function);
 		FuncNode->NodePosX = PosX;
 		FuncNode->NodePosY = PosY;
@@ -6899,7 +6931,16 @@ UEdGraphNode* UBlueprintService::CreateNodeFromDesc(
 				return nullptr;
 			}
 
-			UK2Node_CallFunction* FuncNode = NewObject<UK2Node_CallFunction>(Graph);
+			// Use correct subclass for array functions (wildcard pin type propagation)
+			UK2Node_CallFunction* FuncNode;
+			if (Function->HasMetaData(FBlueprintMetadata::MD_ArrayParam))
+			{
+				FuncNode = NewObject<UK2Node_CallArrayFunction>(Graph);
+			}
+			else
+			{
+				FuncNode = NewObject<UK2Node_CallFunction>(Graph);
+			}
 			FuncNode->SetFromFunction(Function);
 			FuncNode->NodePosX = PosX;
 			FuncNode->NodePosY = PosY;
@@ -8022,51 +8063,153 @@ bool UBlueprintService::AutoLayoutGraph(
 		}
 	}
 
-	// Pure nodes (no exec pins): place in same layer as first consumer
-	for (UEdGraphNode* Node : LayoutNodes)
+	// Check if exec-based BFS produced any meaningful layering.
+	// If all layered nodes are at layer 0 (common for pure functions with no exec connections),
+	// fall back to data-flow-based layering instead.
+	bool bExecFlowIsFlat = true;
+	for (auto& Pair : NodeLayer)
 	{
-		if (NodeLayer.Contains(Node)) continue;
-
-		bool bHasExecPin = false;
-		for (UEdGraphPin* Pin : Node->Pins)
+		if (Pair.Value > 0)
 		{
-			if (Pin && Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec)
+			bExecFlowIsFlat = false;
+			break;
+		}
+	}
+
+	if (bExecFlowIsFlat && LayoutNodes.Num() > 1)
+	{
+		// ── Data-flow fallback: assign layers by longest data-flow path from sources ──
+		// Build data-flow adjacency: for each node, find nodes whose outputs feed into it
+		TMap<UEdGraphNode*, TArray<UEdGraphNode*>> DataPredecessors;
+		for (UEdGraphNode* Node : LayoutNodes)
+		{
+			for (UEdGraphPin* Pin : Node->Pins)
 			{
-				bHasExecPin = true;
-				break;
+				if (Pin && Pin->Direction == EGPD_Input && Pin->PinType.PinCategory != UEdGraphSchema_K2::PC_Exec)
+				{
+					for (UEdGraphPin* LinkedPin : Pin->LinkedTo)
+					{
+						if (LinkedPin && LinkedPin->GetOwningNode())
+						{
+							DataPredecessors.FindOrAdd(Node).AddUnique(LinkedPin->GetOwningNode());
+						}
+					}
+				}
 			}
 		}
 
-		if (!bHasExecPin)
+		// Topological sort via BFS (Kahn's algorithm) to assign layers by data-flow depth.
+		// Nodes with no data predecessors start at layer 0.
+		NodeLayer.Empty();
+
+		// Compute in-degree for each node in data flow
+		TMap<UEdGraphNode*, int32> InDegree;
+		for (UEdGraphNode* Node : LayoutNodes)
 		{
-			// Find the minimum layer of any consumer
-			int32 MinConsumerLayer = INT32_MAX;
-			const TArray<UEdGraphNode*>* Consumers = DataConsumers.Find(Node);
+			InDegree.FindOrAdd(Node); // ensure entry exists (default 0)
+		}
+		for (auto& Pair : DataPredecessors)
+		{
+			InDegree.FindOrAdd(Pair.Key) = Pair.Value.Num();
+		}
+
+		// Seed BFS with data sources (in-degree 0)
+		TQueue<UEdGraphNode*> DataQueue;
+		for (auto& Pair : InDegree)
+		{
+			if (Pair.Value == 0)
+			{
+				NodeLayer.Add(Pair.Key, 0);
+				DataQueue.Enqueue(Pair.Key);
+			}
+		}
+
+		while (!DataQueue.IsEmpty())
+		{
+			UEdGraphNode* Current;
+			DataQueue.Dequeue(Current);
+			int32 CurrentLayer = NodeLayer.FindRef(Current);
+
+			const TArray<UEdGraphNode*>* Consumers = DataConsumers.Find(Current);
 			if (Consumers)
 			{
 				for (UEdGraphNode* Consumer : *Consumers)
 				{
-					const int32* ConsumerLayer = NodeLayer.Find(Consumer);
-					if (ConsumerLayer && *ConsumerLayer < MinConsumerLayer)
+					int32 NewLayer = CurrentLayer + 1;
+					int32* ExistingLayer = NodeLayer.Find(Consumer);
+					if (!ExistingLayer || *ExistingLayer < NewLayer)
 					{
-						MinConsumerLayer = *ConsumerLayer;
+						NodeLayer.Add(Consumer, NewLayer);
+					}
+
+					// Decrement in-degree; enqueue when all predecessors processed
+					int32& Deg = InDegree.FindOrAdd(Consumer);
+					Deg--;
+					if (Deg <= 0)
+					{
+						DataQueue.Enqueue(Consumer);
 					}
 				}
 			}
+		}
 
-			if (MinConsumerLayer == INT32_MAX)
+		// Assign any remaining unreached nodes to layer 0
+		for (UEdGraphNode* Node : LayoutNodes)
+		{
+			if (!NodeLayer.Contains(Node))
 			{
-				MinConsumerLayer = 0; // Disconnected pure node
+				NodeLayer.Add(Node, 0);
+			}
+		}
+	}
+	else
+	{
+		// Original exec-based layering worked — place pure nodes relative to consumers.
+		for (UEdGraphNode* Node : LayoutNodes)
+		{
+			if (NodeLayer.Contains(Node)) continue;
+
+			bool bHasExecPin = false;
+			for (UEdGraphPin* Pin : Node->Pins)
+			{
+				if (Pin && Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec)
+				{
+					bHasExecPin = true;
+					break;
+				}
 			}
 
+			if (!bHasExecPin)
+			{
+				// Find the minimum layer of any consumer
+				int32 MinConsumerLayer = INT32_MAX;
+				const TArray<UEdGraphNode*>* Consumers = DataConsumers.Find(Node);
+				if (Consumers)
+				{
+					for (UEdGraphNode* Consumer : *Consumers)
+					{
+						const int32* ConsumerLayer = NodeLayer.Find(Consumer);
+						if (ConsumerLayer && *ConsumerLayer < MinConsumerLayer)
+						{
+							MinConsumerLayer = *ConsumerLayer;
+						}
+					}
+				}
+
+				if (MinConsumerLayer == INT32_MAX)
+				{
+					MinConsumerLayer = 0; // Disconnected pure node
+				}
+
 				// Place pure nodes one column LEFT of their consumer so they appear
-			// as data inputs flowing into the exec node, not stacked alongside it.
-			NodeLayer.Add(Node, FMath::Max(0, MinConsumerLayer - 1));
-		}
-		else
-		{
-			// Exec node never reached by BFS — disconnected island
-			NodeLayer.Add(Node, 0);
+				// as data inputs flowing into the exec node, not stacked alongside it.
+				NodeLayer.Add(Node, FMath::Max(0, MinConsumerLayer - 1));
+			}
+			else
+			{
+				// Exec node never reached by BFS — disconnected island
+				NodeLayer.Add(Node, 0);
+			}
 		}
 	}
 

--- a/Source/VibeUE/Private/Tools/AssetManagerToolRegistration.cpp
+++ b/Source/VibeUE/Private/Tools/AssetManagerToolRegistration.cpp
@@ -395,7 +395,8 @@ REGISTER_VIBEUE_TOOL(manage_asset,
 	"  Delete (guarded)     : action='delete', asset_path='...'  (blocked if referenced; use skip_reference_check=true to override)\n"
 	"\nNever emulate a move by duplicating then deleting the original. That creates a different asset and can break references.\n"
 	"  Per-action docs      : action='help', help_action='search'\n"
-	"\nAll paths use Content Browser format: /Game/... or /Engine/...",
+	"\nAll paths use Content Browser format: /Game/..., /Engine/..., or /PluginName/...\n"
+	"Search covers ALL content roots (Game, Engine, Plugins) automatically.",
 	"Assets",
 	TOOL_PARAMS(
 		TOOL_PARAM("action",

--- a/Source/VibeUE/Private/UI/SAIChatWindow.cpp
+++ b/Source/VibeUE/Private/UI/SAIChatWindow.cpp
@@ -511,13 +511,73 @@ void SAIChatWindow::Construct(const FArguments& InArgs)
         FLLMProviderInfo ProviderInfo = ChatSession->GetCurrentProviderInfo();
         AddSystemNotification(FString::Printf(TEXT("⚠️ Please set your %s API key in Settings"), *ProviderInfo.DisplayName));
     }
+
+    // Register for app activation changes so we can restore focus to the text box
+    // when the user returns to UE after switching to another application
+    AppActivationHandle = FSlateApplication::Get().OnApplicationActivationStateChanged().AddSP(
+        this, &SAIChatWindow::OnApplicationActivationChanged);
 }
 
 SAIChatWindow::~SAIChatWindow()
 {
+    // Unregister app activation handler
+    if (AppActivationHandle.IsValid())
+    {
+        FSlateApplication::Get().OnApplicationActivationStateChanged().Remove(AppActivationHandle);
+        AppActivationHandle.Reset();
+    }
+
     if (ChatSession.IsValid())
     {
         ChatSession->Shutdown();
+    }
+}
+
+void SAIChatWindow::FocusInputTextBox()
+{
+    if (bIsFocusingInput || !InputTextBox.IsValid())
+    {
+        return;
+    }
+    TGuardValue<bool> ReentrancyGuard(bIsFocusingInput, true);
+    FSlateApplication::Get().SetKeyboardFocus(InputTextBox, EFocusCause::SetDirectly);
+}
+
+FReply SAIChatWindow::OnFocusReceived(const FGeometry& MyGeometry, const FFocusEvent& InFocusEvent)
+{
+    // Route panel-level focus (e.g. clicking empty space) straight to the text box
+    if (InputTextBox.IsValid())
+    {
+        return FReply::Handled().SetUserFocus(InputTextBox.ToSharedRef(), EFocusCause::SetDirectly);
+    }
+    return SCompoundWidget::OnFocusReceived(MyGeometry, InFocusEvent);
+}
+
+void SAIChatWindow::OnApplicationActivationChanged(bool bIsActivated)
+{
+    if (!bIsActivated)
+    {
+        // Record whether our text box had focus before leaving the app
+        bInputBoxWasFocusedBeforeDeactivation = InputTextBox.IsValid() &&
+            FSlateApplication::Get().GetKeyboardFocusedWidget() == InputTextBox;
+        return;
+    }
+
+    // App reactivated — restore focus to text box if it was focused before we left
+    if (bInputBoxWasFocusedBeforeDeactivation && InputTextBox.IsValid())
+    {
+        bInputBoxWasFocusedBeforeDeactivation = false;
+        // Delay one frame so Slate finishes its own activation processing first
+        RegisterActiveTimer(0.0f, FWidgetActiveTimerDelegate::CreateLambda(
+            [WeakInputBox = TWeakPtr<SMultiLineEditableTextBox>(InputTextBox)](double, float) -> EActiveTimerReturnType
+            {
+                if (TSharedPtr<SMultiLineEditableTextBox> TextBox = WeakInputBox.Pin())
+                {
+                    FSlateApplication::Get().SetKeyboardFocus(TextBox, EFocusCause::SetDirectly);
+                }
+                return EActiveTimerReturnType::Stop;
+            }
+        ));
     }
 }
 

--- a/Source/VibeUE/Public/UI/SAIChatWindow.h
+++ b/Source/VibeUE/Public/UI/SAIChatWindow.h
@@ -68,7 +68,25 @@ public:
     /** Static method to clear any attached image */
     static void ClearImageAttachment();
 
+    /** Set keyboard focus to the input text box */
+    void FocusInputTextBox();
+
+    // SWidget overrides for focus routing
+    virtual bool SupportsKeyboardFocus() const override { return true; }
+    virtual FReply OnFocusReceived(const FGeometry& MyGeometry, const FFocusEvent& InFocusEvent) override;
+
 private:
+    /** Handle for the app activation state change delegate */
+    FDelegateHandle AppActivationHandle;
+
+    /** Whether the InputTextBox had focus before the app was last deactivated */
+    bool bInputBoxWasFocusedBeforeDeactivation = false;
+
+    /** Re-entrancy guard: prevents FocusInputTextBox from triggering itself via OnTabActivated */
+    bool bIsFocusingInput = false;
+
+    /** Called when the UE application gains or loses OS-level focus */
+    void OnApplicationActivationChanged(bool bIsActivated);
     /** The chat session managing conversation state */
     TSharedPtr<FChatSession> ChatSession;
     


### PR DESCRIPTION
## Summary

Fixes three bugs identified from VibeUE chat log analysis where multiple AI models repeatedly failed to create array operations in blueprints, and updates the skill documentation to guide LLMs on array patterns.

## C++ Fixes (UBlueprintService.cpp)

### Array Function Node Class (Root Cause Fix)
`CreateNodeByKey` and `CreateNodeFromDesc` always created `UK2Node_CallFunction` for FUNC-type keys. Array library functions (e.g. `Array_Length`, `Array_Random`, `Array_Add`) require `UK2Node_CallArrayFunction` — the subclass that overrides `NotifyPinConnectionListChanged` to propagate types through wildcard pins.

**Fix**: Detect `ArrayParm` metadata on the function (same check UE's own `BlueprintFunctionNodeSpawner::Create` uses) and instantiate `UK2Node_CallArrayFunction` when present. Applied in all 3 node creation paths.

### ConnectNodes Return Value
`TryCreateConnection` return value was discarded — `ConnectNodes` always returned true even on failure. Now checks and returns the actual success/failure with a warning log.

### AutoLayoutGraph Pure Function Support
Pure functions have no exec pins, so exec-based BFS assigned all nodes to layer 0 (stacked vertically). Added a data-flow fallback using Kahn's algorithm when exec BFS produces flat results.

## Skill Doc Update (blueprint-graphs/skill.md)

- Added `KismetArrayLibrary` to Common Function Call Classes
- New **Array Operations** section: function table, `K2Node_GetArrayItem` guidance, wildcard pin explanation, `build_graph` patterns, and common mistakes
- Added `array` and `wildcard` keywords to frontmatter