### PR TITLE
Add evaluator binding APIs and update skill docs

### DIFF
--- a/Content/Skills/blueprint-graphs/skill.md
+++ b/Content/Skills/blueprint-graphs/skill.md
@@ -130,6 +130,35 @@ for node in nodes:
 For function graphs, find nodes by `node_type` or `node_title`.
 For event-style overrides, find nodes by the **display title Unreal shows in the graph**, not by the raw override function name.
 
+### ⚠️ Event-Style Overrides Use `"EventGraph"` — NOT the Function Name
+
+When an override is **event-style** (void/latent functions like `ReceiveTreeStart`, `ReceiveTick`,
+`ReceiveLatentEnterState`, `ReceiveStateCompleted`), the event node lives inside `"EventGraph"`.
+Do **NOT** use the function name as the graph name — that graph doesn't exist.
+
+```python
+# WRONG — returns 0 nodes, creates nothing
+nodes = unreal.BlueprintService.get_nodes_in_graph(bp_path, "ReceiveTreeStart")
+node_id = unreal.BlueprintService.add_function_call_node(bp_path, "ReceiveTreeStart", ...)
+
+# CORRECT — event-style overrides are in EventGraph
+nodes = unreal.BlueprintService.get_nodes_in_graph(bp_path, "EventGraph")
+node_id = unreal.BlueprintService.add_function_call_node(bp_path, "EventGraph", ...)
+```
+
+Common event-style overrides and their **graph name → node title**:
+
+| Raw Function Name | Graph Name | Node Title in Graph |
+|---|---|---|
+| `ReceiveTreeStart` | `"EventGraph"` | `Event TreeStart` |
+| `ReceiveTick` | `"EventGraph"` | `Event Tick` |
+| `ReceiveTreeStop` | `"EventGraph"` | `Event TreeStop` |
+| `ReceiveLatentEnterState` | `"EventGraph"` | `Event EnterState` |
+| `ReceiveLatentTick` | `"EventGraph"` | `Event Tick` |
+| `ReceiveStateCompleted` | `"EventGraph"` | `Event StateCompleted` |
+
+Only **function-style** overrides (non-void, like `GetStaticDescription`) create a separate function graph.
+
 ### ⚠️ Do Not Guess Blueprint Function Node Names
 
 Blueprint display titles and internal UFunction names are often **not the same**.
@@ -605,6 +634,22 @@ For `add_function_call_node(path, graph, class, func, x, y)`:
 
 Array operations use **wildcard pins** — the `TargetArray` and element pins start with no type until a typed array is connected. The engine automatically propagates the array element type through all wildcard pins when you connect a typed array variable.
 
+### ⚠️ Random Element From Array — Use `Array_Random`, NOT Manual Length+Random+Get
+
+When you need a random element from an array, use `Array_Random` — a single node that returns
+a random item. Do **NOT** manually build `Array_Length` → `RandomIntegerInRange` → `Array_Get`.
+That pattern has 3 nodes, is harder to wire, and `Array_Get` is deprecated in UE5.
+
+```python
+# CORRECT — single node, editor shows it as "Random Array Item"
+arr_rand_id = unreal.BlueprintService.add_function_call_node(
+    bp_path, "EventGraph", "KismetArrayLibrary", "Array_Random", 600, 200)
+# Pins: TargetArray (in, wildcard), OutItem (out, wildcard), OutIndex (out, int)
+
+# Or via build_graph:
+{"ref": "rand", "type": "spawner_key", "params": {"key": "FUNC KismetArrayLibrary::Array_Random"}}
+```
+
 ### Available Array Functions (KismetArrayLibrary)
 
 | Function | Purpose | Key Pins |
@@ -612,7 +657,7 @@ Array operations use **wildcard pins** — the `TargetArray` and element pins st
 | `Array_Length` | Get array element count | TargetArray(in), ReturnValue(int) |
 | `Array_LastIndex` | Get last valid index | TargetArray(in), ReturnValue(int) |
 | `Array_IsEmpty` | Check if empty | TargetArray(in), ReturnValue(bool) |
-| `Array_Random` | Get random element | TargetArray(in), OutItem(out), OutIndex(int) |
+| **`Array_Random`** | **Get random element ("Random Array Item")** | **TargetArray(in), OutItem(out), OutIndex(int)** |
 | `Array_Add` | Add element, returns index | TargetArray(in/out), NewItem(in), ReturnValue(int) |
 | `Array_Remove` | Remove by index | TargetArray(in/out), IndexToRemove(int) |
 | `Array_Clear` | Remove all elements | TargetArray(in/out) |

--- a/Content/Skills/state-trees/skill.md
+++ b/Content/Skills/state-trees/skill.md
@@ -467,11 +467,16 @@ For nested struct properties, use the exact dotted path returned by `get_task_pr
 ### Evaluators & Global Tasks
 
 ```python
-# Find available evaluator types
+# Find available evaluator types (includes both struct and Blueprint evaluator types)
 types = unreal.StateTreeService.get_available_evaluator_types()
 
-# Add global evaluator (runs every tick, data available to all states)
+# Add global evaluator by struct name (runs every tick, data available to all states)
 unreal.StateTreeService.add_evaluator("/Game/AI/MyBehavior", "FMyCustomEvaluator")
+
+# Add Blueprint evaluator by name, path, or generated class name
+unreal.StateTreeService.add_evaluator("/Game/AI/MyBehavior", "STE_PatrolPointManagement")
+unreal.StateTreeService.add_evaluator("/Game/AI/MyBehavior", "/Game/StateTree/Evaluators/STE_PatrolPointManagement")
+unreal.StateTreeService.add_evaluator("/Game/AI/MyBehavior", "STE_PatrolPointManagement_C")
 
 # Add global task (runs while tree is active)
 unreal.StateTreeService.add_global_task("/Game/AI/MyBehavior", "FStateTreeDelayTask")
@@ -663,6 +668,36 @@ unreal.StateTreeService.bind_task_property_to_root_parameter(
     st_path, state_path, task_struct,
     "Duration",        # task property
     "IdlingTime"       # root parameter name
+)
+```
+
+#### Binding Evaluator Properties
+
+Evaluators are global (not tied to a state), so there is no `state_path` parameter.
+
+```python
+# Bind an evaluator property to a root parameter
+unreal.StateTreeService.bind_evaluator_property_to_root_parameter(
+    st_path,
+    "STE_PatrolPointManagement",  # evaluator struct name (or Blueprint wrapper name)
+    "PatrolTag",                  # evaluator property to bind
+    "PatrolTag"                   # root parameter name
+)
+
+# Bind an evaluator property to context data
+unreal.StateTreeService.bind_evaluator_property_to_context(
+    st_path,
+    "STE_PatrolPointManagement",  # evaluator struct name
+    "ActorRef",                   # evaluator property to bind
+    "Actor",                      # context name
+    ""                            # context property path (empty = whole object)
+)
+
+# Unbind an evaluator property
+unreal.StateTreeService.unbind_evaluator_property(
+    st_path,
+    "STE_PatrolPointManagement",
+    "PatrolTag"
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -1414,6 +1414,9 @@ Use `set_state_type`, `set_linked_subtree`, and `set_linked_asset` for in-place 
 - `remove_evaluator(asset_path, evaluator_struct_name, match_index)` - Remove an evaluator
 - `get_evaluator_property_names(asset_path, evaluator_struct_name, match_index)` - Get evaluator properties
 - `set_evaluator_property_value(asset_path, evaluator_struct_name, property_path, value, match_index)` - Set evaluator property
+- `bind_evaluator_property_to_root_parameter(asset_path, evaluator_struct_name, evaluator_property_path, parameter_path, match_index)` - Bind evaluator property to a root parameter
+- `bind_evaluator_property_to_context(asset_path, evaluator_struct_name, evaluator_property_path, context_name, context_property_path, match_index)` - Bind evaluator property to context data
+- `unbind_evaluator_property(asset_path, evaluator_struct_name, evaluator_property_path, match_index)` - Remove an evaluator property binding
 - `add_global_task(asset_path, task_struct_name)` - Add a global task
 - `remove_global_task(asset_path, task_struct_name, match_index)` - Remove a global task
 - `get_global_task_property_names(asset_path, task_struct_name, match_index)` - Get global task properties

--- a/Source/VibeUE/Private/PythonAPI/UStateTreeService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UStateTreeService.cpp
@@ -29,6 +29,7 @@
 #include "StateTreeCompiler.h"
 #include "StateTreeCompilerLog.h"
 #include "Blueprint/StateTreeTaskBlueprintBase.h"
+#include "Blueprint/StateTreeEvaluatorBlueprintBase.h"
 #include "StateTreeEditingSubsystem.h"
 #include "StateTreeViewModel.h"
 #include "Editor.h"
@@ -265,12 +266,20 @@ static bool StructNameMatches(const UScriptStruct* Struct, const FString& Expect
 static bool BlueprintWrapperMatchesName(const FStateTreeEditorNode& EditorNode, const FString& ExpectedName)
 {
 	const UScriptStruct* NodeStruct = EditorNode.Node.GetScriptStruct();
-	if (!NodeStruct || !NodeStruct->GetName().Equals(TEXT("StateTreeBlueprintTaskWrapper"), ESearchCase::IgnoreCase))
+	if (!NodeStruct)
 	{
 		return false;
 	}
 
-	// Check display name (e.g. "STT Rotate")
+	const FString StructName = NodeStruct->GetName();
+	const bool bIsTaskWrapper = StructName.Equals(TEXT("StateTreeBlueprintTaskWrapper"), ESearchCase::IgnoreCase);
+	const bool bIsEvalWrapper = StructName.Equals(TEXT("StateTreeBlueprintEvaluatorWrapper"), ESearchCase::IgnoreCase);
+	if (!bIsTaskWrapper && !bIsEvalWrapper)
+	{
+		return false;
+	}
+
+	// Check display name (e.g. "STT Rotate" or "STE PatrolPointManagement")
 	const FString DisplayName = EditorNode.GetName().ToString();
 	if (DisplayName.Equals(ExpectedName, ESearchCase::IgnoreCase)
 		|| DisplayName.Replace(TEXT(" "), TEXT("_")).Equals(ExpectedName, ESearchCase::IgnoreCase))
@@ -278,36 +287,37 @@ static bool BlueprintWrapperMatchesName(const FStateTreeEditorNode& EditorNode, 
 		return true;
 	}
 
-	// Read the TaskClass property to get the Blueprint class path
+	// Read the class property (TaskClass for tasks, EvaluatorClass for evaluators)
+	const FName ClassPropName = bIsTaskWrapper ? TEXT("TaskClass") : TEXT("EvaluatorClass");
 	const void* NodeMemory = EditorNode.Node.GetMemory();
 	if (!NodeMemory)
 	{
 		return false;
 	}
 
-	const FProperty* TaskClassProp = FindFProperty<FProperty>(NodeStruct, TEXT("TaskClass"));
-	if (!TaskClassProp)
+	const FProperty* ClassProp = FindFProperty<FProperty>(NodeStruct, ClassPropName);
+	if (!ClassProp)
 	{
 		return false;
 	}
 
-	FString TaskClassStr;
-	TaskClassProp->ExportTextItem_Direct(TaskClassStr, TaskClassProp->ContainerPtrToValuePtr<void>(NodeMemory), nullptr, nullptr, 0);
-	if (TaskClassStr.IsEmpty())
+	FString ClassStr;
+	ClassProp->ExportTextItem_Direct(ClassStr, ClassProp->ContainerPtrToValuePtr<void>(NodeMemory), nullptr, nullptr, 0);
+	if (ClassStr.IsEmpty())
 	{
 		return false;
 	}
 
-	// TaskClassStr is something like "/Script/Engine.BlueprintGeneratedClass'/Game/StateTree/STT_Rotate.STT_Rotate_C'"
+	// ClassStr is something like "/Script/Engine.BlueprintGeneratedClass'/Game/StateTree/STT_Rotate.STT_Rotate_C'"
 	// Extract the class name after the last dot or slash
 	FString ClassName;
-	if (TaskClassStr.Split(TEXT("."), nullptr, &ClassName, ESearchCase::IgnoreCase, ESearchDir::FromEnd))
+	if (ClassStr.Split(TEXT("."), nullptr, &ClassName, ESearchCase::IgnoreCase, ESearchDir::FromEnd))
 	{
 		ClassName.RemoveFromEnd(TEXT("'"));
 	}
 	else
 	{
-		ClassName = TaskClassStr;
+		ClassName = ClassStr;
 	}
 
 	// Match against "STT_Rotate_C" or "STT_Rotate" (without _C suffix)
@@ -942,6 +952,27 @@ static bool IsValidBlueprintTaskClass(UClass* InClass)
 	return true;
 }
 
+static bool IsValidBlueprintEvaluatorClass(UClass* InClass)
+{
+	const UClass* BlueprintEvalBaseClass = UStateTreeEvaluatorBlueprintBase::StaticClass();
+	if (!InClass || !BlueprintEvalBaseClass)
+	{
+		return false;
+	}
+
+	if (!InClass->IsChildOf(BlueprintEvalBaseClass) || InClass == BlueprintEvalBaseClass)
+	{
+		return false;
+	}
+
+	if (InClass->HasAnyClassFlags(CLASS_Abstract | CLASS_Deprecated | CLASS_NewerVersionExists))
+	{
+		return false;
+	}
+
+	return true;
+}
+
 static UClass* TryResolveBlueprintTaskClassFromObjectPath(const FString& ObjectPath)
 {
 	if (ObjectPath.IsEmpty())
@@ -1174,6 +1205,206 @@ static bool SetBlueprintTaskClassOnWrapperNode(FStateTreeEditorNode& InOutNode, 
 	}
 
 	// TaskClass controls wrapper instance type. Refresh instance containers after assignment.
+	InOutNode.Instance.Reset();
+	InOutNode.InstanceObject = nullptr;
+	InOutNode.ExecutionRuntimeData.Reset();
+	InOutNode.ExecutionRuntimeDataObject = nullptr;
+
+	if (const FStateTreeNodeBase* NodeBase = InOutNode.Node.GetPtr<FStateTreeNodeBase>())
+	{
+		if (const UScriptStruct* InstanceType = Cast<const UScriptStruct>(NodeBase->GetInstanceDataType()))
+		{
+			InOutNode.Instance.InitializeAs(InstanceType);
+		}
+		else if (const UClass* InstanceClass = Cast<const UClass>(NodeBase->GetInstanceDataType()))
+		{
+			InOutNode.InstanceObject = NewObject<UObject>(Outer, InstanceClass);
+		}
+
+		if (const UScriptStruct* RuntimeType = Cast<const UScriptStruct>(NodeBase->GetExecutionRuntimeDataType()))
+		{
+			InOutNode.ExecutionRuntimeData.InitializeAs(RuntimeType);
+		}
+		else if (const UClass* RuntimeClass = Cast<const UClass>(NodeBase->GetExecutionRuntimeDataType()))
+		{
+			InOutNode.ExecutionRuntimeDataObject = NewObject<UObject>(Outer, RuntimeClass);
+		}
+	}
+
+	return InOutNode.Instance.IsValid() || InOutNode.InstanceObject != nullptr;
+}
+
+// ---- Blueprint Evaluator resolution helpers (mirrors task helpers above) ----
+
+static UClass* TryResolveBlueprintEvaluatorClassFromObjectPath(const FString& ObjectPath)
+{
+	if (ObjectPath.IsEmpty()) { return nullptr; }
+	if (UClass* LoadedClass = LoadObject<UClass>(nullptr, *ObjectPath))
+	{
+		if (IsValidBlueprintEvaluatorClass(LoadedClass)) { return LoadedClass; }
+	}
+	if (UClass* FoundClass = FindFirstObject<UClass>(*ObjectPath, EFindFirstObjectOptions::None))
+	{
+		if (IsValidBlueprintEvaluatorClass(FoundClass)) { return FoundClass; }
+	}
+	return nullptr;
+}
+
+static UClass* TryResolveBlueprintEvaluatorClassFromAssetPath(const FString& AssetPath)
+{
+	if (AssetPath.IsEmpty()) { return nullptr; }
+	if (UObject* LoadedAsset = UEditorAssetLibrary::LoadAsset(AssetPath))
+	{
+		if (UBlueprint* Blueprint = Cast<UBlueprint>(LoadedAsset))
+		{
+			if (IsValidBlueprintEvaluatorClass(Blueprint->GeneratedClass)) { return Blueprint->GeneratedClass; }
+		}
+		if (UClass* LoadedClass = Cast<UClass>(LoadedAsset))
+		{
+			if (IsValidBlueprintEvaluatorClass(LoadedClass)) { return LoadedClass; }
+		}
+	}
+	const FString AssetName = FPackageName::GetShortName(AssetPath);
+	if (!AssetName.IsEmpty())
+	{
+		const FString GeneratedClassPath = FString::Printf(TEXT("%s.%s_C"), *AssetPath, *AssetName);
+		if (UClass* GeneratedClass = TryResolveBlueprintEvaluatorClassFromObjectPath(GeneratedClassPath))
+		{
+			return GeneratedClass;
+		}
+	}
+	return nullptr;
+}
+
+static UClass* ResolveBlueprintEvaluatorClass(const FString& EvalIdentifier)
+{
+	FString Identifier = EvalIdentifier;
+	Identifier.TrimStartAndEndInline();
+	if (Identifier.IsEmpty()) { return nullptr; }
+
+	// Short name (no path separator)
+	if (!Identifier.Contains(TEXT("/")))
+	{
+		if (UClass* LoadedClass = FindFirstObject<UClass>(*Identifier, EFindFirstObjectOptions::None))
+		{
+			if (IsValidBlueprintEvaluatorClass(LoadedClass)) { return LoadedClass; }
+		}
+		if (!Identifier.EndsWith(TEXT("_C")))
+		{
+			if (UClass* LoadedClass = FindFirstObject<UClass>(*(Identifier + TEXT("_C")), EFindFirstObjectOptions::None))
+			{
+				if (IsValidBlueprintEvaluatorClass(LoadedClass)) { return LoadedClass; }
+			}
+		}
+	}
+
+	// Full path
+	if (Identifier.StartsWith(TEXT("/")))
+	{
+		if (Identifier.Contains(TEXT(".")))
+		{
+			if (UClass* EvalClass = TryResolveBlueprintEvaluatorClassFromObjectPath(Identifier)) { return EvalClass; }
+			FString PackagePath, ObjectName;
+			if (Identifier.Split(TEXT("."), &PackagePath, &ObjectName, ESearchCase::CaseSensitive, ESearchDir::FromEnd))
+			{
+				if (UClass* EvalClass = TryResolveBlueprintEvaluatorClassFromAssetPath(PackagePath)) { return EvalClass; }
+				if (!ObjectName.EndsWith(TEXT("_C")))
+				{
+					if (UClass* EvalClass = TryResolveBlueprintEvaluatorClassFromObjectPath(PackagePath + TEXT(".") + ObjectName + TEXT("_C"))) { return EvalClass; }
+				}
+			}
+		}
+		else
+		{
+			if (UClass* EvalClass = TryResolveBlueprintEvaluatorClassFromAssetPath(Identifier)) { return EvalClass; }
+		}
+	}
+
+	// Asset registry search by short name
+	FString TargetBlueprintName = Identifier;
+	if (TargetBlueprintName.Contains(TEXT(".")))
+	{
+		FString LeftPart, RightPart;
+		if (TargetBlueprintName.Split(TEXT("."), &LeftPart, &RightPart, ESearchCase::CaseSensitive, ESearchDir::FromEnd))
+		{
+			TargetBlueprintName = RightPart;
+		}
+	}
+	if (TargetBlueprintName.Contains(TEXT("/")))
+	{
+		TargetBlueprintName = FPackageName::GetShortName(TargetBlueprintName);
+	}
+	if (TargetBlueprintName.EndsWith(TEXT("_C")))
+	{
+		TargetBlueprintName.LeftChopInline(2);
+	}
+	if (TargetBlueprintName.IsEmpty()) { return nullptr; }
+
+	FAssetRegistryModule& AssetRegistry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
+	FARFilter Filter;
+	Filter.ClassPaths.Add(UBlueprint::StaticClass()->GetClassPathName());
+	Filter.PackagePaths.Add(FName(TEXT("/Game")));
+	Filter.bRecursivePaths = true;
+
+	TArray<FAssetData> BlueprintAssets;
+	AssetRegistry.Get().GetAssets(Filter, BlueprintAssets);
+
+	for (const FAssetData& AssetData : BlueprintAssets)
+	{
+		if (!AssetData.AssetName.ToString().Equals(TargetBlueprintName, ESearchCase::IgnoreCase)) { continue; }
+		if (UClass* EvalClass = TryResolveBlueprintEvaluatorClassFromAssetPath(AssetData.PackageName.ToString())) { return EvalClass; }
+		const FAssetTagValueRef GeneratedClassTag = AssetData.TagsAndValues.FindTag(TEXT("GeneratedClass"));
+		if (GeneratedClassTag.IsSet())
+		{
+			const FString GeneratedClassObjectPath = FPackageName::ExportTextPathToObjectPath(GeneratedClassTag.GetValue());
+			if (UClass* EvalClass = TryResolveBlueprintEvaluatorClassFromObjectPath(GeneratedClassObjectPath)) { return EvalClass; }
+		}
+	}
+
+	return nullptr;
+}
+
+static bool SetBlueprintEvaluatorClassOnWrapperNode(FStateTreeEditorNode& InOutNode, UClass* BlueprintEvalClass, UObject* Outer)
+{
+	if (!BlueprintEvalClass || !IsValidBlueprintEvaluatorClass(BlueprintEvalClass))
+	{
+		return false;
+	}
+
+	if (Outer == nullptr)
+	{
+		Outer = GetTransientPackage();
+	}
+
+	const UScriptStruct* NodeStruct = InOutNode.Node.GetScriptStruct();
+	void* NodeMemory = InOutNode.Node.GetMutableMemory();
+	if (!NodeStruct || !NodeMemory)
+	{
+		return false;
+	}
+
+	FProperty* EvalClassProperty = FindFProperty<FProperty>(NodeStruct, TEXT("EvaluatorClass"));
+	if (!EvalClassProperty)
+	{
+		return false;
+	}
+
+	void* EvalClassValuePtr = EvalClassProperty->ContainerPtrToValuePtr<void>(NodeMemory);
+	if (!EvalClassValuePtr)
+	{
+		return false;
+	}
+
+	if (FObjectPropertyBase* ObjectProperty = CastField<FObjectPropertyBase>(EvalClassProperty))
+	{
+		ObjectProperty->SetObjectPropertyValue(EvalClassValuePtr, BlueprintEvalClass);
+	}
+	else if (!SetPropertyValueFromString(EvalClassProperty, EvalClassValuePtr, BlueprintEvalClass->GetPathName()))
+	{
+		return false;
+	}
+
+	// EvaluatorClass controls wrapper instance type. Refresh instance containers after assignment.
 	InOutNode.Instance.Reset();
 	InOutNode.InstanceObject = nullptr;
 	InOutNode.ExecutionRuntimeData.Reset();
@@ -1937,6 +2168,48 @@ TArray<FString> UStateTreeService::GetAvailableEvaluatorTypes()
 				Results.Add(Struct->GetName());
 			}
 		}
+	}
+
+	// Append Blueprint evaluator types
+	{
+		TSet<FString> UniqueTypes(Results);
+		const UClass* BlueprintEvalBaseClass = UStateTreeEvaluatorBlueprintBase::StaticClass();
+		if (BlueprintEvalBaseClass)
+		{
+			for (TObjectIterator<UClass> It; It; ++It)
+			{
+				if (IsValidBlueprintEvaluatorClass(*It))
+				{
+					UniqueTypes.Add((*It)->GetName());
+				}
+			}
+		}
+
+		FAssetRegistryModule& AssetRegistry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
+		FARFilter Filter;
+		Filter.ClassPaths.Add(UBlueprint::StaticClass()->GetClassPathName());
+		Filter.PackagePaths.Add(FName(TEXT("/Game")));
+		Filter.bRecursivePaths = true;
+
+		TArray<FAssetData> BlueprintAssets;
+		AssetRegistry.Get().GetAssets(Filter, BlueprintAssets);
+
+		for (const FAssetData& AssetData : BlueprintAssets)
+		{
+			const FAssetTagValueRef GeneratedClassTag = AssetData.TagsAndValues.FindTag(TEXT("GeneratedClass"));
+			if (!GeneratedClassTag.IsSet()) { continue; }
+			const FString GeneratedClassObjectPath = FPackageName::ExportTextPathToObjectPath(GeneratedClassTag.GetValue());
+			if (GeneratedClassObjectPath.IsEmpty()) { continue; }
+			if (UClass* GeneratedClass = LoadObject<UClass>(nullptr, *GeneratedClassObjectPath))
+			{
+				if (IsValidBlueprintEvaluatorClass(GeneratedClass))
+				{
+					UniqueTypes.Add(GeneratedClass->GetName());
+				}
+			}
+		}
+
+		Results = UniqueTypes.Array();
 	}
 
 	Results.Sort();
@@ -4214,27 +4487,62 @@ bool UStateTreeService::AddEvaluator(const FString& AssetPath, const FString& Ev
 	}
 
 	UScriptStruct* EvalStruct = FindNodeStruct(EvaluatorStructName);
-	if (!EvalStruct)
-	{
-		UE_LOG(LogStateTreeService, Warning, TEXT("AddEvaluator: Struct not found: %s"), *EvaluatorStructName);
-		return false;
-	}
+	UClass* BlueprintEvalClass = nullptr;
 
-	if (!EvalStruct->IsChildOf(FStateTreeEvaluatorBase::StaticStruct()))
+	if (EvalStruct)
 	{
-		UE_LOG(LogStateTreeService, Warning, TEXT("AddEvaluator: Struct '%s' is not a FStateTreeEvaluatorBase"), *EvaluatorStructName);
-		return false;
+		// Verify struct-backed evaluator derives from FStateTreeEvaluatorBase
+		if (!EvalStruct->IsChildOf(FStateTreeEvaluatorBase::StaticStruct()))
+		{
+			UE_LOG(LogStateTreeService, Warning, TEXT("AddEvaluator: Struct '%s' is not a FStateTreeEvaluatorBase"), *EvaluatorStructName);
+			return false;
+		}
+	}
+	else
+	{
+		// Try to resolve as a Blueprint evaluator class
+		BlueprintEvalClass = ResolveBlueprintEvaluatorClass(EvaluatorStructName);
+		if (!BlueprintEvalClass)
+		{
+			UE_LOG(LogStateTreeService, Warning, TEXT("AddEvaluator: Evaluator struct/class not found: %s"), *EvaluatorStructName);
+			return false;
+		}
+
+		EvalStruct = FindNodeStruct(TEXT("StateTreeBlueprintEvaluatorWrapper"));
+		if (!EvalStruct)
+		{
+			UE_LOG(LogStateTreeService, Warning, TEXT("AddEvaluator: StateTreeBlueprintEvaluatorWrapper struct not found while adding blueprint evaluator '%s'"), *EvaluatorStructName);
+			return false;
+		}
 	}
 
 	FStateTreeEditorNode& NewNode = EditorData->Evaluators.AddDefaulted_GetRef();
-	if (!InitEditorNodeFromStruct(NewNode, EvalStruct))
+	if (!InitEditorNodeFromStruct(NewNode, EvalStruct, EditorData))
 	{
 		EditorData->Evaluators.RemoveAt(EditorData->Evaluators.Num() - 1);
 		return false;
 	}
 
+	if (BlueprintEvalClass)
+	{
+		if (!SetBlueprintEvaluatorClassOnWrapperNode(NewNode, BlueprintEvalClass, EditorData))
+		{
+			EditorData->Evaluators.RemoveAt(EditorData->Evaluators.Num() - 1);
+			UE_LOG(LogStateTreeService, Warning, TEXT("AddEvaluator: Failed to set blueprint evaluator class '%s' on wrapper"), *BlueprintEvalClass->GetName());
+			return false;
+		}
+	}
+
 	MarkStateTreeDirty(StateTree);
-	UE_LOG(LogStateTreeService, Log, TEXT("AddEvaluator: Added '%s' to %s"), *EvaluatorStructName, *AssetPath);
+	if (BlueprintEvalClass)
+	{
+		UE_LOG(LogStateTreeService, Log, TEXT("AddEvaluator: Added blueprint evaluator '%s' to %s"),
+		       *BlueprintEvalClass->GetName(), *AssetPath);
+	}
+	else
+	{
+		UE_LOG(LogStateTreeService, Log, TEXT("AddEvaluator: Added '%s' to %s"), *EvaluatorStructName, *AssetPath);
+	}
 	return true;
 #else
 	return false;
@@ -5256,6 +5564,190 @@ bool UStateTreeService::SetEvaluatorPropertyValue(const FString& AssetPath, cons
 		return false;
 	}
 
+	MarkStateTreeDirty(StateTree);
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool UStateTreeService::BindEvaluatorPropertyToRootParameter(const FString& AssetPath, const FString& EvaluatorStructName,
+	const FString& EvaluatorPropertyPath, const FString& ParameterPath, int32 MatchIndex)
+{
+	if (EvaluatorPropertyPath.IsEmpty() || ParameterPath.IsEmpty())
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("BindEvaluatorPropertyToRootParameter: EvaluatorPropertyPath and ParameterPath are required"));
+		return false;
+	}
+
+	UStateTree* StateTree = LoadStateTree(AssetPath);
+	if (!StateTree)
+	{
+		return false;
+	}
+
+#if WITH_EDITORONLY_DATA
+	UStateTreeEditorData* EditorData = GetEditorData(StateTree);
+	if (!EditorData)
+	{
+		return false;
+	}
+
+	FStateTreeEditorNode* EvalNode = FindEditorNodeByStructInArray(EditorData->Evaluators, EvaluatorStructName, MatchIndex);
+	if (!EvalNode)
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("BindEvaluatorPropertyToRootParameter: Evaluator '%s' not found at match index %d"),
+			*EvaluatorStructName, MatchIndex);
+		return false;
+	}
+
+	FPropertyBindingPath SourcePath;
+	if (!MakeBindingPath(EditorData->GetRootParametersGuid(), ParameterPath, SourcePath))
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("BindEvaluatorPropertyToRootParameter: Invalid parameter path: %s"), *ParameterPath);
+		return false;
+	}
+
+	FPropertyBindingPath TargetPath;
+	if (!MakeBindingPath(EvalNode->ID, EvaluatorPropertyPath, TargetPath))
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("BindEvaluatorPropertyToRootParameter: Invalid evaluator property path: %s"), *EvaluatorPropertyPath);
+		return false;
+	}
+
+	EditorData->AddPropertyBinding(SourcePath, TargetPath);
+	MarkStateTreeDirty(StateTree);
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool UStateTreeService::BindEvaluatorPropertyToContext(const FString& AssetPath, const FString& EvaluatorStructName,
+	const FString& EvaluatorPropertyPath, const FString& ContextName, const FString& ContextPropertyPath, int32 MatchIndex)
+{
+	if (EvaluatorPropertyPath.IsEmpty())
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("BindEvaluatorPropertyToContext: EvaluatorPropertyPath is required"));
+		return false;
+	}
+
+	UStateTree* StateTree = LoadStateTree(AssetPath);
+	if (!StateTree)
+	{
+		return false;
+	}
+
+#if WITH_EDITORONLY_DATA
+	UStateTreeEditorData* EditorData = GetEditorData(StateTree);
+	if (!EditorData)
+	{
+		return false;
+	}
+
+	FStateTreeEditorNode* EvalNode = FindEditorNodeByStructInArray(EditorData->Evaluators, EvaluatorStructName, MatchIndex);
+	if (!EvalNode)
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("BindEvaluatorPropertyToContext: Evaluator '%s' not found at match index %d"),
+			*EvaluatorStructName, MatchIndex);
+		return false;
+	}
+
+	FGuid ContextStructID;
+	if (!ResolveContextStructID(StateTree, ContextName, ContextStructID))
+	{
+		const TConstArrayView<FStateTreeExternalDataDesc> CtxDescs = StateTree->GetSchema()->GetContextDataDescs();
+		if (CtxDescs.IsEmpty())
+		{
+			UE_LOG(LogStateTreeService, Warning,
+				TEXT("BindEvaluatorPropertyToContext: Context '%s' not found — this StateTree has NO context actor class set. "
+				     "Call set_context_actor_class() first to assign one, then retry the bind."),
+				*ContextName);
+		}
+		else
+		{
+			FString Available;
+			for (const FStateTreeExternalDataDesc& Desc : CtxDescs)
+			{
+				if (!Available.IsEmpty()) Available += TEXT(", ");
+				Available += Desc.Name.ToString();
+			}
+			UE_LOG(LogStateTreeService, Warning,
+				TEXT("BindEvaluatorPropertyToContext: Context '%s' not found. Available contexts: [%s]"),
+				*ContextName, *Available);
+		}
+		return false;
+	}
+
+	FPropertyBindingPath SourcePath;
+	if (!MakeBindingPath(ContextStructID, ContextPropertyPath, SourcePath))
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("BindEvaluatorPropertyToContext: Invalid context property path: %s"), *ContextPropertyPath);
+		return false;
+	}
+
+	FPropertyBindingPath TargetPath;
+	if (!MakeBindingPath(EvalNode->ID, EvaluatorPropertyPath, TargetPath))
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("BindEvaluatorPropertyToContext: Invalid evaluator property path: %s"), *EvaluatorPropertyPath);
+		return false;
+	}
+
+	EditorData->AddPropertyBinding(SourcePath, TargetPath);
+	MarkStateTreeDirty(StateTree);
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool UStateTreeService::UnbindEvaluatorProperty(const FString& AssetPath, const FString& EvaluatorStructName,
+	const FString& EvaluatorPropertyPath, int32 MatchIndex)
+{
+	if (EvaluatorPropertyPath.IsEmpty())
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("UnbindEvaluatorProperty: EvaluatorPropertyPath is required"));
+		return false;
+	}
+
+	UStateTree* StateTree = LoadStateTree(AssetPath);
+	if (!StateTree)
+	{
+		return false;
+	}
+
+#if WITH_EDITORONLY_DATA
+	UStateTreeEditorData* EditorData = GetEditorData(StateTree);
+	if (!EditorData)
+	{
+		return false;
+	}
+
+	FStateTreeEditorNode* EvalNode = FindEditorNodeByStructInArray(EditorData->Evaluators, EvaluatorStructName, MatchIndex);
+	if (!EvalNode)
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("UnbindEvaluatorProperty: Evaluator '%s' not found at match index %d"),
+			*EvaluatorStructName, MatchIndex);
+		return false;
+	}
+
+	FPropertyBindingPath TargetPath;
+	if (!MakeBindingPath(EvalNode->ID, EvaluatorPropertyPath, TargetPath))
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("UnbindEvaluatorProperty: Invalid evaluator property path: %s"), *EvaluatorPropertyPath);
+		return false;
+	}
+
+	FStateTreeEditorPropertyBindings* Bindings = EditorData->GetPropertyEditorBindings();
+	if (!Bindings)
+	{
+		return false;
+	}
+
+	Bindings->RemoveBindings(TargetPath);
 	MarkStateTreeDirty(StateTree);
 	return true;
 #else

--- a/Source/VibeUE/Public/PythonAPI/UStateTreeService.h
+++ b/Source/VibeUE/Public/PythonAPI/UStateTreeService.h
@@ -766,8 +766,8 @@ public:
 	// ---- Evaluator / Global Task Management ----
 
 	/**
-	 * Add a global evaluator to the StateTree by struct type name.
-	 * @param EvaluatorStructName FStateTreeEvaluatorBase-derived struct name
+	 * Add a global evaluator to the StateTree by struct type name or Blueprint evaluator name/path.
+	 * @param EvaluatorStructName FStateTreeEvaluatorBase-derived struct name, or Blueprint evaluator name/path/class
 	 */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
 	static bool AddEvaluator(const FString& AssetPath, const FString& EvaluatorStructName);
@@ -914,6 +914,34 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
 	static bool SetEvaluatorPropertyValue(const FString& AssetPath, const FString& EvaluatorStructName,
 	                                      const FString& PropertyPath, const FString& Value, int32 MatchIndex = -1);
+
+	/**
+	 * Bind an evaluator property to a root parameter path (e.g. parameter "PatrolTag" -> evaluator property "PatrolTag").
+	 * Evaluators are global — no StatePath is needed.
+	 * @param MatchIndex Which matching evaluator to target for the struct type. -1 means the last matching evaluator.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
+	static bool BindEvaluatorPropertyToRootParameter(const FString& AssetPath, const FString& EvaluatorStructName,
+	                                                 const FString& EvaluatorPropertyPath, const FString& ParameterPath,
+	                                                 int32 MatchIndex = -1);
+
+	/**
+	 * Bind an evaluator property to context data (e.g. context "Actor" path "TargetPawn" -> evaluator property "ActorRef").
+	 * Leave ContextPropertyPath empty to bind the whole context object.
+	 * Evaluators are global — no StatePath is needed.
+	 * @param MatchIndex Which matching evaluator to target for the struct type. -1 means the last matching evaluator.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
+	static bool BindEvaluatorPropertyToContext(const FString& AssetPath, const FString& EvaluatorStructName,
+	                                           const FString& EvaluatorPropertyPath,
+	                                           const FString& ContextName = TEXT("Actor"),
+	                                           const FString& ContextPropertyPath = TEXT(""),
+	                                           int32 MatchIndex = -1);
+
+	/** Remove the property binding on an evaluator property (unbind it). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
+	static bool UnbindEvaluatorProperty(const FString& AssetPath, const FString& EvaluatorStructName,
+	                                    const FString& EvaluatorPropertyPath, int32 MatchIndex = -1);
 
 	/** Remove a global task by struct type name. */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")


### PR DESCRIPTION
## Changes

### New C++ APIs — Evaluator Property Bindings
- `BindEvaluatorPropertyToRootParameter` — Bind an evaluator property to a StateTree root parameter
- `BindEvaluatorPropertyToContext` — Bind an evaluator property to a context object
- `UnbindEvaluatorProperty` — Remove a binding from an evaluator property

### Skill Doc Updates
- **blueprint-graphs/skill.md** — Added critical rules:
  - Event-style overrides use `"EventGraph"` graph name, not the function name
  - Use `Array_Random` instead of manual Length+Random+Get pattern
- **state-trees/skill.md** — Added evaluator binding examples section
- **README.md** — Added new evaluator binding API entries