### PR TITLE
Merge 5-7 into master: Global task Blueprint support, binding APIs, evaluator bindings, viewport service, transaction service

### DIFF
--- a/Content/Skills/state-trees/skill.md
+++ b/Content/Skills/state-trees/skill.md
@@ -466,6 +466,13 @@ For nested struct properties, use the exact dotted path returned by `get_task_pr
 
 ### Evaluators & Global Tasks
 
+**Evaluators** run every tick and feed computed data to all states (read-only output).
+**Global Tasks** run for the entire lifetime of the StateTree (full task lifecycle: EnterState, Tick, ExitState).
+
+Both support C++ structs and Blueprint assets.
+
+#### Evaluators
+
 ```python
 # Find available evaluator types (includes both struct and Blueprint evaluator types)
 types = unreal.StateTreeService.get_available_evaluator_types()
@@ -473,13 +480,114 @@ types = unreal.StateTreeService.get_available_evaluator_types()
 # Add global evaluator by struct name (runs every tick, data available to all states)
 unreal.StateTreeService.add_evaluator("/Game/AI/MyBehavior", "FMyCustomEvaluator")
 
-# Add Blueprint evaluator by name, path, or generated class name
+# Add Blueprint evaluator by name, path, or generated class name (all three work)
 unreal.StateTreeService.add_evaluator("/Game/AI/MyBehavior", "STE_PatrolPointManagement")
 unreal.StateTreeService.add_evaluator("/Game/AI/MyBehavior", "/Game/StateTree/Evaluators/STE_PatrolPointManagement")
 unreal.StateTreeService.add_evaluator("/Game/AI/MyBehavior", "STE_PatrolPointManagement_C")
+```
 
-# Add global task (runs while tree is active)
+#### Global Tasks
+
+```python
+# Find available task types (use this to get the exact registered name for Blueprint tasks)
+types = unreal.StateTreeService.get_available_task_types()
+for t in types:
+    print(t)  # e.g. "STT_PatrolManagement_C"
+
+# Add a C++ struct global task
 unreal.StateTreeService.add_global_task("/Game/AI/MyBehavior", "FStateTreeDelayTask")
+
+# Add a Blueprint global task — supports the same name forms as add_evaluator:
+# name, full asset path, or _C generated class name
+unreal.StateTreeService.add_global_task("/Game/AI/MyBehavior", "STT_PatrolManagement")
+unreal.StateTreeService.add_global_task("/Game/AI/MyBehavior", "/Game/StateTree/Tasks/STT_PatrolManagement")
+unreal.StateTreeService.add_global_task("/Game/AI/MyBehavior", "STT_PatrolManagement_C")
+```
+
+#### ⚠️ Always Check Before Adding — Global Tasks Accumulate
+
+```python
+import unreal
+
+st_path = "/Game/AI/MyBehavior"
+
+# Check existing global tasks before adding
+info = unreal.StateTreeService.get_state_tree_info(st_path)
+existing_global = [t.name for t in info.global_tasks]
+print(f"Existing global tasks: {existing_global}")
+
+if "STT PatrolManagement" not in existing_global:
+    result = unreal.StateTreeService.add_global_task(st_path, "STT_PatrolManagement")
+    print(f"Added global task: {result}")
+else:
+    print("Global task already present, skipping")
+```
+
+#### Binding Global Task Properties
+
+Global tasks support the same property binding patterns as per-state tasks. Use `bind_global_task_property_to_root_parameter` or `bind_global_task_property_to_context`.
+
+```python
+import unreal
+
+st_path = "/Game/StateTree/ST_Cube"
+
+# Inspect what properties the global task exposes
+props = unreal.StateTreeService.get_global_task_property_names(st_path, "STT_PatrolManagement")
+for p in props:
+    print(f"  {p.name}: {p.type} = {p.current_value!r}")
+
+# Set a property value directly
+unreal.StateTreeService.set_global_task_property_value(st_path, "STT_PatrolManagement", "PatrolTag", "Patrol1")
+
+# Bind a global task property to a root parameter
+unreal.StateTreeService.bind_global_task_property_to_root_parameter(
+    st_path,
+    "STT_PatrolManagement",   # task name (Blueprint name, _C class, or display name)
+    "PatrolTag",              # task property to bind
+    "PatrolTag"               # root parameter name
+)
+
+# Bind a global task property to the context Actor
+unreal.StateTreeService.bind_global_task_property_to_context(
+    st_path,
+    "STT_PatrolManagement",
+    "ActorRef",               # task property to bind
+    "Actor",                  # context name
+    ""                        # context property path (empty = whole object)
+)
+```
+
+#### Full Add + Bind Workflow
+
+```python
+import unreal
+
+st_path = "/Game/StateTree/ST_Cube"
+
+# 1. Check if already present
+info = unreal.StateTreeService.get_state_tree_info(st_path)
+existing = [t.name for t in info.global_tasks]
+
+if "STT PatrolManagement" not in existing:
+    ok = unreal.StateTreeService.add_global_task(st_path, "STT_PatrolManagement")
+    print(f"add_global_task: {ok}")
+    assert ok, "add_global_task returned False"
+
+# 2. Inspect properties
+props = unreal.StateTreeService.get_global_task_property_names(st_path, "STT_PatrolManagement")
+for p in props:
+    print(f"  {p.name}: {p.type} = {p.current_value!r}")
+
+# 3. Bind to root parameter (if PatrolTag root param exists)
+unreal.StateTreeService.bind_global_task_property_to_root_parameter(
+    st_path, "STT_PatrolManagement", "PatrolTag", "PatrolTag")
+
+# 4. Compile and save
+result = unreal.StateTreeService.compile_state_tree(st_path)
+assert result.success, result.errors
+unreal.StateTreeService.save_state_tree(st_path)
+print("Done")
 ```
 
 ### Transitions
@@ -787,6 +895,25 @@ Recommended pattern:
 When a user asks to rename, change, or list "colors" on a StateTree, they mean **theme colors** —
 the editor-only color labels in the StateTree's global color table. Do NOT load the materials skill
 or look for material parameters. Use `get_theme_colors`, `set_state_theme_color`, and `rename_theme_color`.
+
+### ⚠️ Blueprint Global Tasks — Use Name/Path, Not Wrapper Type
+
+`add_global_task` supports Blueprint tasks by name, asset path, or `_C` generated class — the same
+forms as `add_evaluator`. Do NOT pass `"StateTreeBlueprintTaskWrapper"` directly; that's an internal
+struct name and won't resolve to the correct Blueprint class.
+
+```python
+# WRONG — passes the raw wrapper type; the specific Blueprint class won't be set
+unreal.StateTreeService.add_global_task(st_path, "StateTreeBlueprintTaskWrapper")
+
+# CORRECT — any of these forms work
+unreal.StateTreeService.add_global_task(st_path, "STT_PatrolManagement")
+unreal.StateTreeService.add_global_task(st_path, "STT_PatrolManagement_C")
+unreal.StateTreeService.add_global_task(st_path, "/Game/StateTree/Tasks/STT_PatrolManagement")
+```
+
+When inspecting or binding, use the task's display name as it appears in `get_state_tree_info().global_tasks[N].name`
+(e.g. `"STT PatrolManagement"` — no underscore, no `_C`).
 
 ### ⚠️ Blueprint Task Struct Name in get_task_property_names / bind_task_property_to_context
 

--- a/Source/VibeUE/Private/PythonAPI/UStateTreeService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UStateTreeService.cpp
@@ -4566,27 +4566,59 @@ bool UStateTreeService::AddGlobalTask(const FString& AssetPath, const FString& T
 	}
 
 	UScriptStruct* TaskStruct = FindNodeStruct(TaskStructName);
-	if (!TaskStruct)
-	{
-		UE_LOG(LogStateTreeService, Warning, TEXT("AddGlobalTask: Struct not found: %s"), *TaskStructName);
-		return false;
-	}
+	UClass* BlueprintTaskClass = nullptr;
 
-	if (!TaskStruct->IsChildOf(FStateTreeTaskBase::StaticStruct()))
+	if (TaskStruct)
 	{
-		UE_LOG(LogStateTreeService, Warning, TEXT("AddGlobalTask: Struct '%s' is not a FStateTreeTaskBase"), *TaskStructName);
-		return false;
+		if (!TaskStruct->IsChildOf(FStateTreeTaskBase::StaticStruct()))
+		{
+			UE_LOG(LogStateTreeService, Warning, TEXT("AddGlobalTask: Struct '%s' is not a FStateTreeTaskBase"), *TaskStructName);
+			return false;
+		}
+	}
+	else
+	{
+		BlueprintTaskClass = ResolveBlueprintTaskClass(TaskStructName);
+		if (!BlueprintTaskClass)
+		{
+			UE_LOG(LogStateTreeService, Warning, TEXT("AddGlobalTask: Task struct/class not found: %s"), *TaskStructName);
+			return false;
+		}
+
+		TaskStruct = FindNodeStruct(TEXT("StateTreeBlueprintTaskWrapper"));
+		if (!TaskStruct)
+		{
+			UE_LOG(LogStateTreeService, Warning, TEXT("AddGlobalTask: StateTreeBlueprintTaskWrapper struct not found while adding blueprint task '%s'"), *TaskStructName);
+			return false;
+		}
 	}
 
 	FStateTreeEditorNode& NewNode = EditorData->GlobalTasks.AddDefaulted_GetRef();
-	if (!InitEditorNodeFromStruct(NewNode, TaskStruct))
+	if (!InitEditorNodeFromStruct(NewNode, TaskStruct, EditorData))
 	{
 		EditorData->GlobalTasks.RemoveAt(EditorData->GlobalTasks.Num() - 1);
 		return false;
 	}
 
+	if (BlueprintTaskClass)
+	{
+		if (!SetBlueprintTaskClassOnWrapperNode(NewNode, BlueprintTaskClass, EditorData))
+		{
+			EditorData->GlobalTasks.RemoveAt(EditorData->GlobalTasks.Num() - 1);
+			UE_LOG(LogStateTreeService, Warning, TEXT("AddGlobalTask: Failed to set blueprint task class '%s' on wrapper"), *BlueprintTaskClass->GetName());
+			return false;
+		}
+	}
+
 	MarkStateTreeDirty(StateTree);
-	UE_LOG(LogStateTreeService, Log, TEXT("AddGlobalTask: Added '%s' to %s"), *TaskStructName, *AssetPath);
+	if (BlueprintTaskClass)
+	{
+		UE_LOG(LogStateTreeService, Log, TEXT("AddGlobalTask: Added blueprint task '%s' to %s"), *BlueprintTaskClass->GetName(), *AssetPath);
+	}
+	else
+	{
+		UE_LOG(LogStateTreeService, Log, TEXT("AddGlobalTask: Added '%s' to %s"), *TaskStructName, *AssetPath);
+	}
 	return true;
 #else
 	return false;
@@ -5738,6 +5770,190 @@ bool UStateTreeService::UnbindEvaluatorProperty(const FString& AssetPath, const 
 	if (!MakeBindingPath(EvalNode->ID, EvaluatorPropertyPath, TargetPath))
 	{
 		UE_LOG(LogStateTreeService, Warning, TEXT("UnbindEvaluatorProperty: Invalid evaluator property path: %s"), *EvaluatorPropertyPath);
+		return false;
+	}
+
+	FStateTreeEditorPropertyBindings* Bindings = EditorData->GetPropertyEditorBindings();
+	if (!Bindings)
+	{
+		return false;
+	}
+
+	Bindings->RemoveBindings(TargetPath);
+	MarkStateTreeDirty(StateTree);
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool UStateTreeService::BindGlobalTaskPropertyToRootParameter(const FString& AssetPath, const FString& TaskStructName,
+	const FString& TaskPropertyPath, const FString& ParameterPath, int32 MatchIndex)
+{
+	if (TaskPropertyPath.IsEmpty() || ParameterPath.IsEmpty())
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("BindGlobalTaskPropertyToRootParameter: TaskPropertyPath and ParameterPath are required"));
+		return false;
+	}
+
+	UStateTree* StateTree = LoadStateTree(AssetPath);
+	if (!StateTree)
+	{
+		return false;
+	}
+
+#if WITH_EDITORONLY_DATA
+	UStateTreeEditorData* EditorData = GetEditorData(StateTree);
+	if (!EditorData)
+	{
+		return false;
+	}
+
+	FStateTreeEditorNode* TaskNode = FindEditorNodeByStructInArray(EditorData->GlobalTasks, TaskStructName, MatchIndex);
+	if (!TaskNode)
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("BindGlobalTaskPropertyToRootParameter: Global task '%s' not found at match index %d"),
+			*TaskStructName, MatchIndex);
+		return false;
+	}
+
+	FPropertyBindingPath SourcePath;
+	if (!MakeBindingPath(EditorData->GetRootParametersGuid(), ParameterPath, SourcePath))
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("BindGlobalTaskPropertyToRootParameter: Invalid parameter path: %s"), *ParameterPath);
+		return false;
+	}
+
+	FPropertyBindingPath TargetPath;
+	if (!MakeBindingPath(TaskNode->ID, TaskPropertyPath, TargetPath))
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("BindGlobalTaskPropertyToRootParameter: Invalid task property path: %s"), *TaskPropertyPath);
+		return false;
+	}
+
+	EditorData->AddPropertyBinding(SourcePath, TargetPath);
+	MarkStateTreeDirty(StateTree);
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool UStateTreeService::BindGlobalTaskPropertyToContext(const FString& AssetPath, const FString& TaskStructName,
+	const FString& TaskPropertyPath, const FString& ContextName, const FString& ContextPropertyPath, int32 MatchIndex)
+{
+	if (TaskPropertyPath.IsEmpty())
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("BindGlobalTaskPropertyToContext: TaskPropertyPath is required"));
+		return false;
+	}
+
+	UStateTree* StateTree = LoadStateTree(AssetPath);
+	if (!StateTree)
+	{
+		return false;
+	}
+
+#if WITH_EDITORONLY_DATA
+	UStateTreeEditorData* EditorData = GetEditorData(StateTree);
+	if (!EditorData)
+	{
+		return false;
+	}
+
+	FStateTreeEditorNode* TaskNode = FindEditorNodeByStructInArray(EditorData->GlobalTasks, TaskStructName, MatchIndex);
+	if (!TaskNode)
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("BindGlobalTaskPropertyToContext: Global task '%s' not found at match index %d"),
+			*TaskStructName, MatchIndex);
+		return false;
+	}
+
+	FGuid ContextStructID;
+	if (!ResolveContextStructID(StateTree, ContextName, ContextStructID))
+	{
+		const TConstArrayView<FStateTreeExternalDataDesc> CtxDescs = StateTree->GetSchema()->GetContextDataDescs();
+		if (CtxDescs.IsEmpty())
+		{
+			UE_LOG(LogStateTreeService, Warning,
+				TEXT("BindGlobalTaskPropertyToContext: Context '%s' not found — this StateTree has NO context actor class set. "
+				     "Call set_context_actor_class() first to assign one, then retry the bind."),
+				*ContextName);
+		}
+		else
+		{
+			FString Available;
+			for (const FStateTreeExternalDataDesc& Desc : CtxDescs)
+			{
+				if (!Available.IsEmpty()) Available += TEXT(", ");
+				Available += Desc.Name.ToString();
+			}
+			UE_LOG(LogStateTreeService, Warning,
+				TEXT("BindGlobalTaskPropertyToContext: Context '%s' not found. Available contexts: [%s]"),
+				*ContextName, *Available);
+		}
+		return false;
+	}
+
+	FPropertyBindingPath SourcePath;
+	if (!MakeBindingPath(ContextStructID, ContextPropertyPath, SourcePath))
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("BindGlobalTaskPropertyToContext: Invalid context property path: %s"), *ContextPropertyPath);
+		return false;
+	}
+
+	FPropertyBindingPath TargetPath;
+	if (!MakeBindingPath(TaskNode->ID, TaskPropertyPath, TargetPath))
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("BindGlobalTaskPropertyToContext: Invalid task property path: %s"), *TaskPropertyPath);
+		return false;
+	}
+
+	EditorData->AddPropertyBinding(SourcePath, TargetPath);
+	MarkStateTreeDirty(StateTree);
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool UStateTreeService::UnbindGlobalTaskProperty(const FString& AssetPath, const FString& TaskStructName,
+	const FString& TaskPropertyPath, int32 MatchIndex)
+{
+	if (TaskPropertyPath.IsEmpty())
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("UnbindGlobalTaskProperty: TaskPropertyPath is required"));
+		return false;
+	}
+
+	UStateTree* StateTree = LoadStateTree(AssetPath);
+	if (!StateTree)
+	{
+		return false;
+	}
+
+#if WITH_EDITORONLY_DATA
+	UStateTreeEditorData* EditorData = GetEditorData(StateTree);
+	if (!EditorData)
+	{
+		return false;
+	}
+
+	FStateTreeEditorNode* TaskNode = FindEditorNodeByStructInArray(EditorData->GlobalTasks, TaskStructName, MatchIndex);
+	if (!TaskNode)
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("UnbindGlobalTaskProperty: Global task '%s' not found at match index %d"),
+			*TaskStructName, MatchIndex);
+		return false;
+	}
+
+	FPropertyBindingPath TargetPath;
+	if (!MakeBindingPath(TaskNode->ID, TaskPropertyPath, TargetPath))
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("UnbindGlobalTaskProperty: Invalid task property path: %s"), *TaskPropertyPath);
 		return false;
 	}
 

--- a/Source/VibeUE/Public/PythonAPI/UStateTreeService.h
+++ b/Source/VibeUE/Public/PythonAPI/UStateTreeService.h
@@ -773,8 +773,8 @@ public:
 	static bool AddEvaluator(const FString& AssetPath, const FString& EvaluatorStructName);
 
 	/**
-	 * Add a global task to the StateTree by struct type name.
-	 * @param TaskStructName FStateTreeTaskBase-derived struct name
+	 * Add a global task to the StateTree by struct type name or Blueprint task name/path.
+	 * @param TaskStructName FStateTreeTaskBase-derived struct name, or Blueprint task name/path/class
 	 */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
 	static bool AddGlobalTask(const FString& AssetPath, const FString& TaskStructName);
@@ -942,6 +942,34 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
 	static bool UnbindEvaluatorProperty(const FString& AssetPath, const FString& EvaluatorStructName,
 	                                    const FString& EvaluatorPropertyPath, int32 MatchIndex = -1);
+
+	/**
+	 * Bind a global task property to a root parameter path (e.g. parameter "PatrolTag" -> task property "PatrolTag").
+	 * Global tasks are global — no StatePath is needed.
+	 * @param MatchIndex Which matching global task to target for the struct type. -1 means the last matching task.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
+	static bool BindGlobalTaskPropertyToRootParameter(const FString& AssetPath, const FString& TaskStructName,
+	                                                  const FString& TaskPropertyPath, const FString& ParameterPath,
+	                                                  int32 MatchIndex = -1);
+
+	/**
+	 * Bind a global task property to context data (e.g. context "Actor" path "TargetPawn" -> task property "ActorRef").
+	 * Leave ContextPropertyPath empty to bind the whole context object.
+	 * Global tasks are global — no StatePath is needed.
+	 * @param MatchIndex Which matching global task to target for the struct type. -1 means the last matching task.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
+	static bool BindGlobalTaskPropertyToContext(const FString& AssetPath, const FString& TaskStructName,
+	                                            const FString& TaskPropertyPath,
+	                                            const FString& ContextName = TEXT("Actor"),
+	                                            const FString& ContextPropertyPath = TEXT(""),
+	                                            int32 MatchIndex = -1);
+
+	/** Remove the property binding on a global task property (unbind it). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
+	static bool UnbindGlobalTaskProperty(const FString& AssetPath, const FString& TaskStructName,
+	                                     const FString& TaskPropertyPath, int32 MatchIndex = -1);
 
 	/** Remove a global task by struct type name. */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")


### PR DESCRIPTION
## Summary

- **Global task Blueprint support**: `add_global_task` now resolves Blueprint task classes by name/path (mirrors `add_task`/`add_evaluator`)
- **Global task property binding APIs**: `bind_global_task_property_to_root_parameter`, `bind_global_task_property_to_context`, `unbind_global_task_property`
- **Evaluator binding APIs**: `bind_evaluator_property_to_root_parameter`, `bind_evaluator_property_to_context`, `unbind_evaluator_property`
- **Viewport service**: new viewport capture and management APIs with skill docs
- **Transaction service**: `EditorTransactionService` with undo/redo/transaction grouping support
- **StateTree non-destructive APIs**: move state, non-destructive type editing
- **MetaSound service**: full phase 2 MetaSound graph editing service
- **Bug fixes**: array function wildcard pin type propagation, FocusInputTextBox stack overflow, manage_asset multi-root search, GameplayTagsEditor editor-only build guard
- **Skill docs**: updated state-trees, level-actors, and other skills with new workflow patterns and gotchas

## Test plan

- [ ] Rebuild VibeUE plugin in UE 5.7 — verify no compile errors
- [ ] Add a Blueprint task as a Global Task via `add_global_task("STT_MyTask")`
- [ ] Bind global task property to root parameter via `bind_global_task_property_to_root_parameter`
- [ ] Bind evaluator property to root parameter via `bind_evaluator_property_to_root_parameter`
- [ ] Verify StateTree compiles cleanly after bindings
- [ ] Undo/redo via `EditorTransactionService` across a multi-step transaction group
- [ ] MetaSound graph creation and node connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)