### PR TITLE
feat: add PCG skill for procedural content generation

### DIFF
--- a/Content/Skills/pcg/skill.md
+++ b/Content/Skills/pcg/skill.md
@@ -41,6 +41,22 @@ keywords:
 PCG (Procedural Content Generation) in UE 5.7 is production-ready and fully scriptable via
 the `PCGPythonInterop` plugin. No VibeUE service wrapper is needed — the Python API is complete.
 
+## ⚠️ Read this before writing any code
+
+These are the mistakes that cause infinite retry loops. Check each one before executing:
+
+**Do not call `discover_python_class` or `discover_python_function` on any PCG class — this skill contains everything you need. Calling discover bloats context and causes content filter failures.**
+
+
+1. **Volume Sampler input pin is `"Volume"`, not `"In"`** — `add_edge(input_node, 'In', sampler_node, 'Volume')`. Using `'In'` silently no-ops and produces 0 points.
+2. **`voxel_size` is a `Vector`, not a float** — `set_editor_property('voxel_size', unreal.Vector(200, 200, 200))`. Passing a float raises a TypeError.
+3. **`graph` property on PCGComponent is protected** — use `pcg_comp.set_graph(graph)`, never `set_editor_property('graph', ...)`.
+4. **After modifying a graph, always: save → reload → reassign → generate** — skipping reload means the component runs the old cached version.
+5. **Check for existing nodes before adding** — always inspect `[type(n.get_settings()).__name__ for n in graph.nodes]` first. Adding a node type that already exists creates duplicates that break wiring.
+6. **Always save AND reload after every change** — call `save_asset` then `reload_packages` every time. Without the reload the PCG graph editor window won't update and users will think nothing happened.
+7. **Use Volume Sampler for empty levels, not Surface Sampler** — Surface Sampler requires geometry to sample from. An empty level has no geometry, so Surface Sampler always produces 0 points. Use `PCGVolumeSamplerSettings` with `unbounded=True` for empty or sparse levels.
+8. **Never spawn test actors to verify meshes or materials** — do not use `spawn_actor_from_class` to place test cubes. Verify by checking ISM instance counts on the PCGVolume instead: `sum(c.get_instance_count() for c in volume.get_components_by_class(unreal.InstancedStaticMeshComponent))`.
+
 ## ⚠️ Prerequisites
 
 Both plugins must be enabled in the project's `.uproject`:
@@ -114,7 +130,7 @@ print(settings.get_editor_property('points_per_squared_meter'))
 `node.get_editor_property('node_title')` is `None` by default. Identify nodes by their settings class:
 
 ```python
-for node in graph.get_editor_property('nodes'):
+for node in graph.nodes:
     print(type(node.get_settings()).__name__)
 ```
 
@@ -191,8 +207,9 @@ graph.add_edge(spawner_node, 'Out', output_node, 'Out')
 graph.add_edge(a, 'Out', b, 'In').add_edge_to('Out', c, 'In')
 ```
 
-`add_edge` is **permissive** — it does not error on duplicate edges or wrong pin labels. It
-returns the destination node in both cases. Always verify with `pin.is_connected()` after wiring.
+`add_edge` is **permissive and idempotent** — calling it twice on the same pins does not create
+duplicate edges (deduplicates silently). It does not error on wrong pin labels — it silently
+no-ops if a label doesn't match. Always verify with `pin.is_connected()` after wiring.
 
 ## Node Positioning
 
@@ -225,20 +242,112 @@ for n in nodes_to_remove:
 
 ## Notifying the Editor
 
-Always call after making structural changes so the PCG graph editor refreshes:
+`PCGGraph` has no `notify_graph_changed` or `force_notification_for_editor` method — both silently
+do nothing or raise `AttributeError`. The only reliable way to refresh the PCG editor after
+Python-driven changes is to reload the package:
 
 ```python
-graph.force_notification_for_editor(unreal.PCGChangeType.STRUCTURAL)
+import unreal
+
+pkg = unreal.find_package('/Game/PCG/MyPCGGraph')
+unreal.EditorLoadingAndSavingUtils.reload_packages([pkg])
+```
+
+This forces the editor to re-read the asset from disk, so **always save before reloading**:
+
+```python
+unreal.EditorAssetLibrary.save_asset('/Game/PCG/MyPCGGraph', only_if_is_dirty=False)
+pkg = unreal.find_package('/Game/PCG/MyPCGGraph')
+unreal.EditorLoadingAndSavingUtils.reload_packages([pkg])
 ```
 
 ## Saving
 
+**Always save AND reload after every change** — without the reload the PCG graph editor window will not update and users will think nothing happened:
+
 ```python
-unreal.EditorAssetLibrary.save_asset('/Game/PCG/MyPCGGraph')
+unreal.EditorAssetLibrary.save_asset('/Game/PCGTest/MyGraph', only_if_is_dirty=False)
+pkg = unreal.find_package('/Game/PCGTest/MyGraph')
+unreal.EditorLoadingAndSavingUtils.reload_packages([pkg])
 ```
 
-Note: deleting a PCG graph asset while it is open in the PCG editor will fail silently.
-Close the asset in the editor first, or use `manage_asset(action="delete", ...)`.
+Never call just `save_asset` alone — always follow it with `reload_packages`.
+
+## Deleting PCG Graph Assets
+
+```python
+unreal.EditorAssetLibrary.delete_asset('/Game/PCG/MyPCGGraph')
+```
+
+**If deletion fails (returns False or raises a permission error), this is a Windows file system
+limitation — not a Vibe or PCG API issue.** UE holds an open file handle on every `.uasset` it
+loads during a session. That handle is not released until UE shuts down, even after closing the
+editor tab or running garbage collection.
+
+To reliably delete PCG assets:
+
+1. Close the editor tab first:
+```python
+subsystem = unreal.get_editor_subsystem(unreal.AssetEditorSubsystem)
+asset = unreal.load_asset('/Game/PCG/MyPCGGraph')
+subsystem.close_all_editors_for_asset(asset)
+```
+
+2. If graphs reference each other (e.g. a subgraph node), break the cross-reference first,
+   save, then delete — otherwise UE refuses deletion even with the tab closed:
+```python
+# Remove the subgraph node before deleting the subgraph asset
+for n in list(main_graph.nodes):
+    if type(n.get_settings()).__name__ == 'PCGSubgraphSettings':
+        main_graph.remove_node(n)
+unreal.EditorAssetLibrary.save_asset('/Game/PCG/MainGraph', only_if_is_dirty=False)
+unreal.SystemLibrary.collect_garbage()
+unreal.EditorAssetLibrary.delete_asset('/Game/PCG/SubGraph')
+```
+
+3. If deletion still fails after steps 1–2, the asset was loaded earlier in the session and UE
+   will not release the handle until restart. **Restart UE** — the files will be deletable
+   immediately on reboot before the project loads them again.
+
+## Placing a PCGVolume and Generating
+
+**Always check for existing PCGVolume actors before spawning** — if one already exists, use it. Only spawn if none is found.
+
+```python
+import unreal, time
+
+# Get actors — use EditorActorSubsystem, NOT EditorWorldSubsystem or Level.get_actors()
+actor_subsys = unreal.get_editor_subsystem(unreal.EditorActorSubsystem)
+actors = actor_subsys.get_all_level_actors()
+
+# Check for existing volume first
+existing = [a for a in actors if a.get_class().get_name() == 'PCGVolume']
+if existing:
+    volume = existing[0]
+else:
+    volume = actor_subsys.spawn_actor_from_class(
+        unreal.PCGVolume, unreal.Vector(0, 0, 100), unreal.Rotator(0, 0, 0)
+    )
+    volume.set_actor_scale3d(unreal.Vector(10, 10, 5))
+
+# Actor location uses get_actor_location(), NOT get_location()
+print(f'Volume at: {volume.get_actor_location()}')
+
+# Assign graph — graph property is protected, must use set_graph()
+graph = unreal.load_asset('/Game/PCGTest/CubeScatter')
+pcg_comp = volume.get_component_by_class(unreal.PCGComponent)
+pcg_comp.set_graph(graph)
+
+# generate() requires force as a keyword argument
+pcg_comp.generate(force=True)
+
+time.sleep(3)
+
+# Verify — ISM components hold the spawned instances
+comps = volume.get_components_by_class(unreal.InstancedStaticMeshComponent)
+total = sum(c.get_instance_count() for c in comps)
+print(f'ISM components: {len(comps)}, total instances: {total}')
+```
 
 ## Full Example — Surface Sampler → Mesh Spawner
 
@@ -268,9 +377,10 @@ graph.add_edge(input_node, 'In', sampler_node, 'Surface')
 graph.add_edge(sampler_node, 'Out', spawner_node, 'In')
 graph.add_edge(spawner_node, 'Out', output_node, 'Out')
 
-# Notify and save
-graph.force_notification_for_editor(unreal.PCGChangeType.STRUCTURAL)
-unreal.EditorAssetLibrary.save_asset('/Game/PCG/BP_Scatter')
+# Save and reload to refresh the PCG editor
+unreal.EditorAssetLibrary.save_asset('/Game/PCG/BP_Scatter', only_if_is_dirty=False)
+pkg = unreal.find_package('/Game/PCG/BP_Scatter')
+unreal.EditorLoadingAndSavingUtils.reload_packages([pkg])
 print("PCG graph created successfully")
 ```
 
@@ -297,6 +407,70 @@ Confirmed names for commonly used settings:
 | `PCGSubgraphSettings` | subgraph ref | `subgraph_override` (not `subgraph`) |
 | `PCGSurfaceSamplerSettings` | unbounded | `unbounded` |
 | `PCGSurfaceSamplerSettings` | density | `points_per_squared_meter` |
+
+## Struct Properties Are Lowercase
+
+All UE Python struct types use **lowercase** property names — not CamelCase:
+
+```python
+v = unreal.Vector(50, 50, 50)
+print(v.x, v.y, v.z)        # correct — NOT v.X, v.Y, v.Z
+
+r = unreal.Rotator(0, 90, 0)
+print(r.pitch, r.yaw, r.roll)  # correct — NOT r.Pitch, r.Yaw, r.Roll
+```
+
+This applies to `Vector`, `Rotator`, `Transform`, `LinearColor` and all other UE structs in Python.
+
+## Configuring the Static Mesh Spawner
+
+The spawner uses a `mesh_entries` list on its `mesh_selector_parameters`. Each entry has a `descriptor` with a `static_mesh` property. This is the **only** way to assign a mesh — there is no `set_mesh`, `mesh`, or `mesh_selector_type` shortcut:
+
+```python
+import unreal
+
+# Get the spawner node's settings
+spawner_node, spawner_settings = graph.add_node_of_type(unreal.PCGStaticMeshSpawnerSettings)
+
+# Load a mesh
+cube_mesh = unreal.load_asset('/Engine/BasicShapes/Cube')
+
+# Build an entry
+entry = unreal.PCGMeshSelectorWeightedEntry()
+desc = entry.get_editor_property('descriptor')
+desc.set_editor_property('static_mesh', cube_mesh)
+entry.set_editor_property('descriptor', desc)
+entry.set_editor_property('weight', 1)
+
+# Assign to selector
+selector = spawner_settings.get_editor_property('mesh_selector_parameters')
+selector.set_editor_property('mesh_entries', [entry])
+```
+
+For multiple meshes or materials, pass a list of entries — one per mesh/material combination.
+
+To add colour variation, create one entry per material using `override_materials` on the descriptor. **Do not set the material on `static_mesh`** — that property only accepts a StaticMesh:
+
+```python
+import unreal
+
+cube_mesh = unreal.load_asset('/Engine/BasicShapes/Cube')
+color_names = ['Red', 'Blue', 'Green', 'Yellow', 'Purple', 'Orange']
+materials = [unreal.load_asset(f'/Game/PCGTest/M_Cube_{n}') for n in color_names]
+
+entries = []
+for mat in materials:
+    entry = unreal.PCGMeshSelectorWeightedEntry()
+    desc = entry.get_editor_property('descriptor')
+    desc.set_editor_property('static_mesh', cube_mesh)       # mesh goes here
+    desc.set_editor_property('override_materials', [mat])    # material goes here
+    entry.set_editor_property('descriptor', desc)
+    entry.set_editor_property('weight', 1)
+    entries.append(entry)
+
+selector = spawner_settings.get_editor_property('mesh_selector_parameters')
+selector.set_editor_property('mesh_entries', entries)
+```
 
 ## Keep Code Blocks Small
 

--- a/Content/Skills/pcg/skill.md
+++ b/Content/Skills/pcg/skill.md
@@ -1,0 +1,323 @@
+---
+name: pcg
+display_name: Procedural Content Generation (PCG)
+description: Create, inspect, and edit PCG Graph assets — add nodes, configure settings, connect pins, and wire up procedural generation graphs
+unreal_classes:
+  - PCGGraph
+  - PCGNode
+  - PCGEdge
+  - PCGPin
+  - PCGPinProperties
+  - PCGSettings
+  - PCGGraphFactory
+  - PCGSurfaceSamplerSettings
+  - PCGStaticMeshSpawnerSettings
+  - PCGMeshSamplerSettings
+keywords:
+  - pcg
+  - procedural
+  - procedural content generation
+  - pcg graph
+  - pcg node
+  - pcg pin
+  - pcg edge
+  - surface sampler
+  - mesh spawner
+  - static mesh spawner
+  - point filter
+  - density filter
+  - transform
+  - attribute
+  - subgraph
+  - pcg component
+  - connect nodes
+  - add node
+  - wire
+  - graph editor
+---
+
+# PCG Skill
+
+PCG (Procedural Content Generation) in UE 5.7 is production-ready and fully scriptable via
+the `PCGPythonInterop` plugin. No VibeUE service wrapper is needed — the Python API is complete.
+
+## ⚠️ Prerequisites
+
+Both plugins must be enabled in the project's `.uproject`:
+
+```json
+{ "Name": "PCG", "Enabled": true },
+{ "Name": "PCGPythonInterop", "Enabled": true }
+```
+
+Verify they're loaded before executing:
+
+```python
+import unreal
+assert hasattr(unreal, 'PCGGraph'), "PCG plugins not enabled — check .uproject"
+```
+
+## Creating a PCG Graph Asset
+
+```python
+import unreal
+
+factory = unreal.PCGGraphFactory()
+asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
+graph = asset_tools.create_asset('MyPCGGraph', '/Game/PCG', unreal.PCGGraph, factory)
+unreal.EditorAssetLibrary.save_asset('/Game/PCG/MyPCGGraph')
+```
+
+## Loading an Existing PCG Graph
+
+```python
+import unreal
+
+graph = unreal.EditorAssetLibrary.load_asset('/Game/PCG/MyPCGGraph')
+# graph is a PCGGraph — access nodes, input_node, output_node directly
+```
+
+Or use `manage_asset` to search first (use `action="search"`, not `action="find"`):
+```
+manage_asset(action="search", search_query="MyPCGGraph")
+```
+
+## Adding Nodes
+
+Use `add_node_of_type(SettingsClass)` — returns a `(PCGNode, PCGSettings)` tuple.
+All Settings classes are direct attributes of the `unreal` module — no `find_class` needed:
+
+```python
+import unreal
+
+# Surface Sampler node
+node, settings = graph.add_node_of_type(unreal.PCGSurfaceSamplerSettings)
+settings.set_editor_property('points_per_squared_meter', 5.0)
+settings.set_editor_property('point_extents', unreal.Vector(50, 50, 50))
+node.set_node_position(200, 0)
+
+# Static Mesh Spawner node
+spawner_node, spawner_settings = graph.add_node_of_type(unreal.PCGStaticMeshSpawnerSettings)
+spawner_node.set_node_position(500, 0)
+```
+
+Settings can also be read/written after creation via `node.get_settings()`:
+
+```python
+settings = node.get_settings()
+settings.set_editor_property('unbounded', True)
+print(settings.get_editor_property('points_per_squared_meter'))
+```
+
+## Identifying Nodes
+
+`node.get_editor_property('node_title')` is `None` by default. Identify nodes by their settings class:
+
+```python
+for node in graph.get_editor_property('nodes'):
+    print(type(node.get_settings()).__name__)
+```
+
+Note: the `nodes` array does **not** include the graph's Input and Output nodes.
+Access those via `graph.get_input_node()` and `graph.get_output_node()`.
+
+## Discovering Available Node Types
+
+```python
+import unreal
+node_types = sorted([x for x in dir(unreal) if x.endswith('Settings') and 'PCG' in x])
+print(node_types)
+```
+
+## Inspecting Pin Labels
+
+Pin labels live on `PCGPinProperties`, not directly on `PCGPin`.
+**Always inspect before connecting** — pin names vary significantly by node type:
+
+```python
+def pin_labels(pins):
+    return [str(p.get_editor_property('properties').get_editor_property('label')) for p in pins]
+
+node, _ = graph.add_node_of_type(unreal.PCGSurfaceSamplerSettings)
+print('Inputs:', pin_labels(node.get_editor_property('input_pins')))
+print('Outputs:', pin_labels(node.get_editor_property('output_pins')))
+```
+
+**Known pin label gotchas (verified in UE 5.7):**
+
+| Node | Main input pin | Main output pin |
+|---|---|---|
+| Graph Input node | *(no input)* | `"In"` |
+| Graph Output node | `"Out"` | *(no output)* |
+| Surface Sampler | `"Surface"` (not `"In"`) | `"Out"` |
+| Most other nodes | `"In"` | `"Out"` |
+
+The graph Input/Output node pin naming is inverted from what you'd expect — this is intentional in PCG.
+
+## Checking Pin Connection State
+
+`is_connected()` is a **method**, not a property — call it, don't get_editor_property it:
+
+```python
+pin = node.get_editor_property('output_pins')[0]
+print(pin.is_connected())          # correct
+# print(pin.get_editor_property('is_connected'))  # WRONG — raises AttributeError
+```
+
+## Connecting Nodes (Edges)
+
+Use `graph.add_edge()` or `node.add_edge_to()` — both work, prefer `add_edge` for clarity.
+Always inspect pin labels first (see above).
+
+```python
+import unreal
+
+input_node = graph.get_input_node()
+output_node = graph.get_output_node()
+
+# Input node's output pin is labelled "In" — this is correct
+graph.add_edge(input_node, 'In', sampler_node, 'Surface')
+
+# Most other nodes use 'Out' → 'In'
+graph.add_edge(sampler_node, 'Out', filter_node, 'In')
+graph.add_edge(filter_node, 'Out', spawner_node, 'In')
+
+# Output node's input pin is labelled "Out" — this is correct
+graph.add_edge(spawner_node, 'Out', output_node, 'Out')
+```
+
+`add_edge` returns the destination node, enabling chaining:
+```python
+graph.add_edge(a, 'Out', b, 'In').add_edge_to('Out', c, 'In')
+```
+
+`add_edge` is **permissive** — it does not error on duplicate edges or wrong pin labels. It
+returns the destination node in both cases. Always verify with `pin.is_connected()` after wiring.
+
+## Node Positioning
+
+`get_node_position()` returns a plain `tuple`, not a named object:
+
+```python
+node.set_node_position(200, 0)
+x, y = node.get_node_position()  # unpack as tuple
+```
+
+## Removing Edges and Nodes
+
+```python
+import unreal
+
+# Remove a specific edge — returns True if removed, False if edge didn't exist (no crash)
+removed = graph.remove_edge(from_node, 'Out', to_node, 'In')
+
+# Remove from the source node side
+from_node.remove_edge_to('Out', to_node, 'In')
+
+# Delete a node (also removes its connected edges)
+graph.remove_node(node)
+
+# Bulk removal — pass the list explicitly
+nodes_to_remove = list(graph.get_editor_property('nodes'))
+for n in nodes_to_remove:
+    graph.remove_node(n)
+```
+
+## Notifying the Editor
+
+Always call after making structural changes so the PCG graph editor refreshes:
+
+```python
+graph.force_notification_for_editor(unreal.PCGChangeType.STRUCTURAL)
+```
+
+## Saving
+
+```python
+unreal.EditorAssetLibrary.save_asset('/Game/PCG/MyPCGGraph')
+```
+
+Note: deleting a PCG graph asset while it is open in the PCG editor will fail silently.
+Close the asset in the editor first, or use `manage_asset(action="delete", ...)`.
+
+## Full Example — Surface Sampler → Mesh Spawner
+
+```python
+import unreal
+
+# Create asset
+factory = unreal.PCGGraphFactory()
+asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
+graph = asset_tools.create_asset('BP_Scatter', '/Game/PCG', unreal.PCGGraph, factory)
+
+input_node = graph.get_input_node()
+output_node = graph.get_output_node()
+output_node.set_node_position(800, 0)
+
+# Surface Sampler — main input pin is "Surface", not "In"
+sampler_node, sampler_settings = graph.add_node_of_type(unreal.PCGSurfaceSamplerSettings)
+sampler_settings.set_editor_property('points_per_squared_meter', 2.0)
+sampler_node.set_node_position(200, 0)
+
+# Static Mesh Spawner
+spawner_node, _ = graph.add_node_of_type(unreal.PCGStaticMeshSpawnerSettings)
+spawner_node.set_node_position(500, 0)
+
+# Wire up — note Input node's output pin is "In", Output node's input pin is "Out"
+graph.add_edge(input_node, 'In', sampler_node, 'Surface')
+graph.add_edge(sampler_node, 'Out', spawner_node, 'In')
+graph.add_edge(spawner_node, 'Out', output_node, 'Out')
+
+# Notify and save
+graph.force_notification_for_editor(unreal.PCGChangeType.STRUCTURAL)
+unreal.EditorAssetLibrary.save_asset('/Game/PCG/BP_Scatter')
+print("PCG graph created successfully")
+```
+
+## Assigning a Subgraph Reference
+
+Use `subgraph_override` (not `subgraph` — that's protected):
+
+```python
+sub_graph = unreal.EditorAssetLibrary.load_asset('/Game/PCG/MySubgraph')
+sg_node, sg_settings = graph.add_node_of_type(unreal.PCGSubgraphSettings)
+sg_settings.set_editor_property('subgraph_override', sub_graph)
+```
+
+## Common Settings Property Names
+
+Some properties have non-obvious names — always use `discover_python_class` if unsure.
+Confirmed names for commonly used settings:
+
+| Settings Class | Property | Correct Name |
+|---|---|---|
+| `PCGTransformPointsSettings` | scale | `scale_min`, `scale_max`, `uniform_scale` |
+| `PCGTransformPointsSettings` | offset | `offset_min`, `offset_max` |
+| `PCGTransformPointsSettings` | rotation | `rotation_min`, `rotation_max` |
+| `PCGSubgraphSettings` | subgraph ref | `subgraph_override` (not `subgraph`) |
+| `PCGSurfaceSamplerSettings` | unbounded | `unbounded` |
+| `PCGSurfaceSamplerSettings` | density | `points_per_squared_meter` |
+
+## Keep Code Blocks Small
+
+PCG operations can be slow if done in bulk. Split large scripts into smaller focused blocks
+rather than one monolithic script — avoids 30s execution timeouts and makes errors easier to diagnose.
+
+## Common Node Settings Classes
+
+| Node Type | Settings Class | Main Input Pin |
+|---|---|---|
+| Surface Sampler | `PCGSurfaceSamplerSettings` | `"Surface"` |
+| Mesh Sampler | `PCGMeshSamplerSettings` | `"In"` |
+| Static Mesh Spawner | `PCGStaticMeshSpawnerSettings` | `"In"` |
+| Density Filter | `PCGDensityFilterSettings` | `"In"` |
+| Point Filter | `PCGPointFilterSettings` → runtime: `PCGAttributeFilteringSettings` | `"In"` |
+| Transform Points | `PCGTransformPointsSettings` | `"In"` |
+| Copy Points | `PCGCopyPointsSettings` | `"Source"`, `"Target"` (no `"In"`) |
+| Merge | `PCGMergeSettings` | `"In"` |
+| Difference | `PCGDifferenceSettings` | `"In"` |
+| Intersection | `PCGIntersectionSettings` | `"In"` |
+| Subgraph | `PCGSubgraphSettings` | `"In"` — assign graph via `settings.set_editor_property('subgraph_override', graph_asset)` |
+| Create Attribute | `PCGCreateAttributeSettings` | `"In"` |
+
+When in doubt, discover: `[x for x in dir(unreal) if 'PCG' in x and x.endswith('Settings')]`

--- a/Content/Skills/vibeue/SKILL.md
+++ b/Content/Skills/vibeue/SKILL.md
@@ -17,9 +17,18 @@ manage_skills(action="list")
 
 ## Load a skill before working in a domain
 
+Always load the relevant skill **before writing any code**. The skill contains exact API patterns and gotchas — without it you will guess wrong property names and spiral into discovery loops.
+
+| Task | Load this skill |
+|---|---|
+| Blueprints | `blueprints` |
+| PCG / procedural generation / scatter | `pcg` |
+| Materials | `materials` |
+| State Trees | `state-trees` |
+
 ```
+manage_skills(action="load", skill_name="pcg")
 manage_skills(action="load", skill_name="blueprints")
-manage_skills(action="load", skill_name="state-trees")
 manage_skills(action="load", skill_name="materials")
 ```
 

--- a/Content/Skills/vibeue/SKILL.md
+++ b/Content/Skills/vibeue/SKILL.md
@@ -3,7 +3,7 @@ name: vibeue
 description: Unreal Engine 5 development using the VibeUE Python API. Use when working
   in Unreal Engine — blueprints, state trees, materials, actors, landscapes, animation,
   niagara, widgets, sound, foliage, data tables, gameplay tags, enhanced input, skeletons,
-  and more. Requires the VibeUE MCP server to be connected.
+  PCG (procedural content generation), and more. Requires the VibeUE MCP server to be connected.
 compatibility: Requires VibeUE MCP server
 ---
 

--- a/test_prompts/pcg/01_pcg_graph_tests.md
+++ b/test_prompts/pcg/01_pcg_graph_tests.md
@@ -1,0 +1,328 @@
+# PCG Graph Tests
+
+Tests for creating, editing, and connecting nodes in PCG Graph assets via the PCGPythonInterop plugin.
+Run sequentially. Requires PCG and PCGPythonInterop plugins enabled in the project.
+
+---
+
+## Prerequisites
+
+Check whether the PCG and PCGPythonInterop plugins are loaded by verifying that `unreal.PCGGraph` exists in the Python environment. Report the result clearly.
+
+---
+
+Search for any existing PCG graph assets with "PCGTest" in the name (use manage_asset action="search") and delete them if found.
+
+---
+
+## Graph Creation
+
+Create a new PCG Graph asset called "PCG_TestGraph" saved to "/Game/PCGTest". Confirm the asset exists at that path.
+
+---
+
+Open "PCG_TestGraph" in the PCG editor.
+
+---
+
+## Inspect Empty Graph
+
+List all nodes currently in PCG_TestGraph. The `nodes` array will be empty — Input and Output nodes are not included in it, access them via get_input_node() and get_output_node().
+
+---
+
+Get the Input node from PCG_TestGraph and print its output pin labels. Note: the Input node's output pin is labelled "In" — this is intentional in PCG.
+
+---
+
+Get the Output node from PCG_TestGraph and print its input pin labels. Note: the Output node's input pin is labelled "Out" — this is intentional in PCG.
+
+---
+
+## Adding Nodes
+
+Add a Surface Sampler node to PCG_TestGraph. Print the settings class name (node_title will be None — identify nodes via type(node.get_settings()).__name__) and its output pin labels.
+
+---
+
+Add a Static Mesh Spawner node to PCG_TestGraph. Print its settings class name and input pin labels.
+
+---
+
+Add a Density Filter node to PCG_TestGraph.
+
+---
+
+Add a Transform Points node to PCG_TestGraph.
+
+---
+
+Add a Merge node to PCG_TestGraph.
+
+---
+
+List all nodes in PCG_TestGraph now by their settings class name. Should show Surface Sampler, Static Mesh Spawner, Density Filter, Transform Points, and Merge — 5 nodes (Input and Output are not in the nodes array).
+
+---
+
+## Node Positioning
+
+Set the Surface Sampler node to position (200, 0).
+
+---
+
+Set the Density Filter node to position (400, 0).
+
+---
+
+Set the Transform Points node to position (600, 0).
+
+---
+
+Set the Static Mesh Spawner node to position (800, 0).
+
+---
+
+Set the Merge node to position (600, -300).
+
+---
+
+Get the position of the Surface Sampler node and verify it is (200, 0). Note: get_node_position() returns a plain tuple — unpack as x, y = node.get_node_position().
+
+---
+
+## Configuring Node Settings
+
+Set the Surface Sampler's `points_per_squared_meter` to 3.0 and `point_extents` to (50, 50, 50).
+
+---
+
+Read back the `points_per_squared_meter` property from the Surface Sampler. Should be 3.0.
+
+---
+
+Set the `unbounded` property to True on the Surface Sampler.
+
+---
+
+Read back `unbounded` from the Surface Sampler. Should be True.
+
+---
+
+## Inspecting Pin Labels
+
+Print all input and output pin labels for the Surface Sampler node. Labels are accessed via pin.get_editor_property('properties').get_editor_property('label') — NOT directly via pin.get_editor_property('label'). Expect main input = "Surface" (not "In").
+
+---
+
+Print all input and output pin labels for the Density Filter node. Expect main input = "In".
+
+---
+
+Print all input and output pin labels for the Static Mesh Spawner node. Expect main input = "In".
+
+---
+
+## Connecting Nodes — Main Chain
+
+Connect the Input node's output pin ("In") to the Surface Sampler's input pin ("Surface"). Note the inverted naming: the graph Input node's output pin is labelled "In".
+
+---
+
+Connect the Surface Sampler's output pin to the Density Filter's input pin.
+
+---
+
+Connect the Density Filter's output pin to the Transform Points' input pin.
+
+---
+
+Connect the Transform Points' output pin to the Static Mesh Spawner's input pin.
+
+---
+
+Connect the Static Mesh Spawner's output pin ("Out") to the Output node's input pin ("Out"). Note: the graph Output node's input pin is labelled "Out".
+
+---
+
+## Connecting Nodes — Branch
+
+Connect the Surface Sampler's output pin to the Merge node's input pin (first input).
+
+---
+
+Connect the Merge node's output pin to the Output node's input pin.
+
+---
+
+## Verify Connections
+
+List all nodes in PCG_TestGraph and their connected edges. Confirm the main chain (Input → Sampler → Filter → Transform → Spawner → Output) is fully wired.
+
+---
+
+## Removing an Edge
+
+Disconnect the edge between the Density Filter and Transform Points nodes.
+
+---
+
+Verify the disconnection — list the edges on the Density Filter's output pin. Should be empty.
+
+---
+
+## Reconnecting
+
+Reconnect the Density Filter output to the Transform Points input.
+
+---
+
+Verify the reconnection — the edge should be present again.
+
+---
+
+## Removing a Node
+
+Remove the Merge node from PCG_TestGraph.
+
+---
+
+List all nodes in PCG_TestGraph. Merge node should no longer appear. Count should be 6.
+
+---
+
+## Force Editor Notification
+
+Force a structural notification on PCG_TestGraph so the PCG editor refreshes.
+
+---
+
+## Adding a Generic Node by Class Name
+
+Add a node to PCG_TestGraph using the generic approach — use `unreal.PCGCopyPointsSettings` directly (no find_class, all Settings classes are direct attributes of the unreal module). Position it at (400, -300).
+
+---
+
+List all nodes again. CopyPoints node should appear.
+
+---
+
+Connect the Surface Sampler output ("Out") to the CopyPoints "Source" pin — CopyPoints has no "In" pin, it uses "Source" and "Target". Connect CopyPoints output to the Output node's input ("Out").
+
+---
+
+## Subgraph Node
+
+Create a second PCG Graph asset called "PCG_SubgraphTest" saved to "/Game/PCGTest".
+
+---
+
+Add a Surface Sampler node and a Static Mesh Spawner node to PCG_SubgraphTest. Connect Input → Sampler → Spawner → Output.
+
+---
+
+Save PCG_SubgraphTest.
+
+---
+
+Back in PCG_TestGraph, add a Subgraph node that references PCG_SubgraphTest. Assign it via settings.set_editor_property('subgraph_override', sub_graph_asset) — the property is 'subgraph_override', not 'subgraph' (which is protected).
+
+---
+
+Position the Subgraph node at (200, -300).
+
+---
+
+Connect the Input node's output to the Subgraph node's input.
+
+---
+
+List all nodes in PCG_TestGraph and confirm the Subgraph node is present.
+
+---
+
+## Save and Reload
+
+Save PCG_TestGraph.
+
+---
+
+Reload PCG_TestGraph from disk and list all its nodes. Confirm the node count and connections match what was built.
+
+---
+
+## Edge Cases
+
+Try to add an edge between two pins that are already connected. Expected: returns True permissively (does not error or deduplicate — be aware of this).
+
+---
+
+Try to add an edge between incompatible pin types (if any exist in this graph). Report what happens.
+
+---
+
+Try to remove an edge that doesn't exist. Should return false or report gracefully — not crash.
+
+---
+
+Try to get settings from the Output node. Note: it returns PCGGraphInputOutputSettings (not None) — the Output node does have settings.
+
+---
+
+## Bulk Node Removal
+
+Add 5 Point Filter nodes to PCG_TestGraph using unreal.PCGPointFilterSettings. Note: the runtime settings class name will be PCGAttributeFilteringSettings — use that when filtering nodes by type.
+
+---
+
+List all nodes — confirm 5 new Point Filter nodes are present.
+
+---
+
+Remove all 5 Point Filter nodes one by one.
+
+---
+
+List nodes again — Point Filter nodes should be gone, others intact.
+
+---
+
+## Graph Properties
+
+Set the `description` property on PCG_TestGraph to "Test graph for VibeUE PCG skill validation".
+
+---
+
+Read back the `description`. Should match what was set.
+
+---
+
+Set `is_standalone_graph` to True on PCG_TestGraph.
+
+---
+
+Read back `is_standalone_graph`. Should be True.
+
+---
+
+## Final Save and Verify
+
+Force a structural notification on PCG_TestGraph.
+
+---
+
+Save both PCG_TestGraph and PCG_SubgraphTest.
+
+---
+
+Verify both assets exist at /Game/PCGTest by searching for PCG assets with "PCGTest" in the name.
+
+---
+
+## Cleanup
+
+Delete all assets under /Game/PCGTest.
+
+---
+
+Search for PCG assets with "PCGTest" in the name. Should return nothing.


### PR DESCRIPTION
## Summary

Adds a complete PCG (Procedural Content Generation) skill for VibeUE, enabling AI agents to create and edit PCG graphs, connect nodes, configure samplers, assign meshes and materials, and trigger generation — all via Python without guessing APIs.

The skill was developed iteratively through ~70 live test prompts using DeepSeek and Qwen models via Vibe, with each model failure surfacing a real gotcha that was then documented. The result is a skill that guides models end-to-end through realistic PCG workflows.

### Files changed

- `Content/Skills/pcg/skill.md` — full PCG skill (new)
- `Content/Skills/vibeue/SKILL.md` — added PCG to domain routing table and load-before-coding warning
- `test_prompts/pcg/01_pcg_graph_tests.md` — 69-prompt test suite

---

## What the skill covers

- Creating and loading PCG graph assets
- Adding nodes (`add_node_of_type`) and inspecting/configuring settings
- Connecting nodes (`add_edge`) with correct pin labels
- Removing nodes and edges
- Configuring the Static Mesh Spawner with `mesh_entries` / `descriptor` pattern
- Adding colour variation with `override_materials` per entry
- Placing a `PCGVolume`, assigning a graph via `set_graph()`, and generating
- Saving and reloading packages to trigger live editor updates
- Deleting assets (Windows file lock explanation and workaround)

---

## Gotchas documented (from live testing)

These are all mistakes real models made during testing that caused retry loops — now documented in the skill's "Read before coding" section:

1. **Volume Sampler input pin is `"Volume"`, not `"In"`** — using `"In"` silently no-ops and produces 0 points
2. **`voxel_size` is a `Vector`, not a float** — passing a float raises TypeError
3. **`graph` property on PCGComponent is protected** — must use `pcg_comp.set_graph(graph)`, not `set_editor_property`
4. **Always save → reload → reassign → generate after changes** — skipping reload runs the old cached graph
5. **Check for existing nodes before adding** — duplicate node types break wiring
6. **Always save AND reload after every change** — without reload the PCG editor window won't update
7. **Use Volume Sampler for empty levels, not Surface Sampler** — Surface Sampler requires geometry; empty levels need `PCGVolumeSamplerSettings` with `unbounded=True`
8. **Never spawn test actors to verify** — check ISM instance counts instead: `sum(c.get_instance_count() for c in volume.get_components_by_class(unreal.InstancedStaticMeshComponent))`

---

## Verification — MCP (direct Python)

Run these in order via `execute_python_code` to verify the skill APIs work in your environment.

### Step 1 — Create graph and scatter cubes

```python
import unreal

# Create graph
factory = unreal.PCGGraphFactory()
asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
graph = asset_tools.create_asset('PCGSkillTest', '/Game/PCGSkillVerify', unreal.PCGGraph, factory)

input_node = graph.get_input_node()
output_node = graph.get_output_node()
output_node.set_node_position(800, 0)

# Volume Sampler
vol_node, vol_settings = graph.add_node_of_type(unreal.PCGVolumeSamplerSettings)
vol_settings.set_editor_property('voxel_size', unreal.Vector(200, 200, 200))
vol_settings.set_editor_property('unbounded', True)
vol_node.set_node_position(200, 0)

# Transform Points
tx_node, tx_settings = graph.add_node_of_type(unreal.PCGTransformPointsSettings)
tx_settings.set_editor_property('rotation_min', unreal.Rotator(0, -180, 0))
tx_settings.set_editor_property('rotation_max', unreal.Rotator(0, 180, 0))
tx_settings.set_editor_property('scale_min', unreal.Vector(0.5, 0.5, 0.5))
tx_settings.set_editor_property('scale_max', unreal.Vector(2, 2, 2))
tx_settings.set_editor_property('uniform_scale', False)
tx_node.set_node_position(450, 0)

# Static Mesh Spawner
spawner_node, spawner_settings = graph.add_node_of_type(unreal.PCGStaticMeshSpawnerSettings)
spawner_node.set_node_position(650, 0)

# Assign cube mesh
cube_mesh = unreal.load_asset('/Engine/BasicShapes/Cube')
entry = unreal.PCGMeshSelectorWeightedEntry()
desc = entry.get_editor_property('descriptor')
desc.set_editor_property('static_mesh', cube_mesh)
entry.set_editor_property('descriptor', desc)
entry.set_editor_property('weight', 1)
selector = spawner_settings.get_editor_property('mesh_selector_parameters')
selector.set_editor_property('mesh_entries', [entry])

# Wire: Input -> VolumeSampler -> TransformPoints -> Spawner -> Output
graph.add_edge(input_node, 'In', vol_node, 'Volume')
graph.add_edge(vol_node, 'Out', tx_node, 'In')
graph.add_edge(tx_node, 'Out', spawner_node, 'In')
graph.add_edge(spawner_node, 'Out', output_node, 'Out')

# Save and reload
unreal.EditorAssetLibrary.save_asset('/Game/PCGSkillVerify/PCGSkillTest', only_if_is_dirty=False)
pkg = unreal.find_package('/Game/PCGSkillVerify/PCGSkillTest')
unreal.EditorLoadingAndSavingUtils.reload_packages([pkg])
print("Graph created and saved")
```

### Step 2 — Place volume and generate

```python
import unreal, time

actor_subsys = unreal.get_editor_subsystem(unreal.EditorActorSubsystem)
volume = actor_subsys.spawn_actor_from_class(
    unreal.PCGVolume, unreal.Vector(0, 0, 100), unreal.Rotator(0, 0, 0)
)
volume.set_actor_scale3d(unreal.Vector(20, 20, 5))

graph = unreal.load_asset('/Game/PCGSkillVerify/PCGSkillTest')
pcg_comp = volume.get_component_by_class(unreal.PCGComponent)
pcg_comp.set_graph(graph)
pcg_comp.generate(force=True)
time.sleep(3)

comps = volume.get_components_by_class(unreal.InstancedStaticMeshComponent)
total = sum(c.get_instance_count() for c in comps)
print(f"ISM components: {len(comps)}, total instances: {total}")
# Expected: ISM components: 1, total instances: > 0
```

### Step 3 — Add 6 coloured materials and update spawner

```python
import unreal, time

# Create materials
mat_factory = unreal.MaterialFactoryNew()
asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
colors = {
    'Red':    (1.0, 0.0, 0.0),
    'Blue':   (0.0, 0.2, 1.0),
    'Green':  (0.0, 0.8, 0.0),
    'Yellow': (1.0, 0.9, 0.0),
    'Purple': (0.5, 0.0, 1.0),
    'Orange': (1.0, 0.4, 0.0),
}
materials = []
for name, (r, g, b) in colors.items():
    mat = asset_tools.create_asset('M_Cube_' + name, '/Game/PCGSkillVerify', unreal.Material, mat_factory)
    expr = unreal.MaterialEditingLibrary.create_material_expression(mat, unreal.MaterialExpressionConstant3Vector, -300, 0)
    expr.constant = unreal.LinearColor(r, g, b, 1.0)
    unreal.MaterialEditingLibrary.connect_material_property(expr, '', unreal.MaterialProperty.MP_BASE_COLOR)
    unreal.MaterialEditingLibrary.recompile_material(mat)
    unreal.EditorAssetLibrary.save_asset('/Game/PCGSkillVerify/M_Cube_' + name, only_if_is_dirty=False)
    materials.append(mat)
    print('Created M_Cube_' + name)

# Update spawner entries
cube_mesh = unreal.load_asset('/Engine/BasicShapes/Cube')
graph = unreal.load_asset('/Game/PCGSkillVerify/PCGSkillTest')
for n in graph.nodes:
    s = n.get_settings()
    if type(s).__name__ == 'PCGStaticMeshSpawnerSettings':
        entries = []
        for mat in materials:
            entry = unreal.PCGMeshSelectorWeightedEntry()
            desc = entry.get_editor_property('descriptor')
            desc.set_editor_property('static_mesh', cube_mesh)
            desc.set_editor_property('override_materials', [mat])
            entry.set_editor_property('descriptor', desc)
            entry.set_editor_property('weight', 1)
            entries.append(entry)
        sel = s.get_editor_property('mesh_selector_parameters')
        sel.set_editor_property('mesh_entries', entries)

unreal.EditorAssetLibrary.save_asset('/Game/PCGSkillVerify/PCGSkillTest', only_if_is_dirty=False)
pkg = unreal.find_package('/Game/PCGSkillVerify/PCGSkillTest')
unreal.EditorLoadingAndSavingUtils.reload_packages([pkg])

actor_subsys = unreal.get_editor_subsystem(unreal.EditorActorSubsystem)
vols = [a for a in actor_subsys.get_all_level_actors() if a.get_class().get_name() == 'PCGVolume']
pcg_comp = vols[0].get_component_by_class(unreal.PCGComponent)
graph = unreal.load_asset('/Game/PCGSkillVerify/PCGSkillTest')
pcg_comp.set_graph(graph)
pcg_comp.generate(force=True)
time.sleep(3)

comps = vols[0].get_components_by_class(unreal.InstancedStaticMeshComponent)
total = sum(c.get_instance_count() for c in comps)
print(f"ISM components: {len(comps)}, total instances: {total}")
# Expected: ISM components: 6, total instances: > 0 (one component per colour)
```

**Expected final result:** 6 ISM components in the PCGVolume, cubes visibly scattered across the volume in 6 colours (red, blue, green, yellow, purple, orange), with random scale and rotation variation.

### Cleanup

```python
import unreal
actor_subsys = unreal.get_editor_subsystem(unreal.EditorActorSubsystem)
for a in actor_subsys.get_all_level_actors():
    if a.get_class().get_name() == 'PCGVolume':
        actor_subsys.destroy_actor(a)
asset_editor_subsys = unreal.get_editor_subsystem(unreal.AssetEditorSubsystem)
for p in unreal.EditorAssetLibrary.list_assets('/Game/PCGSkillVerify', recursive=True):
    a = unreal.load_asset(p.split('.')[0])
    if a: asset_editor_subsys.close_all_editors_for_asset(a)
unreal.SystemLibrary.collect_garbage()
for p in unreal.EditorAssetLibrary.list_assets('/Game/PCGSkillVerify', recursive=True):
    unreal.EditorAssetLibrary.delete_asset(p.split('.')[0])
print("Cleaned up")
# Note: if any assets fail to delete, restart UE — Windows holds file handles until shutdown
```

---

## Verification — Vibe (AI agent)

Start a fresh Vibe session (to ensure the updated skill is loaded), then run these 3 prompts in order. Each should complete without human intervention.

**Prompt 1:** Create a PCG graph asset called `PCGSkillTest` in `/Game/PCGSkillVerify`. Add a Volume Sampler node (voxel_size=Vector(200,200,200), unbounded=True), a Transform Points node (rotation_min/max for full 360° yaw, scale_min=(0.5,0.5,0.5), scale_max=(2,2,2), uniform_scale=False), and a Static Mesh Spawner using `/Engine/BasicShapes/Cube`. Wire them Input→VolumeSampler→TransformPoints→Spawner→Output. Save and reload the package.

**Prompt 2:** Spawn a PCGVolume in the level at (0,0,100) with scale (20,20,5). Load the `PCGSkillTest` graph from `/Game/PCGSkillVerify`, assign it to the volume using `set_graph()`, and generate with `force=True`. Confirm cubes are visible by checking total ISM instance count is above 0.

**Prompt 3:** Create 6 flat-colour materials in `/Game/PCGSkillVerify`: `M_Cube_Red` (1,0,0), `M_Cube_Blue` (0,0.2,1), `M_Cube_Green` (0,0.8,0), `M_Cube_Yellow` (1,0.9,0), `M_Cube_Purple` (0.5,0,1), `M_Cube_Orange` (1,0.4,0). Load the `PCGSkillTest` graph, find the Static Mesh Spawner node, and replace its entries with 6 weighted entries — one per material, all using `/Engine/BasicShapes/Cube`, weight 1 each, using `override_materials` on the descriptor. Save, reload, find the existing PCGVolume, reassign with `set_graph()`, regenerate with `force=True`. Confirm there are 6 ISM components.

**Pass criteria:** All 3 prompts complete without hitting retry limits. Final state: 6 ISM components, cubes visible in 6 colours in the viewport.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)