### PR TITLE
Global-task property bindings and reasoning round-trip

### DIFF
--- a/Content/Skills/state-trees/skill.md
+++ b/Content/Skills/state-trees/skill.md
@@ -556,6 +556,16 @@ unreal.StateTreeService.bind_global_task_property_to_context(
     "Actor",                  # context name
     ""                        # context property path (empty = whole object)
 )
+
+# Bind a state task property to a property produced by a global task
+unreal.StateTreeService.bind_task_property_to_global_task_property(
+    st_path,
+    "Peaceful/Patrol",        # state path containing the task to update
+    "STT_MoveToPatrolPoint",  # state task name
+    "PatrolPointManager",     # target property on the state task
+    "STT_PatrolManagement",   # source global task name
+    "PatrolPointManager"      # source property on the global task
+)
 ```
 
 #### Full Add + Bind Workflow
@@ -776,6 +786,14 @@ unreal.StateTreeService.bind_task_property_to_root_parameter(
     st_path, state_path, task_struct,
     "Duration",        # task property
     "IdlingTime"       # root parameter name
+)
+
+# Bind a task property to a property exposed by a global task
+unreal.StateTreeService.bind_task_property_to_global_task_property(
+    st_path, state_path, task_struct,
+    "PatrolPointManager",     # task property
+    "STT_PatrolManagement",   # global task name
+    "PatrolPointManager"      # global task property
 )
 ```
 
@@ -1389,6 +1407,11 @@ unreal.StateTreeService.set_transition_condition_property_value(
 unreal.StateTreeService.bind_enter_condition_property_to_context(
     path, "Root/Idle", "StateTreeObjectIsValidCondition", "Object",
     "Actor", "TargetPawn")
+
+# Bind an enter condition property to a property exposed by a global task
+unreal.StateTreeService.bind_enter_condition_property_to_global_task_property(
+    path, "Peaceful/Patrol", "StateTreeObjectIsValidCondition", "Object",
+    "STT_PatrolManagement", "PatrolPointManager")
 
 # Bind a transition condition property to context data
 unreal.StateTreeService.bind_transition_condition_property_to_context(

--- a/README.md
+++ b/README.md
@@ -1411,6 +1411,7 @@ Use `set_state_type`, `set_linked_subtree`, and `set_linked_asset` for in-place 
 - `set_task_property_value_detailed(...)` - Set task property with structured result (failure reason + readback value)
 - `bind_task_property_to_root_parameter(asset_path, state_path, task_struct_name, task_property_path, parameter_path, task_match_index)` - Bind task property to a root parameter
 - `bind_task_property_to_context(asset_path, state_path, task_struct_name, task_property_path, context_name, context_property_path, task_match_index)` - Bind task property to context data
+- `bind_task_property_to_global_task_property(asset_path, state_path, task_struct_name, task_property_path, global_task_struct_name, global_task_property_path, task_match_index, global_task_match_index)` - Bind a state task property to a property on a global task
 - `unbind_task_property(asset_path, state_path, task_struct_name, task_property_path, task_match_index)` - Remove a task property binding
 
 **Evaluators & Global Tasks:**
@@ -1425,6 +1426,9 @@ Use `set_state_type`, `set_linked_subtree`, and `set_linked_asset` for in-place 
 - `remove_global_task(asset_path, task_struct_name, match_index)` - Remove a global task
 - `get_global_task_property_names(asset_path, task_struct_name, match_index)` - Get global task properties
 - `set_global_task_property_value(asset_path, task_struct_name, property_path, value, match_index)` - Set global task property
+- `bind_global_task_property_to_root_parameter(asset_path, task_struct_name, task_property_path, parameter_path, match_index)` - Bind global task property to a root parameter
+- `bind_global_task_property_to_context(asset_path, task_struct_name, task_property_path, context_name, context_property_path, match_index)` - Bind global task property to context data
+- `unbind_global_task_property(asset_path, task_struct_name, task_property_path, match_index)` - Remove a global task property binding
 
 **Enter Conditions:**
 - `add_enter_condition(asset_path, state_path, condition_struct_name)` - Add an enter condition to a state
@@ -1433,6 +1437,7 @@ Use `set_state_type`, `set_linked_subtree`, and `set_linked_asset` for in-place 
 - `get_enter_condition_property_names(asset_path, state_path, condition_struct_name, condition_match_index)` - Discover condition properties
 - `set_enter_condition_property_value(asset_path, state_path, condition_struct_name, property_path, value, condition_match_index)` - Set a condition property
 - `bind_enter_condition_property_to_context(asset_path, state_path, condition_struct_name, condition_property_path, context_name, context_property_path, condition_match_index)` - Bind an enter condition property to context data
+- `bind_enter_condition_property_to_global_task_property(asset_path, state_path, condition_struct_name, condition_property_path, global_task_struct_name, global_task_property_path, condition_match_index, global_task_match_index)` - Bind an enter condition property to a property on a global task
 - `bind_enter_condition_property_to_root_parameter(asset_path, state_path, condition_struct_name, condition_property_path, parameter_path, condition_match_index)` - Bind an enter condition property to a root parameter
 - `unbind_enter_condition_property(asset_path, state_path, condition_struct_name, condition_property_path, condition_match_index)` - Remove an enter condition property binding
 

--- a/Source/VibeUE/Private/Chat/ChatSession.cpp
+++ b/Source/VibeUE/Private/Chat/ChatSession.cpp
@@ -409,6 +409,34 @@ void FChatSession::OnStreamComplete(bool bSuccess)
             }
         }
 
+        // Capture reasoning content (DeepSeek/OpenAI thinking mode). The provider rejects
+        // follow-up requests with HTTP 400 unless this is echoed back on the assistant
+        // message that produced it, so store it on the message for re-serialization.
+        // Inline <think>...</think> extraction above wins for ThinkingContent if both
+        // happened to be present, but reasoning_details is independent and always copied.
+        FString ReasoningFromClient;
+        FString ReasoningDetailsFromClient;
+        if (CurrentProvider == ELLMProvider::VibeUE && VibeUEClient.IsValid())
+        {
+            ReasoningFromClient = VibeUEClient->GetLastReasoningContent();
+            ReasoningDetailsFromClient = VibeUEClient->GetLastReasoningDetailsJson();
+        }
+        else if (OpenRouterClient.IsValid())
+        {
+            ReasoningFromClient = OpenRouterClient->GetLastReasoningContent();
+            ReasoningDetailsFromClient = OpenRouterClient->GetLastReasoningDetailsJson();
+        }
+        if (Message.ThinkingContent.IsEmpty() && !ReasoningFromClient.IsEmpty())
+        {
+            Message.ThinkingContent = ReasoningFromClient;
+            UE_LOG(LogChatSession, Log, TEXT("Captured reasoning string (%d chars) for replay"), ReasoningFromClient.Len());
+        }
+        if (!ReasoningDetailsFromClient.IsEmpty())
+        {
+            Message.ReasoningDetailsJson = ReasoningDetailsFromClient;
+            UE_LOG(LogChatSession, Log, TEXT("Captured reasoning_details (%d chars JSON) for replay"), ReasoningDetailsFromClient.Len());
+        }
+
         Message.bIsStreaming = false;
         OnMessageUpdated.ExecuteIfBound(CurrentStreamingMessageIndex, Message);
     }

--- a/Source/VibeUE/Private/Chat/LLMClientBase.cpp
+++ b/Source/VibeUE/Private/Chat/LLMClientBase.cpp
@@ -278,6 +278,8 @@ void FLLMClientBase::ResetStreamingState()
 {
     StreamBuffer.Empty();
     AccumulatedContent.Empty();
+    AccumulatedReasoning.Empty();
+    LastReasoningDetailsJson.Empty();
     LastResponseModel.Empty();
     PendingToolCalls.Empty();
     bToolCallsDetectedInStream = false;
@@ -676,6 +678,20 @@ void FLLMClientBase::ProcessSSEChunk(const FString& JsonData)
                 }
             }
         }
+    }
+
+    // Capture reasoning content delta if present (DeepSeek/OpenAI thinking mode).
+    // Field name varies: DeepSeek direct uses "reasoning_content", OpenRouter
+    // normalizes to "reasoning". Either must be echoed back in the next request
+    // (as "reasoning_content") or the provider returns HTTP 400.
+    FString DeltaReasoning;
+    if (!(*DeltaObj)->TryGetStringField(TEXT("reasoning_content"), DeltaReasoning) || DeltaReasoning.IsEmpty())
+    {
+        (*DeltaObj)->TryGetStringField(TEXT("reasoning"), DeltaReasoning);
+    }
+    if (!DeltaReasoning.IsEmpty())
+    {
+        AccumulatedReasoning += DeltaReasoning;
     }
 
     // Get content if present
@@ -1223,6 +1239,34 @@ void FLLMClientBase::ProcessNonStreamingResponse(const FString& ResponseContent)
         return;
     }
     
+    // Capture reasoning content if present (DeepSeek/OpenAI thinking mode).
+    // Field name varies: DeepSeek direct uses "reasoning_content", OpenRouter
+    // normalizes to "reasoning". Either must be echoed back in the next request
+    // (as "reasoning_content") or the provider returns HTTP 400.
+    FString MessageReasoning;
+    if ((!(*MessageObj)->TryGetStringField(TEXT("reasoning_content"), MessageReasoning) || MessageReasoning.IsEmpty()))
+    {
+        (*MessageObj)->TryGetStringField(TEXT("reasoning"), MessageReasoning);
+    }
+    if (!MessageReasoning.IsEmpty())
+    {
+        AccumulatedReasoning = MessageReasoning;
+        UE_LOG(LogLLMClientBase, Log, TEXT("[NON-STREAM] Captured reasoning content (%d chars)"), MessageReasoning.Len());
+    }
+
+    // Capture reasoning_details (OpenRouter structured array) — this is the
+    // canonical field that gets forwarded to providers across turns. Stored
+    // as raw JSON for replay.
+    const TArray<TSharedPtr<FJsonValue>>* ReasoningDetailsArray;
+    if ((*MessageObj)->TryGetArrayField(TEXT("reasoning_details"), ReasoningDetailsArray) && ReasoningDetailsArray->Num() > 0)
+    {
+        LastReasoningDetailsJson.Empty();
+        TSharedRef<TJsonWriter<>> DetailsWriter = TJsonWriterFactory<>::Create(&LastReasoningDetailsJson);
+        FJsonSerializer::Serialize(*ReasoningDetailsArray, DetailsWriter);
+        UE_LOG(LogLLMClientBase, Log, TEXT("[NON-STREAM] Captured reasoning_details (%d blocks, %d chars JSON)"),
+            ReasoningDetailsArray->Num(), LastReasoningDetailsJson.Len());
+    }
+
     // ALWAYS extract and display content first, even when tool_calls are present
     // This shows the LLM's reasoning/status message alongside tool execution
     FString Content;
@@ -1681,11 +1725,19 @@ void FLLMClientBase::HandleRequestComplete(FHttpRequestPtr Request, FHttpRespons
         {
             FString RawLogPath = FPaths::ProjectSavedDir() / TEXT("Logs") / TEXT("VibeUE_RawLLM.log");
             // Log summary instead of full response to avoid massive log files from streaming chunks
+            // For non-SSE (JSON) responses, also dump the body so we can verify
+            // fields like reasoning_content / reasoning are actually present.
+            // Skip dumping for SSE streams (event-stream / large chunked text).
+            bool bIsSSE = ContentType.Contains(TEXT("event-stream"));
             FString ResponseLog = FString::Printf(TEXT("\n========== RESPONSE [%s] ==========\nHTTP %d, Content-Type: %s, Length: %d bytes\n"),
                 *FDateTime::Now().ToString(),
                 ResponseCode,
                 *ContentType,
                 ResponseContent.Len());
+            if (!bIsSSE && ResponseContent.Len() < 200000)
+            {
+                ResponseLog += ResponseContent + TEXT("\n");
+            }
             FFileHelper::SaveStringToFile(ResponseLog, *RawLogPath, FFileHelper::EEncodingOptions::ForceUTF8, &IFileManager::Get(), FILEWRITE_Append);
             UE_LOG(LogLLMClientBase, Verbose, TEXT("Response summary logged to: %s"), *RawLogPath);
         }

--- a/Source/VibeUE/Private/Chat/OpenRouterClient.cpp
+++ b/Source/VibeUE/Private/Chat/OpenRouterClient.cpp
@@ -194,6 +194,22 @@ TSharedPtr<IHttpRequest, ESPMode::ThreadSafe> FOpenRouterClient::BuildHttpReques
         RequestBody->SetObjectField(TEXT("cache_control"), CacheControl);
     }
 
+    // Reasoning blocks (reasoning_details / reasoning_content) are provider-specific.
+    // Each provider returns reasoning in its own encrypted/signed format that only it
+    // can validate. Replaying one provider's reasoning to another causes 400 errors
+    // like "reasoning_content must be passed back to the API". Strip foreign reasoning
+    // by comparing the "provider/" prefix on ModelUsed vs the target ModelId.
+    auto GetProviderPrefix = [](const FString& ModelString) -> FString
+    {
+        int32 SlashIdx;
+        if (ModelString.FindChar(TEXT('/'), SlashIdx))
+        {
+            return ModelString.Left(SlashIdx);
+        }
+        return ModelString;
+    };
+    const FString TargetProvider = GetProviderPrefix(ModelId);
+
     TArray<TSharedPtr<FJsonValue>> MessagesArray;
     for (const FChatMessage& Message : CachedMessages)
     {
@@ -204,6 +220,18 @@ TSharedPtr<IHttpRequest, ESPMode::ThreadSafe> FOpenRouterClient::BuildHttpReques
         {
             TC.Arguments = SanitizeForLLM(TC.Arguments);
         }
+
+        // Strip reasoning from cross-provider assistant messages.
+        if (Message.Role == TEXT("assistant") && !Message.ModelUsed.IsEmpty() && !TargetProvider.IsEmpty())
+        {
+            const FString MsgProvider = GetProviderPrefix(Message.ModelUsed);
+            if (!MsgProvider.IsEmpty() && MsgProvider != TargetProvider)
+            {
+                SanitizedMessage.ThinkingContent.Empty();
+                SanitizedMessage.ReasoningDetailsJson.Empty();
+            }
+        }
+
         MessagesArray.Add(MakeShared<FJsonValueObject>(SanitizedMessage.ToJson()));
     }
     RequestBody->SetArrayField(TEXT("messages"), MessagesArray);

--- a/Source/VibeUE/Private/Chat/VibeUEAPIClient.cpp
+++ b/Source/VibeUE/Private/Chat/VibeUEAPIClient.cpp
@@ -83,6 +83,25 @@ TSharedPtr<IHttpRequest, ESPMode::ThreadSafe> FVibeUEAPIClient::BuildHttpRequest
         return nullptr;
     }
 
+    // Reasoning blocks (reasoning_details / reasoning_content) are provider-specific.
+    // Each provider returns reasoning in its own encrypted/signed format that only it
+    // can validate (xAI returns "xai-responses-v1" encrypted blobs, DeepSeek expects
+    // its own "reasoning_content" string, Anthropic uses signed thinking blocks, etc.).
+    // Replaying one provider's reasoning to another provider causes 400 errors like
+    // "reasoning_content must be passed back to the API" because the receiver discards
+    // the foreign blocks and then sees the assistant turn as missing reasoning.
+    // Extract the provider prefix from "provider/model" model IDs to gate replay.
+    auto GetProviderPrefix = [](const FString& ModelString) -> FString
+    {
+        int32 SlashIdx;
+        if (ModelString.FindChar(TEXT('/'), SlashIdx))
+        {
+            return ModelString.Left(SlashIdx);
+        }
+        return ModelString;
+    };
+    const FString TargetProvider = GetProviderPrefix(ModelId);
+
     // Build messages array
     TArray<TSharedPtr<FJsonValue>> MessagesArray;
     for (const FChatMessage& Msg : Messages)
@@ -90,7 +109,18 @@ TSharedPtr<IHttpRequest, ESPMode::ThreadSafe> FVibeUEAPIClient::BuildHttpRequest
         // Sanitize message content before serialization
         FChatMessage SanitizedMessage = Msg;
         SanitizedMessage.Content = SanitizeForLLM(Msg.Content);
-        
+
+        // Strip reasoning from cross-provider assistant messages.
+        if (Msg.Role == TEXT("assistant") && !Msg.ModelUsed.IsEmpty() && !TargetProvider.IsEmpty())
+        {
+            const FString MsgProvider = GetProviderPrefix(Msg.ModelUsed);
+            if (!MsgProvider.IsEmpty() && MsgProvider != TargetProvider)
+            {
+                SanitizedMessage.ThinkingContent.Empty();
+                SanitizedMessage.ReasoningDetailsJson.Empty();
+            }
+        }
+
         // Use ToJson() for consistent serialization (supports multimodal content)
         MessagesArray.Add(MakeShared<FJsonValueObject>(SanitizedMessage.ToJson()));
     }

--- a/Source/VibeUE/Private/PythonAPI/UStateTreeService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UStateTreeService.cpp
@@ -4411,6 +4411,80 @@ bool UStateTreeService::BindTaskPropertyToContext(const FString& AssetPath, cons
 #endif
 }
 
+bool UStateTreeService::BindTaskPropertyToGlobalTaskProperty(const FString& AssetPath, const FString& StatePath,
+	const FString& TaskStructName, const FString& TaskPropertyPath,
+	const FString& GlobalTaskStructName, const FString& GlobalTaskPropertyPath,
+	int32 TaskMatchIndex, int32 GlobalTaskMatchIndex)
+{
+	if (TaskPropertyPath.IsEmpty() || GlobalTaskPropertyPath.IsEmpty())
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("BindTaskPropertyToGlobalTaskProperty: TaskPropertyPath and GlobalTaskPropertyPath are required"));
+		return false;
+	}
+
+	UStateTree* StateTree = LoadStateTree(AssetPath);
+	if (!StateTree)
+	{
+		return false;
+	}
+
+#if WITH_EDITORONLY_DATA
+	UStateTreeEditorData* EditorData = GetEditorData(StateTree);
+	if (!EditorData)
+	{
+		return false;
+	}
+
+	UStateTreeState* State = FindStateByPath(EditorData, StatePath);
+	if (!State)
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("BindTaskPropertyToGlobalTaskProperty: State not found: %s"), *StatePath);
+		return false;
+	}
+
+	FStateTreeEditorNode* TaskNode = FindTaskNodeByStruct(State, TaskStructName, TaskMatchIndex);
+	if (!TaskNode)
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("BindTaskPropertyToGlobalTaskProperty: Task not found in %s for struct '%s' at match index %d"),
+			*StatePath, *TaskStructName, TaskMatchIndex);
+		return false;
+	}
+
+	FStateTreeEditorNode* GlobalTaskNode = FindEditorNodeByStructInArray(EditorData->GlobalTasks, GlobalTaskStructName, GlobalTaskMatchIndex);
+	if (!GlobalTaskNode)
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("BindTaskPropertyToGlobalTaskProperty: Global task '%s' not found at match index %d"),
+			*GlobalTaskStructName, GlobalTaskMatchIndex);
+		return false;
+	}
+
+	FPropertyBindingPath SourcePath;
+	if (!MakeBindingPath(GlobalTaskNode->ID, GlobalTaskPropertyPath, SourcePath))
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("BindTaskPropertyToGlobalTaskProperty: Invalid global task property path: %s"), *GlobalTaskPropertyPath);
+		return false;
+	}
+
+	FPropertyBindingPath TargetPath;
+	if (!MakeBindingPath(TaskNode->ID, TaskPropertyPath, TargetPath))
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("BindTaskPropertyToGlobalTaskProperty: Invalid task property path: %s"), *TaskPropertyPath);
+		return false;
+	}
+
+	EditorData->AddPropertyBinding(SourcePath, TargetPath);
+	MarkStateTreeDirty(StateTree);
+	return true;
+#else
+	return false;
+#endif
+}
+
 bool UStateTreeService::UnbindTaskProperty(const FString& AssetPath, const FString& StatePath,
 	const FString& TaskStructName, const FString& TaskPropertyPath, int32 TaskMatchIndex)
 {
@@ -4907,6 +4981,80 @@ bool UStateTreeService::BindEnterConditionPropertyToContext(const FString& Asset
 	if (!MakeBindingPath(CondNode->ID, ConditionPropertyPath, TargetPath))
 	{
 		UE_LOG(LogStateTreeService, Warning, TEXT("BindEnterConditionPropertyToContext: Invalid condition property path: %s"), *ConditionPropertyPath);
+		return false;
+	}
+
+	EditorData->AddPropertyBinding(SourcePath, TargetPath);
+	MarkStateTreeDirty(StateTree);
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool UStateTreeService::BindEnterConditionPropertyToGlobalTaskProperty(const FString& AssetPath, const FString& StatePath,
+	const FString& ConditionStructName, const FString& ConditionPropertyPath,
+	const FString& GlobalTaskStructName, const FString& GlobalTaskPropertyPath,
+	int32 ConditionMatchIndex, int32 GlobalTaskMatchIndex)
+{
+	if (ConditionPropertyPath.IsEmpty() || GlobalTaskPropertyPath.IsEmpty())
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("BindEnterConditionPropertyToGlobalTaskProperty: ConditionPropertyPath and GlobalTaskPropertyPath are required"));
+		return false;
+	}
+
+	UStateTree* StateTree = LoadStateTree(AssetPath);
+	if (!StateTree)
+	{
+		return false;
+	}
+
+#if WITH_EDITORONLY_DATA
+	UStateTreeEditorData* EditorData = GetEditorData(StateTree);
+	if (!EditorData)
+	{
+		return false;
+	}
+
+	UStateTreeState* State = FindStateByPath(EditorData, StatePath);
+	if (!State)
+	{
+		UE_LOG(LogStateTreeService, Warning, TEXT("BindEnterConditionPropertyToGlobalTaskProperty: State not found: %s"), *StatePath);
+		return false;
+	}
+
+	FStateTreeEditorNode* CondNode = FindEditorNodeByStructInArray(State->EnterConditions, ConditionStructName, ConditionMatchIndex);
+	if (!CondNode)
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("BindEnterConditionPropertyToGlobalTaskProperty: Condition '%s' not found in state '%s'"),
+			*ConditionStructName, *StatePath);
+		return false;
+	}
+
+	FStateTreeEditorNode* GlobalTaskNode = FindEditorNodeByStructInArray(EditorData->GlobalTasks, GlobalTaskStructName, GlobalTaskMatchIndex);
+	if (!GlobalTaskNode)
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("BindEnterConditionPropertyToGlobalTaskProperty: Global task '%s' not found at match index %d"),
+			*GlobalTaskStructName, GlobalTaskMatchIndex);
+		return false;
+	}
+
+	FPropertyBindingPath SourcePath;
+	if (!MakeBindingPath(GlobalTaskNode->ID, GlobalTaskPropertyPath, SourcePath))
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("BindEnterConditionPropertyToGlobalTaskProperty: Invalid global task property path: %s"), *GlobalTaskPropertyPath);
+		return false;
+	}
+
+	FPropertyBindingPath TargetPath;
+	if (!MakeBindingPath(CondNode->ID, ConditionPropertyPath, TargetPath))
+	{
+		UE_LOG(LogStateTreeService, Warning,
+			TEXT("BindEnterConditionPropertyToGlobalTaskProperty: Invalid condition property path: %s"), *ConditionPropertyPath);
 		return false;
 	}
 

--- a/Source/VibeUE/Public/Chat/ChatTypes.h
+++ b/Source/VibeUE/Public/Chat/ChatTypes.h
@@ -170,6 +170,14 @@ struct VIBEUE_API FChatMessage
     /** Chain-of-thought reasoning content (from <think> tags, not shown to user) */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Chat")
     FString ThinkingContent;
+
+    /** OpenRouter-style structured reasoning blocks captured from the assistant
+     *  response (raw JSON of the "reasoning_details" array). This is the canonical
+     *  field OpenRouter forwards to providers like DeepSeek across turns. The
+     *  flat "reasoning"/"reasoning_content" string fields are stripped before
+     *  forwarding, so we must echo this array back to satisfy thinking-mode models. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Chat")
+    FString ReasoningDetailsJson;
     
     /** When the message was sent or received */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Chat")
@@ -301,10 +309,36 @@ struct VIBEUE_API FChatMessage
         {
             JsonObject->SetStringField(TEXT("content"), Content);
         }
-        
+
+        // Echo reasoning back on assistant messages (DeepSeek/OpenAI thinking mode).
+        // The canonical OpenRouter input field is "reasoning_details" (a structured
+        // array) — the only one OpenRouter forwards to providers across turns. The
+        // flat "reasoning"/"reasoning_content" string fields are stripped. We emit
+        // all three for resilience: reasoning_details satisfies OpenRouter, and
+        // the strings cover DeepSeek-direct or other OpenAI-compatible routes.
+        // Without this, DeepSeek v4 rejects with HTTP 400 "reasoning_content must
+        // be passed back to the API".
+        if (Role == TEXT("assistant"))
+        {
+            if (!ReasoningDetailsJson.IsEmpty())
+            {
+                TArray<TSharedPtr<FJsonValue>> DetailsArray;
+                TSharedRef<TJsonReader<>> DetailsReader = TJsonReaderFactory<>::Create(ReasoningDetailsJson);
+                if (FJsonSerializer::Deserialize(DetailsReader, DetailsArray) && DetailsArray.Num() > 0)
+                {
+                    JsonObject->SetArrayField(TEXT("reasoning_details"), DetailsArray);
+                }
+            }
+            if (!ThinkingContent.IsEmpty())
+            {
+                JsonObject->SetStringField(TEXT("reasoning_content"), ThinkingContent);
+                JsonObject->SetStringField(TEXT("reasoning"), ThinkingContent);
+            }
+        }
+
         return JsonObject;
     }
-    
+
     /** Create from JSON (for persistence) */
     static FChatMessage FromJson(const TSharedPtr<FJsonObject>& JsonObject)
     {
@@ -315,6 +349,14 @@ struct VIBEUE_API FChatMessage
             JsonObject->TryGetStringField(TEXT("content"), Message.Content);
             JsonObject->TryGetStringField(TEXT("tool_call_id"), Message.ToolCallId);
             JsonObject->TryGetStringField(TEXT("model_used"), Message.ModelUsed);
+            JsonObject->TryGetStringField(TEXT("reasoning_content"), Message.ThinkingContent);
+            // reasoning_details is an array — read it back as raw JSON for replay
+            const TArray<TSharedPtr<FJsonValue>>* DetailsArray;
+            if (JsonObject->TryGetArrayField(TEXT("reasoning_details"), DetailsArray) && DetailsArray->Num() > 0)
+            {
+                TSharedRef<TJsonWriter<>> DetailsWriter = TJsonWriterFactory<>::Create(&Message.ReasoningDetailsJson);
+                FJsonSerializer::Serialize(*DetailsArray, DetailsWriter);
+            }
             
             FString TimestampStr;
             if (JsonObject->TryGetStringField(TEXT("timestamp"), TimestampStr))

--- a/Source/VibeUE/Public/Chat/LLMClientBase.h
+++ b/Source/VibeUE/Public/Chat/LLMClientBase.h
@@ -123,6 +123,17 @@ private:
     /** Accumulated content from response (for non-streaming or final content) */
     FString AccumulatedContent;
 
+    /** Accumulated reasoning_content from response (DeepSeek/OpenAI thinking-mode field).
+     *  Must be echoed back in the next request for thinking-mode models or they reject
+     *  the call with HTTP 400 "reasoning_content must be passed back to the API". */
+    FString AccumulatedReasoning;
+
+    /** Raw JSON of the OpenRouter "reasoning_details" array from the response.
+     *  This is the canonical field that gets forwarded across turns; the flat
+     *  reasoning string fields are stripped by OpenRouter. Must be echoed back
+     *  on the assistant message for thinking-mode models like DeepSeek v4. */
+    FString LastReasoningDetailsJson;
+
     /** Actual model used by the backend (populated from response JSON "model" field) */
     FString LastResponseModel;
 
@@ -168,6 +179,12 @@ public:
 
     /** Get the actual model used by the backend (e.g. model chosen by auto-router) */
     const FString& GetLastResponseModel() const { return LastResponseModel; }
+
+    /** Get the reasoning_content captured from the last response (empty for non-thinking models) */
+    const FString& GetLastReasoningContent() const { return AccumulatedReasoning; }
+
+    /** Get the raw JSON of the reasoning_details array from the last response (empty if absent) */
+    const FString& GetLastReasoningDetailsJson() const { return LastReasoningDetailsJson; }
     
     /** Check if the last response was incomplete (finish_reason: null with tool intent) */
     bool WasResponseIncomplete() const { return bResponseIncomplete; }

--- a/Source/VibeUE/Public/PythonAPI/UStateTreeService.h
+++ b/Source/VibeUE/Public/PythonAPI/UStateTreeService.h
@@ -739,6 +739,18 @@ public:
 	                                     int32 TaskMatchIndex = -1);
 
 	/**
+	 * Bind a task property to a property exposed by a global task node.
+	 * Use this when a state task should read data produced by a global task in the same StateTree.
+	 * @param TaskMatchIndex Which matching state task to target for the struct type. -1 means the last matching task.
+	 * @param GlobalTaskMatchIndex Which matching global task to target for the struct type. -1 means the last matching task.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
+	static bool BindTaskPropertyToGlobalTaskProperty(const FString& AssetPath, const FString& StatePath,
+	                                                const FString& TaskStructName, const FString& TaskPropertyPath,
+	                                                const FString& GlobalTaskStructName, const FString& GlobalTaskPropertyPath,
+	                                                int32 TaskMatchIndex = -1, int32 GlobalTaskMatchIndex = -1);
+
+	/**
 	 * Remove the property binding on a task property (unbind it).
 	 * After unbinding, the property reverts to its default/unbound value.
 	 * @param TaskMatchIndex Which matching task to target for the struct type. -1 means the last matching task.
@@ -818,6 +830,18 @@ public:
 	                                                const FString& ContextName = TEXT("Actor"),
 	                                                const FString& ContextPropertyPath = TEXT(""),
 	                                                int32 ConditionMatchIndex = -1);
+
+	/**
+	 * Bind an enter condition property to a property exposed by a global task node.
+	 * Use this when an enter condition should read data produced by a global task in the same StateTree.
+	 * @param ConditionMatchIndex Which matching condition to target. -1 means the last matching condition.
+	 * @param GlobalTaskMatchIndex Which matching global task to target for the struct type. -1 means the last matching task.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|StateTree")
+	static bool BindEnterConditionPropertyToGlobalTaskProperty(const FString& AssetPath, const FString& StatePath,
+	                                                          const FString& ConditionStructName, const FString& ConditionPropertyPath,
+	                                                          const FString& GlobalTaskStructName, const FString& GlobalTaskPropertyPath,
+	                                                          int32 ConditionMatchIndex = -1, int32 GlobalTaskMatchIndex = -1);
 
 	/**
 	 * Bind an enter condition property to a root parameter (e.g. parameter "CanChase" -> condition property "bLeft").


### PR DESCRIPTION
## Summary
- StateTree: bind state task and enter-condition properties to properties exposed by global tasks (`BindTaskPropertyToGlobalTaskProperty`, `BindEnterConditionPropertyToGlobalTaskProperty`), with skill + README docs.
- Chat: capture and echo back `reasoning_details` / `reasoning_content` on assistant messages so OpenRouter forwards them to thinking-mode providers (DeepSeek v4 otherwise rejects with HTTP 400 "reasoning_content must be passed back to the API").

## Test plan
- [ ] Build VibeUE module against UE 5.7
- [ ] Bind a state-task property to a global-task property via Python and confirm the binding resolves at runtime
- [ ] Bind an enter-condition property to a global-task property and confirm gating works
- [ ] Run a multi-turn chat with DeepSeek v4 via OpenRouter and confirm no HTTP 400 on follow-up turns
- [ ] Run a multi-turn chat with a non-thinking model and confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)