### PR TITLE
Add comment box APIs: AddCommentNode and AddCommentAroundNodes

### DIFF
--- a/Content/Skills/blueprint-graphs/skill.md
+++ b/Content/Skills/blueprint-graphs/skill.md
@@ -88,6 +88,27 @@ for m in matches:
 
 Also: search `discover_nodes` by **function name**, not variable type. To find the Broadcast Delegate node for a `StateTreeDelegate` variable, search `"Broadcast"` — NOT `"Dispatcher"` or `"StateTreeDelegate"`.
 
+### 👀 Reading the User's Live Graph Selection — `get_selected_nodes()`
+
+`get_nodes_in_graph()` returns **every** node in a graph. To act on just the nodes the user has highlighted in the open Blueprint editor, use `get_selected_nodes()` instead. Returned objects are the same `FBlueprintNodeInfo` shape as `get_nodes_in_graph()` — same `node_id`, `node_title`, `node_type`, `pos_x`, `pos_y`, `pin_names`, and `pins` fields — so you can pass `node.node_id` straight into `get_node_pins()`, `set_node_position()`, `delete_node()`, etc.
+
+**The Blueprint MUST already be open in the editor.** Selection state lives on the Slate panel, not on the asset; closing the editor discards it. Calling `get_selected_nodes()` for a closed asset returns an empty array (and logs a warning).
+
+```python
+# Caller knows the asset
+selected = unreal.BlueprintService.get_selected_nodes("/Game/BP_Player")
+
+# Caller does NOT know which asset the user is looking at — empty path
+# returns the selection from the first open Blueprint editor that has one.
+selected = unreal.BlueprintService.get_selected_nodes("")
+
+for n in selected:
+    print(f"selected: {n.node_title} ({n.node_type}) @ ({n.pos_x}, {n.pos_y})")
+    pins = unreal.BlueprintService.get_node_pins("/Game/BP_Player", "EventGraph", n.node_id)
+```
+
+Use this when the user says "this node", "the selected node(s)", "what I have highlighted", or "the one I'm looking at". An empty result means *nothing is selected in any open Blueprint editor* — ask the user to click a node in the graph rather than guessing.
+
 ### ⚠️ Branch Node Pin Names
 
 Use **`then`** and **`else`**, NOT `true`/`false`:

--- a/Content/Skills/blueprint-graphs/skill.md
+++ b/Content/Skills/blueprint-graphs/skill.md
@@ -109,6 +109,53 @@ for n in selected:
 
 Use this when the user says "this node", "the selected node(s)", "what I have highlighted", or "the one I'm looking at". An empty result means *nothing is selected in any open Blueprint editor* — ask the user to click a node in the graph rather than guessing.
 
+### 💬 Comment Boxes — `add_comment_node()` / `add_comment_around_nodes()`
+
+Comment boxes are the coloured bubbles that visually group nodes (the editor shortcut is `C` after selecting nodes). Two APIs:
+
+- **`add_comment_node(blueprint_path, graph_name, comment_text, pos_x, pos_y, width, height, r, g, b, a)`** — explicit position and size. Use when you already know exactly where you want the box.
+- **`add_comment_around_nodes(blueprint_path, graph_name, comment_text, node_ids, padding, r, g, b, a)`** — computes the bounding box of the supplied nodes (plus `padding`, default 40 px) and pads room for the title bar. This is the programmatic equivalent of select-then-press-`C`.
+
+#### ✍️ Write *informative* comment text — this is the whole point
+
+Comment boxes are documentation that lives next to the code. A future reader (human or LLM) should be able to glance at the comment and understand **what this group of nodes accomplishes and why**, without re‑reading every pin. Treat the comment text the same way you'd treat a function header comment.
+
+**Good comments** explain intent and behaviour:
+
+- `"Pick a random patrol point and cache its world location for the Move To task"`
+- `"On Damage > 0: play hit reaction, flash material, decrement Health"`
+- `"Debounce input — ignore re‑presses within 0.25s of the last fire"`
+- `"Early‑out when the owning controller is not locally controlled (server‑auth path)"`
+
+**Bad comments** restate node titles or are filler:
+
+- `"Print String"` ❌ (just the node name)
+- `"Logic"` / `"Stuff"` / `"TODO"` ❌ (says nothing)
+- `"Branch + Set Variable"` ❌ (mechanical, not intent)
+- The user's verbatim request like `"add a comment around the nodes"` ❌ — that's the *task*, not the *meaning*
+
+**Workflow**: before calling `add_comment_around_nodes`, inspect the selected nodes (titles, pin connections, variables they read/write) and synthesise a one‑line description of what the group does. If the user gave you a hint ("this is the patrol picker"), build on it; if they didn't, derive it from the nodes themselves. Use multiple lines (`\n`) when the group has a non‑trivial flow worth narrating.
+
+```python
+sel = unreal.BlueprintService.get_selected_nodes("/Game/BP_Player")
+ids = [n.node_id for n in sel]
+
+# Derive intent from the selected nodes (event, variables read/written, called
+# functions) and write a comment that documents WHY this group exists.
+comment = (
+    "Pick a random patrol point on EnterState\n"
+    "Caches the chosen point's world location into PatrolPointLocation\n"
+    "so the subsequent Move To task has a stable target."
+)
+
+unreal.BlueprintService.add_comment_around_nodes(
+    "/Game/BP_Player", "EventGraph", comment, ids)
+```
+
+Both functions return the new comment node's `node_id` (a GUID string), or `""` on failure. Colour parameters are RGBA in 0–1 range; the default is the standard pale yellow. Unknown `node_ids` passed to `add_comment_around_nodes()` are skipped with a warning — if *all* IDs are invalid, the call returns `""`.
+
+Standard editor behaviour applies: any K2 nodes whose bounds fall inside the comment box get picked up and dragged with it (GroupMovement mode).
+
 ### ⚠️ Branch Node Pin Names
 
 Use **`then`** and **`else`**, NOT `true`/`false`:

--- a/Content/Skills/pie-testing/skill.md
+++ b/Content/Skills/pie-testing/skill.md
@@ -1,0 +1,76 @@
+---
+name: pie-testing
+display_name: Play-In-Editor Testing
+description: Start, stop, and query Play-In-Editor (PIE) sessions for runtime testing
+  of Blueprints, gameplay logic, widgets, AI, and any in-game behavior. Use when the
+  user asks you to "play", "test", "run", "PIE", "start the game", "stop the game",
+  or otherwise needs a live game world to validate changes.
+vibeue_classes:
+  - WidgetService
+unreal_classes:
+  - UEditorEngine
+  - FRequestPlaySessionParams
+keywords:
+  - pie
+  - play in editor
+  - play
+  - run
+  - test
+  - testing
+  - simulate
+  - gameplay
+  - runtime
+  - start game
+  - stop game
+  - end play
+---
+
+# Play-In-Editor (PIE) Testing Skill
+
+PIE is the only way to validate runtime behavior — Blueprint logic, AI ticking, animation, input, widget interaction, gameplay events. Without starting PIE, your "fix" is unverified.
+
+## Methods
+
+PIE control lives on `WidgetService` for historical reasons (it grew out of widget testing) but **applies to ALL runtime testing**, not just widgets.
+
+| Method | Description |
+|--------|-------------|
+| `unreal.WidgetService.start_pie()` | Start PIE if not already running. Returns `True` on success or if already running. |
+| `unreal.WidgetService.stop_pie()` | End the current PIE session. Returns `True` if stopped or already stopped. |
+| `unreal.WidgetService.is_pie_running()` | `True` if PIE or Simulate-In-Editor is active. |
+
+## Standard Test Loop
+
+```python
+# 1. Make sure you're starting from a clean state
+if unreal.WidgetService.is_pie_running():
+    unreal.WidgetService.stop_pie()
+
+# 2. Start the session (uses the editor's current PIE settings — default map, viewport)
+unreal.WidgetService.start_pie()
+
+# 3. Let the test run / inspect log output / interact via other services
+# 4. Stop when done
+unreal.WidgetService.stop_pie()
+```
+
+## Gotchas
+
+- **PIE start is asynchronous.** `start_pie()` returns immediately after `RequestPlaySession` is queued. The world isn't actually playing until the editor processes the request on its next tick. If you need to act inside the running world, give it a tick or poll `is_pie_running()`.
+- **Already-running is treated as success.** `start_pie()` returns `True` if a PIE session already exists — it does NOT restart. Stop first if you need a fresh session.
+- **`stop_pie()` cleans up tracked PIE widgets** (those spawned via `WidgetService.spawn_widget_in_pie`). Other widgets/actors are torn down by the engine as part of `RequestEndPlayMap`.
+- **Save before starting.** Dirty asset changes are NOT picked up by PIE unless saved/compiled. Always `compile_blueprint(...)` before launching PIE to test Blueprint changes.
+- **Don't leave PIE running between tasks.** Subsequent edits (recompiles, asset moves, hot reload) can fail or behave oddly while a PIE world is alive. Call `stop_pie()` before returning control to the user.
+
+## When to use PIE
+
+- Verifying a Blueprint event fires (combine with log inspection — see `LogsToolset`)
+- Validating gameplay logic (damage, scoring, state transitions)
+- Testing widgets in their real runtime context (combine with `umg-widgets` skill's `spawn_widget_in_pie`)
+- Reproducing user-reported runtime bugs
+
+## When NOT to use PIE
+
+- Pure asset/editor validation (use `compile_blueprint`, `find_assets`, etc.)
+- Static introspection (use `get_nodes_in_graph`, `get_node_pins`)
+- Anything you can verify without a live world — PIE is slow, save it for genuine runtime checks.

--- a/Content/Skills/vibeue/SKILL.md
+++ b/Content/Skills/vibeue/SKILL.md
@@ -25,6 +25,7 @@ Always load the relevant skill **before writing any code**. The skill contains e
 | PCG / procedural generation / scatter | `pcg` |
 | Materials | `materials` |
 | State Trees | `state-trees` |
+| Play / test / run / PIE | `pie-testing` |
 
 ```
 manage_skills(action="load", skill_name="pcg")

--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -29,6 +29,7 @@
 #include "K2Node_AddDelegate.h"          // For delegate bind nodes (add_delegate_bind_node)
 #include "K2Node_CreateDelegate.h"       // For create event nodes (add_create_delegate_node)
 #include "K2Node_MakeStruct.h"           // For STRUCT key: creating typed struct Make nodes
+#include "EdGraphNode_Comment.h"         // For UEdGraphNode_Comment (comment box nodes)
 #include "InputAction.h"                 // For UInputAction
 #include "Kismet/KismetSystemLibrary.h"
 #include "Kismet/KismetMathLibrary.h"
@@ -3678,6 +3679,186 @@ FString UBlueprintService::AddPrintStringNode(
 	UE_LOG(LogTemp, Log, TEXT("AddPrintStringNode: Added print string node to %s"), *GraphName);
 
 	return PrintNode->NodeGuid.ToString();
+}
+
+namespace
+{
+	// Estimate a node's size for bounding-box math when NodeWidth/NodeHeight haven't been
+	// computed yet (Slate widget hasn't run). The defaults are intentionally generous so
+	// the comment box doesn't visually clip the wrapped nodes.
+	static void EstimateNodeBounds(UEdGraphNode* Node, float& OutMinX, float& OutMinY, float& OutMaxX, float& OutMaxY)
+	{
+		const float DefaultWidth = 256.0f;
+		const float DefaultHeight = 128.0f;
+
+		const float W = (Node && Node->NodeWidth  > 0.0f) ? Node->NodeWidth  : DefaultWidth;
+		const float H = (Node && Node->NodeHeight > 0.0f) ? Node->NodeHeight : DefaultHeight;
+
+		OutMinX = Node ? Node->NodePosX : 0.0f;
+		OutMinY = Node ? Node->NodePosY : 0.0f;
+		OutMaxX = OutMinX + W;
+		OutMaxY = OutMinY + H;
+	}
+
+	static UEdGraphNode_Comment* SpawnCommentNode(
+		UEdGraph* Graph,
+		const FString& CommentText,
+		float PosX, float PosY,
+		float Width, float Height,
+		float R, float G, float B, float A)
+	{
+		if (!Graph)
+		{
+			return nullptr;
+		}
+
+		UEdGraphNode_Comment* CommentNode = NewObject<UEdGraphNode_Comment>(Graph);
+		Graph->AddNode(CommentNode, /*bFromUI=*/false, /*bSelectNewNode=*/false);
+		CommentNode->CreateNewGuid();
+		CommentNode->PostPlacedNewNode();
+		CommentNode->AllocateDefaultPins();
+
+		CommentNode->NodePosX  = PosX;
+		CommentNode->NodePosY  = PosY;
+		CommentNode->NodeWidth  = FMath::Max(64.0f, Width);
+		CommentNode->NodeHeight = FMath::Max(64.0f, Height);
+		CommentNode->NodeComment = CommentText;
+		CommentNode->CommentColor = FLinearColor(R, G, B, A);
+
+		return CommentNode;
+	}
+}
+
+FString UBlueprintService::AddCommentNode(
+	const FString& BlueprintPath,
+	const FString& GraphName,
+	const FString& CommentText,
+	float PosX,
+	float PosY,
+	float Width,
+	float Height,
+	float R, float G, float B, float A)
+{
+	UBlueprint* Blueprint = LoadBlueprint(BlueprintPath);
+	if (!Blueprint)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddCommentNode: Failed to load blueprint: %s"), *BlueprintPath);
+		return FString();
+	}
+
+	UEdGraph* Graph = ResolveBlueprintGraph(Blueprint, GraphName);
+	if (!Graph)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddCommentNode: Graph '%s' not found in %s"), *GraphName, *BlueprintPath);
+		return FString();
+	}
+
+	const FScopedTransaction Transaction(NSLOCTEXT("VibeUE", "AddCommentNode", "Add Comment Node"));
+	Graph->Modify();
+
+	UEdGraphNode_Comment* CommentNode = SpawnCommentNode(Graph, CommentText, PosX, PosY, Width, Height, R, G, B, A);
+	if (!CommentNode)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddCommentNode: Failed to spawn comment node in graph '%s'"), *GraphName);
+		return FString();
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+	UE_LOG(LogTemp, Log, TEXT("AddCommentNode: Added comment '%s' in %s at (%.0f, %.0f) size (%.0f x %.0f)"),
+		*CommentText, *GraphName, PosX, PosY, Width, Height);
+
+	return CommentNode->NodeGuid.ToString();
+}
+
+FString UBlueprintService::AddCommentAroundNodes(
+	const FString& BlueprintPath,
+	const FString& GraphName,
+	const FString& CommentText,
+	const TArray<FString>& NodeIds,
+	float Padding,
+	float R, float G, float B, float A)
+{
+	UBlueprint* Blueprint = LoadBlueprint(BlueprintPath);
+	if (!Blueprint)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddCommentAroundNodes: Failed to load blueprint: %s"), *BlueprintPath);
+		return FString();
+	}
+
+	UEdGraph* Graph = ResolveBlueprintGraph(Blueprint, GraphName);
+	if (!Graph)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddCommentAroundNodes: Graph '%s' not found in %s"), *GraphName, *BlueprintPath);
+		return FString();
+	}
+
+	if (NodeIds.Num() == 0)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("AddCommentAroundNodes: No node IDs provided"));
+		return FString();
+	}
+
+	// Resolve node IDs to actual nodes, ignoring (and warning about) unknown IDs.
+	TArray<UEdGraphNode*> Nodes;
+	Nodes.Reserve(NodeIds.Num());
+	for (const FString& Id : NodeIds)
+	{
+		if (UEdGraphNode* Node = FindNodeById(Graph, Id))
+		{
+			Nodes.Add(Node);
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("AddCommentAroundNodes: Node id '%s' not found in graph '%s' (skipped)"),
+				*Id, *GraphName);
+		}
+	}
+
+	if (Nodes.Num() == 0)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddCommentAroundNodes: None of the supplied node IDs were found in graph '%s'"), *GraphName);
+		return FString();
+	}
+
+	// Compute the bounding box.
+	float MinX = TNumericLimits<float>::Max();
+	float MinY = TNumericLimits<float>::Max();
+	float MaxX = TNumericLimits<float>::Lowest();
+	float MaxY = TNumericLimits<float>::Lowest();
+
+	for (UEdGraphNode* Node : Nodes)
+	{
+		float nMinX, nMinY, nMaxX, nMaxY;
+		EstimateNodeBounds(Node, nMinX, nMinY, nMaxX, nMaxY);
+		MinX = FMath::Min(MinX, nMinX);
+		MinY = FMath::Min(MinY, nMinY);
+		MaxX = FMath::Max(MaxX, nMaxX);
+		MaxY = FMath::Max(MaxY, nMaxY);
+	}
+
+	// Apply padding. The top edge needs a bit of extra room so the comment title bar
+	// doesn't overlap the wrapped nodes (~32px is the title bar in the editor).
+	const float TitleBar = 32.0f;
+	const float CommentX = MinX - Padding;
+	const float CommentY = MinY - Padding - TitleBar;
+	const float CommentW = (MaxX - MinX) + (Padding * 2.0f);
+	const float CommentH = (MaxY - MinY) + (Padding * 2.0f) + TitleBar;
+
+	const FScopedTransaction Transaction(NSLOCTEXT("VibeUE", "AddCommentAroundNodes", "Add Comment Around Nodes"));
+	Graph->Modify();
+
+	UEdGraphNode_Comment* CommentNode = SpawnCommentNode(Graph, CommentText, CommentX, CommentY, CommentW, CommentH, R, G, B, A);
+	if (!CommentNode)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddCommentAroundNodes: Failed to spawn comment node in graph '%s'"), *GraphName);
+		return FString();
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+	UE_LOG(LogTemp, Log, TEXT("AddCommentAroundNodes: Wrapped %d node(s) in graph '%s' with comment '%s'"),
+		Nodes.Num(), *GraphName, *CommentText);
+
+	return CommentNode->NodeGuid.ToString();
 }
 
 bool UBlueprintService::ConnectNodes(

--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -3857,6 +3857,151 @@ TArray<FBlueprintNodeInfo> UBlueprintService::GetNodesInGraph(
 	return NodeInfos;
 }
 
+namespace
+{
+	// Helper: convert a UEdGraphNode into the FBlueprintNodeInfo struct used by
+	// GetNodesInGraph / GetSelectedNodes. Mirrors the body of the GetNodesInGraph
+	// loop so both APIs produce identical shapes.
+	static FBlueprintNodeInfo MakeBlueprintNodeInfoFromNode(UEdGraphNode* Node)
+	{
+		FBlueprintNodeInfo NodeInfo;
+		if (!Node)
+		{
+			return NodeInfo;
+		}
+
+		NodeInfo.NodeId = Node->NodeGuid.ToString();
+		NodeInfo.NodeType = Node->GetClass()->GetName();
+		NodeInfo.NodeTitle = Node->GetNodeTitle(ENodeTitleType::FullTitle).ToString();
+		NodeInfo.PosX = Node->NodePosX;
+		NodeInfo.PosY = Node->NodePosY;
+
+		for (UEdGraphPin* Pin : Node->Pins)
+		{
+			if (!Pin)
+			{
+				continue;
+			}
+
+			NodeInfo.PinNames.Add(Pin->PinName.ToString());
+
+			FBlueprintPinInfo PinInfo;
+			PinInfo.PinName = Pin->PinName.ToString();
+			PinInfo.PinType = Pin->PinType.PinCategory.ToString();
+			PinInfo.bIsInput = (Pin->Direction == EGPD_Input);
+			PinInfo.bIsConnected = Pin->LinkedTo.Num() > 0;
+			PinInfo.DefaultValue = Pin->DefaultValue;
+			NodeInfo.Pins.Add(PinInfo);
+		}
+
+		return NodeInfo;
+	}
+}
+
+TArray<FBlueprintNodeInfo> UBlueprintService::GetSelectedNodes(const FString& BlueprintPath)
+{
+	TArray<FBlueprintNodeInfo> NodeInfos;
+
+	UAssetEditorSubsystem* AssetEditorSubsystem = GEditor ? GEditor->GetEditorSubsystem<UAssetEditorSubsystem>() : nullptr;
+	if (!AssetEditorSubsystem)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("GetSelectedNodes: AssetEditorSubsystem not available"));
+		return NodeInfos;
+	}
+
+	// Helper lambda: gather the selected graph nodes from one Blueprint editor.
+	auto CollectFromEditor = [&NodeInfos](FBlueprintEditor* BlueprintEditor) -> bool
+	{
+		if (!BlueprintEditor)
+		{
+			return false;
+		}
+
+		const FGraphPanelSelectionSet Selection = BlueprintEditor->GetSelectedNodes();
+		if (Selection.Num() == 0)
+		{
+			return false;
+		}
+
+		for (UObject* SelectedObject : Selection)
+		{
+			if (UEdGraphNode* GraphNode = Cast<UEdGraphNode>(SelectedObject))
+			{
+				NodeInfos.Add(MakeBlueprintNodeInfoFromNode(GraphNode));
+			}
+		}
+		return NodeInfos.Num() > 0;
+	};
+
+	if (!BlueprintPath.IsEmpty())
+	{
+		// Caller specified the Blueprint — only inspect that one editor.
+		UBlueprint* Blueprint = LoadBlueprint(BlueprintPath);
+		if (!Blueprint)
+		{
+			UE_LOG(LogTemp, Warning, TEXT("GetSelectedNodes: Failed to load blueprint: %s"), *BlueprintPath);
+			return NodeInfos;
+		}
+
+		IAssetEditorInstance* EditorInstance = AssetEditorSubsystem->FindEditorForAsset(Blueprint, /*bFocusIfOpen=*/false);
+		if (!EditorInstance)
+		{
+			UE_LOG(LogTemp, Warning, TEXT("GetSelectedNodes: Blueprint '%s' is not open in the editor (selection state only exists for open assets)"), *BlueprintPath);
+			return NodeInfos;
+		}
+
+		// Blueprint editors all derive from FBlueprintEditor (incl. WidgetBlueprintEditor, AnimBlueprintEditor, etc.).
+		// We rely on the editor name guard to avoid an unsafe static_cast on unrelated editor types.
+		if (EditorInstance->GetEditorName() != FName(TEXT("BlueprintEditor"))
+			&& EditorInstance->GetEditorName() != FName(TEXT("WidgetBlueprintEditor"))
+			&& EditorInstance->GetEditorName() != FName(TEXT("AnimationBlueprintEditor")))
+		{
+			UE_LOG(LogTemp, Warning, TEXT("GetSelectedNodes: Editor for '%s' is not a Blueprint editor (got '%s')"),
+				*BlueprintPath, *EditorInstance->GetEditorName().ToString());
+			return NodeInfos;
+		}
+
+		FBlueprintEditor* BlueprintEditor = static_cast<FBlueprintEditor*>(EditorInstance);
+		CollectFromEditor(BlueprintEditor);
+		return NodeInfos;
+	}
+
+	// No Blueprint specified — scan all open editors and return the first
+	// Blueprint editor that has a non-empty graph selection.
+	const TArray<UObject*> OpenAssets = AssetEditorSubsystem->GetAllEditedAssets();
+	for (UObject* Asset : OpenAssets)
+	{
+		UBlueprint* Blueprint = Cast<UBlueprint>(Asset);
+		if (!Blueprint)
+		{
+			continue;
+		}
+
+		IAssetEditorInstance* EditorInstance = AssetEditorSubsystem->FindEditorForAsset(Blueprint, /*bFocusIfOpen=*/false);
+		if (!EditorInstance)
+		{
+			continue;
+		}
+
+		if (EditorInstance->GetEditorName() != FName(TEXT("BlueprintEditor"))
+			&& EditorInstance->GetEditorName() != FName(TEXT("WidgetBlueprintEditor"))
+			&& EditorInstance->GetEditorName() != FName(TEXT("AnimationBlueprintEditor")))
+		{
+			continue;
+		}
+
+		FBlueprintEditor* BlueprintEditor = static_cast<FBlueprintEditor*>(EditorInstance);
+		if (CollectFromEditor(BlueprintEditor))
+		{
+			UE_LOG(LogTemp, Verbose, TEXT("GetSelectedNodes: Returning selection from blueprint '%s'"),
+				*Blueprint->GetPathName());
+			return NodeInfos;
+		}
+	}
+
+	return NodeInfos;
+}
+
 FBlueprintCompileResult UBlueprintService::CompileBlueprint(const FString& BlueprintPath)
 {
 	FBlueprintCompileResult Result;

--- a/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
+++ b/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
@@ -1834,6 +1834,78 @@ public:
 	);
 
 	/**
+	 * Add a Comment box (UEdGraphNode_Comment) to a graph at an explicit position and size.
+	 * Comment boxes are the yellow/coloured bubbles that visually group nodes. By default
+	 * any K2 nodes whose bounds fall inside the comment box will be picked up and dragged
+	 * with the comment (GroupMovement mode), matching the standard editor behaviour when
+	 * the user creates a comment via the C hotkey.
+	 *
+	 * @param BlueprintPath - Full path to the blueprint
+	 * @param GraphName     - Name of the graph (e.g. "EventGraph", or a function name)
+	 * @param CommentText   - Text displayed in the comment header
+	 * @param PosX          - X position (top-left) in the graph
+	 * @param PosY          - Y position (top-left) in the graph
+	 * @param Width         - Width in graph units (default 400)
+	 * @param Height        - Height in graph units (default 200)
+	 * @param R, G, B, A    - Comment box colour (RGBA, 0-1). Default is the standard pale yellow.
+	 * @return Node ID (GUID) of the new comment node, empty string on failure.
+	 *
+	 * Example:
+	 *   cid = unreal.BlueprintService.add_comment_node(
+	 *       "/Game/BP_Player", "EventGraph", "Damage handling",
+	 *       100.0, 50.0, 600.0, 300.0, 1.0, 0.95, 0.4, 0.4)
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Blueprints")
+	static FString AddCommentNode(
+		const FString& BlueprintPath,
+		const FString& GraphName,
+		const FString& CommentText,
+		float PosX = 0.0f,
+		float PosY = 0.0f,
+		float Width = 400.0f,
+		float Height = 200.0f,
+		float R = 1.0f,
+		float G = 0.95f,
+		float B = 0.4f,
+		float A = 0.4f
+	);
+
+	/**
+	 * Add a Comment box that wraps the supplied nodes. The position and size are computed
+	 * from the bounding box of the listed nodes, plus the requested padding. This is the
+	 * programmatic equivalent of selecting nodes in the editor and pressing C.
+	 *
+	 * Pair this with `get_selected_nodes()` to wrap whatever the user has highlighted in
+	 * the open Blueprint editor:
+	 *
+	 *   sel = unreal.BlueprintService.get_selected_nodes("/Game/BP_Player")
+	 *   ids = [n.node_id for n in sel]
+	 *   unreal.BlueprintService.add_comment_around_nodes(
+	 *       "/Game/BP_Player", "EventGraph", "Damage handling", ids)
+	 *
+	 * @param BlueprintPath - Full path to the blueprint
+	 * @param GraphName     - Name of the graph that contains the nodes
+	 * @param CommentText   - Text displayed in the comment header
+	 * @param NodeIds       - GUIDs of the nodes to wrap (as returned by get_selected_nodes / get_nodes_in_graph)
+	 * @param Padding       - Padding around the bounding box in graph units (default 40)
+	 * @param R, G, B, A    - Comment box colour (RGBA, 0-1). Default is the standard pale yellow.
+	 * @return Node ID (GUID) of the new comment node, empty string on failure (e.g. no
+	 *         valid node IDs found in the graph).
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Blueprints")
+	static FString AddCommentAroundNodes(
+		const FString& BlueprintPath,
+		const FString& GraphName,
+		const FString& CommentText,
+		const TArray<FString>& NodeIds,
+		float Padding = 40.0f,
+		float R = 1.0f,
+		float G = 0.95f,
+		float B = 0.4f,
+		float A = 0.4f
+	);
+
+	/**
 	 * Connect two nodes by their pins.
 	 *
 	 * @param BlueprintPath - Full path to the blueprint

--- a/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
+++ b/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
@@ -1876,6 +1876,39 @@ public:
 	);
 
 	/**
+	 * Get the nodes currently selected by the user in an open Blueprint editor.
+	 *
+	 * Reads the live selection from FBlueprintEditor::GetSelectedNodes(). The
+	 * Blueprint must already be open in the editor (graph selection only exists
+	 * on the open Slate panel — there is no persisted selection state on the
+	 * asset itself). Use this to act on whatever the user has highlighted in
+	 * the graph (e.g. inspect, reposition, document, or programmatically edit
+	 * the selected nodes).
+	 *
+	 * @param BlueprintPath - Full path to the blueprint. If empty, the first
+	 *                        open Blueprint editor with a non-empty selection
+	 *                        is used (handy when the agent doesn't yet know
+	 *                        which asset the user is looking at).
+	 * @return Array of node information for the currently selected graph nodes.
+	 *         The array is empty if no Blueprint editor is open, the asset isn't
+	 *         open, or nothing is selected. The graph the selection belongs to
+	 *         can be inferred from the focused graph; callers that need the
+	 *         graph name explicitly should pair this with get_nodes_in_graph.
+	 *
+	 * Example:
+	 *   selected = unreal.BlueprintService.get_selected_nodes("/Game/BP_Player")
+	 *   for n in selected:
+	 *       print(f"selected: {n.node_title} ({n.node_type}) @ ({n.pos_x},{n.pos_y})")
+	 *
+	 * Example - discover what the user is looking at right now:
+	 *   selected = unreal.BlueprintService.get_selected_nodes("")
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Blueprints")
+	static TArray<FBlueprintNodeInfo> GetSelectedNodes(
+		const FString& BlueprintPath = TEXT("")
+	);
+
+	/**
 	 * Add a cast node to a graph.
 	 *
 	 * @param BlueprintPath - Full path to the blueprint


### PR DESCRIPTION
# Add Comment Box APIs to BlueprintService

Adds two new `UBlueprintService` methods so agents (and Blueprint scripts) can
create the same `UEdGraphNode_Comment` boxes that the editor produces when a
user selects nodes and presses **C**.

## Changes

### `Source/VibeUE/Public/PythonAPI/UBlueprintService.h` + `.cpp`

- **`AddCommentNode(blueprint, graph, text, x, y, w, h, r, g, b, a)`** — explicit
  position and size. Use when the caller already knows the box geometry.
- **`AddCommentAroundNodes(blueprint, graph, text, node_ids, padding, r, g, b, a)`** —
  computes the bounding box of the supplied node GUIDs (with configurable
  padding and an extra title-bar offset) and spawns the comment around them.
  This is the programmatic equivalent of *select-then-press-`C`* in the editor.

Both:
- Use the existing `ResolveBlueprintGraph` helper so `EventGraph` aliasing works.
- Wrap the spawn in `FScopedTransaction` for proper undo support.
- Call `MarkBlueprintAsModified`.
- Skip and warn on unknown `node_ids` (returning `""` only if *all* ids were
  invalid).
- Return the comment node's GUID string on success, `""` on failure.

Unreal handles the rest: any K2 nodes whose bounds fall inside the comment box
get picked up by GroupMovement and drag with the comment, matching standard
editor behaviour.

### `Content/Skills/blueprint-graphs/skill.md`

New "💬 Comment Boxes" section documenting both APIs and — importantly — a
"Write *informative* comment text" subsection with good/bad examples and a
workflow that tells the agent to inspect the selected nodes (titles, pin
connections, variables read/written) and synthesise a one-line description of
what the group **does** before calling `add_comment_around_nodes`. Comment
boxes exist as in-graph documentation; the skill now treats the comment text
as the whole point of the call rather than an afterthought.

## Verification

- Built `StateTreeEditor Win64 Development` cleanly via `BuildAndLaunchGame.ps1`.
- Manual repro in `STT_MoveToPatrolPoint`: called
  `get_selected_nodes()` then `add_comment_around_nodes()` with the resulting
  ids and an intent-describing comment — the new comment box wraps the selected
  nodes in the open Blueprint editor, undoable with Ctrl+Z, and drags the
  wrapped nodes when moved.
