### PR TITLE
Merge 5-7: AnimGraph state machine authoring + transition rules (closes #389)

### DIFF
--- a/Content/Skills/animation-blueprint/skill.md
+++ b/Content/Skills/animation-blueprint/skill.md
@@ -1,10 +1,11 @@
 ---
 name: animation-blueprint
 display_name: Animation Blueprints
-description: Navigate and inspect Animation Blueprints, state machines, states, and transitions
+description: Navigate, inspect AND author Animation Blueprints, state machines, states, transitions and transition rules
 vibeue_classes:
   - AnimGraphService
   - AssetDiscoveryService
+  - BlueprintService
 unreal_classes:
   - EditorAssetLibrary
 keywords:
@@ -14,11 +15,43 @@ keywords:
   - state machine
   - state
   - transition
+  - transition rule
   - animgraph
   - locomotion
+  - combat
+  - authoring
 ---
 
 # Animation Blueprint Skill
+
+## ⚠️ #1 GOTCHA — Transitions need a RULE or they NEVER fire
+
+`add_transition()` only draws the arrow between two states. The transition's rule graph
+starts empty, which evaluates to **false**, so the transition is **inert** — the state
+machine will never move. You MUST set a rule on every transition:
+
+```python
+import unreal
+abp = "/Game/ABP_Character"
+
+# 1) Add the bool/float variable the rule reads (on the AnimBP), then COMPILE so it resolves
+unreal.BlueprintService.add_variable(abp, "bIsDead", "bool")
+unreal.BlueprintService.compile_blueprint(abp)
+
+# 2) Draw the transition
+unreal.AnimGraphService.add_transition(abp, "Locomotion", "Idle", "Dead", 0.2)
+
+# 3) Give it a rule — THIS is what makes it fire
+unreal.AnimGraphService.set_transition_rule_from_bool(abp, "Locomotion", "Idle", "Dead", "bIsDead")
+```
+
+Rule options:
+- `set_transition_rule_from_bool(abp, machine, src, dst, bool_var, invert=False)`
+- `set_transition_rule_comparison(abp, machine, src, dst, float_var, op, value)` — op ∈ `greater/less/greater_equal/less_equal/equal/not_equal`
+- `set_transition_rule_automatic(abp, machine, src, dst, trigger_time=-1.0)` — fires when the source state's animation is (almost) finished; perfect for one-shots (attack→idle)
+- `clear_transition_rule(...)` — non-destructively reset a rule
+
+After authoring, **always** run `validate_state_machine()` (see below) and compile.
 
 ## Critical Rules
 
@@ -185,6 +218,88 @@ for t in transitions:
 idle_transitions = unreal.AnimGraphService.get_state_transitions(abp_path, machine_name, "Idle")
 ```
 
+---
+
+## Authoring State Machines (build / edit)
+
+### ⭐ Fastest path: declarative `build_state_machine`
+
+Build (or extend) a whole machine from one JSON spec in a single atomic, idempotent call.
+Re-running it never duplicates existing states/transitions. It sets animations, rules,
+the entry state, then compiles — and returns a JSON report.
+
+```python
+import unreal, json
+
+abp = "/Game/ABP_Character"
+
+# Add the variables the rules read FIRST, then compile so the rules can resolve them
+unreal.BlueprintService.add_variable(abp, "Speed", "float")
+unreal.BlueprintService.add_variable(abp, "bAttack", "bool")
+unreal.BlueprintService.compile_blueprint(abp)
+
+spec = {
+    "states": [
+        {"name": "Idle",   "animation": "/Game/Anims/Idle",   "loop": True,  "pos": [0, 0]},
+        {"name": "Walk",   "animation": "/Game/Anims/Walk",   "loop": True,  "pos": [350, 0]},
+        {"name": "Attack", "animation": "/Game/Anims/Attack", "loop": False, "pos": [350, 250]},
+    ],
+    "transitions": [
+        {"from": "Idle",   "to": "Walk",   "rule": {"type": "comparison", "variable": "Speed", "op": "greater", "value": 10}, "blend": 0.15},
+        {"from": "Walk",   "to": "Idle",   "rule": {"type": "comparison", "variable": "Speed", "op": "less_equal", "value": 10}},
+        {"from": "Idle",   "to": "Attack", "rule": {"type": "bool", "variable": "bAttack"}},
+        {"from": "Attack", "to": "Idle",   "rule": {"type": "automatic"}},  # when the attack anim ends
+    ],
+    "entry": "Idle",
+}
+
+report = json.loads(unreal.AnimGraphService.build_state_machine(abp, "Locomotion", json.dumps(spec)))
+print(report)  # {"success":true,"states_created":3,"transitions_created":4,"errors":[]}
+```
+
+`rule.type` ∈ `bool` (`variable`, optional `invert`), `comparison` (`variable`,`op`,`value`),
+`automatic` (optional `trigger_time`), `always` (always-true), or omit `rule` to leave it inert.
+
+### Manual / incremental authoring
+
+```python
+import unreal
+abp = "/Game/ABP_Character"
+
+# State machine + states
+unreal.AnimGraphService.add_state_machine(abp, "Locomotion", 0, 0)
+unreal.AnimGraphService.add_state(abp, "Locomotion", "Idle", 0, 0)
+unreal.AnimGraphService.add_state(abp, "Locomotion", "Walk", 350, 0)
+
+# One call: create+assign the sequence player inside the state AND wire it to Output Pose
+unreal.AnimGraphService.set_state_animation(abp, "Locomotion", "Idle", "/Game/Anims/Idle", True)
+unreal.AnimGraphService.set_state_animation(abp, "Locomotion", "Walk", "/Game/Anims/Walk", True)
+
+# Default/entry state
+unreal.AnimGraphService.set_entry_state(abp, "Locomotion", "Idle")
+
+# Transitions + rules (rules are mandatory — see top gotcha)
+unreal.AnimGraphService.add_transition(abp, "Locomotion", "Idle", "Walk", 0.15)
+unreal.AnimGraphService.set_transition_rule_comparison(abp, "Locomotion", "Idle", "Walk", "Speed", "greater", 10.0)
+unreal.AnimGraphService.set_transition_priority(abp, "Locomotion", "Idle", "Walk", 1)
+
+unreal.BlueprintService.compile_blueprint(abp)
+```
+
+### Verify before claiming success — `validate_state_machine`
+
+```python
+result = unreal.AnimGraphService.validate_state_machine(abp, "Locomotion")
+print(f"valid={result.is_valid}  states={result.state_count}  transitions={result.transition_count}")
+for e in result.errors:   print("ERROR:", e)    # inert transitions, no entry state
+for w in result.warnings: print("WARN :", w)    # unreachable states, states with no animation
+```
+
+Treat any `errors` as a build failure. The most common error is an **inert transition**
+(a transition with no rule) — fix it with one of the `set_transition_rule_*` calls.
+
+---
+
 ### Find Used Animation Sequences
 
 ```python
@@ -248,6 +363,22 @@ unreal.AnimGraphService.focus_node(abp_path, node_id)
 | `priority` | int | Priority (lower = higher) |
 | `blend_duration` | float | Crossfade time in seconds |
 | `is_automatic` | bool | Auto-transition based on sequence |
+| `rule_type` | string | `None` (inert), `Bool`, `Comparison`, `Automatic`, `Custom` |
+| `rule_variable` | string | Bound variable name (for Bool/Comparison rules) |
+| `rule_summary` | string | Human-readable rule, e.g. `Speed > 150`, `bIsDead == true` |
+| `has_rule` | bool | **False = inert (never fires).** True = transition can fire |
+
+### AnimStateMachineValidationResult
+
+Returned by `validate_state_machine()`.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `is_valid` | bool | True when there are no blocking errors |
+| `state_count` | int | Number of states |
+| `transition_count` | int | Number of transitions |
+| `errors` | [string] | Blocking problems (inert transitions, no entry state) |
+| `warnings` | [string] | Non-blocking issues (unreachable states, states with no animation) |
 
 ---
 

--- a/Content/Skills/blueprint-graphs/build-graph.md
+++ b/Content/Skills/blueprint-graphs/build-graph.md
@@ -188,6 +188,57 @@ print(f"Success: {result.b_success}, errors: {result.errors}")
 
 **Target (self)** on the Broadcast node connects to `self` by default when the Blueprint is the correct class (`StateTreeTaskBlueprintBase`). You do not need to wire it manually.
 
+### Subscribe to an Event Dispatcher on Another Blueprint (Bind Event)
+
+The inverse of broadcast: a StateTree task Blueprint wants to **subscribe** to an event dispatcher (multicast delegate) declared on another Blueprint exposed via an Input variable (e.g. `Cube : BP_Cube_C` with dispatcher `FinishedLooking`), then call `Finish Task` when it fires.
+
+**Preferred — `add_delegate_bind_on_variable` (one call, no class string).**
+Mirrors `add_function_call_on_variable`: it reads the variable's type, finds the delegate on that class, creates the bind node + variable Get, and wires the Target (self) pin for you.
+
+```python
+import unreal
+
+bp = "/Game/StateTree/Tasks/STT_LookInRandomDirection"
+g  = "EventGraph"
+
+# Existing node GUIDs (from get_nodes_in_graph)
+look_at_id = "<Look At node GUID>"
+
+# One-shot: derives BP_Cube_C from the Cube variable's type, creates bind + Get,
+# wires Get -> Target. Returns the bind node GUID.
+bind_id = unreal.BlueprintService.add_delegate_bind_on_variable(
+    bp, g, "Cube", "FinishedLooking", 960.0, 0.0)
+
+# Add the Custom Event + FinishTask call and wire the remaining pins.
+custom_id = unreal.BlueprintService.add_custom_event_node(bp, g, "OnFinishedLooking", 960.0, 240.0)
+finish_id = unreal.BlueprintService.add_function_call_node(
+    bp, g, "StateTreeTaskBlueprintBase", "FinishTask", 1480.0, 240.0)
+
+# 1) upstream exec -> bind
+unreal.BlueprintService.connect_nodes(bp, g, look_at_id, "then",       bind_id,   "execute")
+# 2) custom event's delegate output -> bind's Delegate pin
+unreal.BlueprintService.connect_nodes(bp, g, custom_id,  "OutputDelegate", bind_id, "Delegate")
+# 3) custom event fires -> FinishTask
+unreal.BlueprintService.connect_nodes(bp, g, custom_id,  "then",       finish_id, "execute")
+
+unreal.BlueprintService.compile_blueprint(bp)
+unreal.EditorAssetLibrary.save_asset(bp)
+```
+
+**Pin names on `K2Node_AddDelegate` (the bind node):**
+- exec in: `execute`
+- exec out: `then`
+- Target: `self` (object input — already wired for you by `add_delegate_bind_on_variable`)
+- Delegate: `Delegate` (input — wire a Custom Event's `OutputDelegate` here)
+
+**Lower-level alternative — `add_delegate_bind_node`** (when you don't have a variable to derive the class from, e.g. you want to bind in code without a member variable). `target_class` resolution accepts any of:
+- `"Self"` / `""` — the current Blueprint
+- Native class with or without prefix: `"Actor"`, `"AActor"`, `"UButton"`
+- Blueprint asset path: `"/Game/StateTree/BP_Cube"` (or `.BP_Cube_C`)
+- Short Blueprint name with or without `_C`: `"BP_Cube"`, `"BP_Cube_C"`
+
+You also need to compose the variable Get and wire Target yourself when using this primitive.
+
 ### Round-Trip: Export → Modify → Rebuild
 
 Use `get_graph_definition` to capture an existing graph, modify the definition, then

--- a/Content/Skills/blueprints/skill.md
+++ b/Content/Skills/blueprints/skill.md
@@ -132,7 +132,9 @@ unreal.EditorAssetLibrary.save_asset(bp)
 
 **Pins on the Call node:** `execute` (input exec), `then` (output exec), `self` (input target — defaulted to Self), plus one input pin per signature parameter.
 
-**Subscribing to it elsewhere:** use `add_delegate_bind_node(other_bp, graph, "<owner class>", "FinishedLooking", x, y)` paired with `add_custom_event_node` (or `add_create_delegate_node`) to bind a callback.
+**Subscribing to it elsewhere:**
+- **Preferred** — `add_delegate_bind_on_variable(other_bp, graph, variable_name, "FinishedLooking", x, y)` when the dispatcher lives on the class of an existing variable (e.g. `Cube : BP_Cube_C`). Mirrors `add_function_call_on_variable`: derives the owner class from the variable's type, creates the bind node + Get, and auto-wires Target. Pair with `add_custom_event_node` and wire `CustomEvent.OutputDelegate → Bind.Delegate`.
+- **Lower-level** — `add_delegate_bind_node(other_bp, graph, "<owner class>", "FinishedLooking", x, y)` when you have no variable to derive from. `<owner class>` accepts `"Self"`, native class names (with/without U/A prefix), Blueprint asset paths (`/Game/.../BP_Cube`), or short BP names with/without `_C` (`BP_Cube`, `BP_Cube_C`). You wire the Target pin yourself.
 
 **Common mistakes:**
 

--- a/FAB-DESCRIPTION.md
+++ b/FAB-DESCRIPTION.md
@@ -6,9 +6,9 @@ Revolutionize your Unreal Engine workflow with AI-powered Blueprint and UMG auto
 ✨ WHAT MAKES VIBEUE SPECIAL:
 
 • 🎮 IN-EDITOR AI CHAT - Built-in chat client inside Unreal Engine!
-• 29 Python API Services with 950 Methods
+• 30 Python API Services with 1020 Methods
 • 10 MCP Discovery & Execution Tools - Explore and execute Python
-• 30 Domain Skills - Lazy-loaded knowledge reducing context overhead 50-65%
+• 34 Domain Skills - Lazy-loaded knowledge reducing context overhead 50-65%
 • Native C++ HTTP MCP Server - No Python dependency required
 • Complete Blueprint lifecycle management (create, compile, modify)
 • Animation System - Sequences, Blueprints, Montages, Skeletons with full editing

--- a/FAB_Tech_Details.md
+++ b/FAB_Tech_Details.md
@@ -1,8 +1,8 @@
 In-Editor AI Chat & MCP Server for Blueprint/UMG/Animation/Niagara/Landscape/Foliage automation. Built-in chat client inside Unreal Engine or connect VS Code, Claude Code, Cursor, and AntiGravity via native C++ HTTP MCP server with 10 discovery/execution tools.
 
-Python API Services - 29 specialized services with 950 methods, including ViewportService (19) for full viewport camera/layout control, StateTreeService (77) for full StateTree asset editing, EditorTransactionService (16) for undo/redo and transaction management, MetaSoundService (17) for MetaSound graph authoring, and broad coverage for animation, Blueprints, widgets, landscape, Niagara, audio, settings, and data workflows.
+Python API Services - 30 specialized services with 1020 methods, including ViewportService (19) for full viewport camera/layout control, StateTreeService (94) for full StateTree asset editing, EditorTransactionService (16) for undo/redo and transaction management, MetaSoundService (17) for MetaSound graph authoring, and broad coverage for animation, Blueprints, widgets, landscape, Niagara, audio, settings, and data workflows.
 
-Skills System - 30 lazy-loaded domain skills reducing context overhead 50-65% while maintaining comprehensive domain guidance.
+Skills System - 34 lazy-loaded domain skills reducing context overhead 50-65% while maintaining comprehensive domain guidance.
 
 Module: VibeUE (Editor) with 163 C++ classes enabling Blueprint/UMG/Material/Enhanced Input/Data/Landscape/StateTree automation.
 

--- a/MakePlugin.ps1
+++ b/MakePlugin.ps1
@@ -91,7 +91,17 @@ $ExcludeDevFiles = @(
     "FAB_Tech_Details.md",   # FAB submission details not needed by end users
     "FAB-Checklist.md",      # Internal checklist not needed by end users
     ".gitignore",            # Git-specific file not needed by end users
-    "vibeue-proxy.json"      # Local proxy config with bearer token (auto-generated at runtime)
+    # --- VibeUE MCP proxy: external/standalone tooling, NOT needed by the in-editor
+    #     plugin and rejected by Epic/FAB review (standalone server + process-spawning .bat) ---
+    "vibeue-proxy.json",     # Local proxy config with bearer token (auto-generated at runtime)
+    "vibeue-proxy.py",       # Standalone HTTP proxy server (opens a port; for use when UE is closed)
+    "start-vibeue-proxy.bat" # Proxy launcher (kills/spawns background process, Windows startup helper)
+)
+
+# Folders that exist only to hold the excluded proxy tooling (avoids shipping an empty dir).
+# Content/Python currently contains ONLY the proxy script + launcher above.
+$ExcludeProxyDirs = @(
+    (Join-Path $SourceDir "Content\Python")
 )
 
 # Note: test_prompts folder is now included for user reference and examples
@@ -104,7 +114,7 @@ $RobocopyArgs = @(
     $PackageDir,
     "/E",                # Copy subdirectories including empty ones
     "/XD"                # Exclude directories
-) + $ExcludeDirectories + @(
+) + $ExcludeDirectories + $ExcludeProxyDirs + @(
     "/XF"                # Exclude files
 ) + $ExcludeFiles + $ExcludeDevFiles
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ High-level services exposed to Python for common game development tasks:
 | Service | Methods | Domain |
 |---------|---------|--------|
 | `StateTreeService` | 94 | StateTree asset creation, state hierarchy, state type/link configuration, editor selection, tasks, evaluators, conditions, transitions, delegate bindings, parameters, component overrides, property bindings, **utility AI considerations**, compile/save |
-| `BlueprintService` | 116 | Blueprint lifecycle, variables, functions, components, nodes, **event dispatchers (multicast delegates) + broadcast nodes**, **custom event input pin CRUD**, **timelines (float/vector/color/event tracks, key CRUD)**, comment boxes, batch graph builder, subset auto-layout |
+| `BlueprintService` | 117 | Blueprint lifecycle, variables, functions, components, nodes, **event dispatchers (multicast delegates) + broadcast nodes + bind-on-variable**, **custom event input pin CRUD**, **timelines (float/vector/color/event tracks, key CRUD)**, comment boxes, batch graph builder, subset auto-layout |
 | `AnimSequenceService` | 89 | Animation sequence creation, keyframes, bone tracks, curves, notifies, preview |
 | `LandscapeService` | 68 | Landscape creation, sculpting, heightmaps, weight layers, holes, splines |
 | `AnimMontageService` | 62 | Animation montages: sections, slots, segments, branching points, blend settings |
@@ -683,7 +683,8 @@ unreal.BlueprintService.create_blueprint("BP_MyActor", "Actor", "/Game/Blueprint
 - `remove_event_dispatcher(path, name)` - Remove the dispatcher and its signature graph
 - `add_event_dispatcher_parameter(path, name, param_name, param_type, ...)` - Add an input on the signature
 - `add_call_delegate_node(path, graph, name, x, y)` - Spawn the `UK2Node_CallDelegate` (broadcast) node
-- `add_delegate_bind_node(path, graph, target_class, delegate_name, x, y)` - Spawn a Bind Event node to subscribe
+- `add_delegate_bind_node(path, graph, target_class, delegate_name, x, y)` - Spawn a Bind Event node to subscribe. `target_class` accepts `"Self"`, native class names, Blueprint asset paths, or short BP names with/without `_C`
+- `add_delegate_bind_on_variable(path, graph, variable_name, delegate_name, x, y)` - One-shot: derives owner class from a variable's type, creates Bind Event + Get, auto-wires Target (mirrors `add_function_call_on_variable`)
 - `add_create_delegate_node(...)`, `add_create_event_node(...)` - Wrap a function as a delegate reference
 
 **Timelines (full track + key CRUD):**

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://www.vibeue.com/
 ## ✨ Key Features
 
 - **In-Editor AI Chat** - Chat with AI directly inside Unreal Editor
-- **Python API Services** - 30 specialized services with 1020 methods for Blueprints, Materials, Widgets, Landscape Terrain, Splines, Foliage, Animation Sequences, Animation Blueprints, Animation Montages, Niagara, Skeletons, Sound Cues, MetaSounds, Gameplay Tags, Screenshots, Viewport Control, Runtime Virtual Textures, StateTree Behavior, UV Mapping, Editor Transactions, Project/Engine Settings, and more
+- **Python API Services** - 30 specialized services with 1030 methods for Blueprints, Materials, Widgets, Landscape Terrain, Splines, Foliage, Animation Sequences, Animation Blueprints, Animation Montages, Niagara, Skeletons, Sound Cues, MetaSounds, Gameplay Tags, Screenshots, Viewport Control, Runtime Virtual Textures, StateTree Behavior, UV Mapping, Editor Transactions, Project/Engine Settings, and more
 - **Full Unreal Python Access** - Execute any Unreal Engine Python API through MCP
 - **MCP Tools** - 10 tools for discovery, execution, asset workflows, debugging, terrain generation, and web research
 - **Domain Skills** - 34 lazy-loaded skill packs covering Blueprints, graph editing, materials, terrain, animation, audio, AI, gameplay tags, widgets, viewport, data, PCG (procedural content generation), UV mapping, and more
@@ -343,7 +343,7 @@ High-level services exposed to Python for common game development tasks:
 | `SkeletonService` | 53 | Skeleton & skeletal mesh manipulation, bones, sockets, retargeting, curves, blend profiles |
 | `MaterialNodeService` | 41 | Material graph expressions and connections, **material diagnostics (compile errors + sampler info)** |
 | `WidgetService` | 41 | UMG widget blueprints, components, snapshots, styling, animation, preview/PIE validation, and MVVM ViewModel bindings |
-| `AnimGraphService` | 38 | Animation Blueprint state machines, states, transitions, anim nodes |
+| `AnimGraphService` | 48 | Animation Blueprint state machines, states, transitions, transition rules, declarative builder, validation, anim nodes |
 | `SoundCueService` | 38 | Sound cue graph editing, sound node creation, wiring, and audio behavior authoring |
 | `NiagaraService` | 37 | Niagara system lifecycle, emitters, parameters, settings discovery |
 | `ActorService` | 33 | Level actor management, viewport camera control, transform lock/constraints |
@@ -700,9 +700,20 @@ unreal.BlueprintService.create_blueprint("BP_MyActor", "Actor", "/Game/Blueprint
 - `get_function_parameters(...)`, `get_graph_definition(...)`, `get_available_components(...)`
 - `compare_components(...)`, `diff_blueprints(...)`
 
-### AnimGraphService (38 methods)
+### AnimGraphService (48 methods)
 
-AnimGraphService provides comprehensive Animation Blueprint manipulation for state machines, states, transitions, and animation nodes:
+AnimGraphService provides comprehensive Animation Blueprint manipulation for state machines, states, transitions, transition rules, and animation nodes — including a declarative one-call builder and a validation pass so AI-authored machines actually run:
+
+**High-Level Authoring (recommended):**
+- `build_state_machine(path, machine, spec_json, x, y)` - Build/extend an entire state machine (states, animations, transitions, rules, entry) from one JSON spec, atomically and idempotently; compiles and returns a JSON report
+- `set_state_animation(path, machine, state, anim_path, loop, play_rate)` - One call: create/assign the state's sequence player AND wire it to Output Pose
+- `validate_state_machine(path, machine)` - Report inert transitions, missing entry state, states with no animation, unreachable states
+
+**Transition Rules (a transition with NO rule never fires):**
+- `set_transition_rule_from_bool(path, machine, source, dest, bool_var, invert)` - Drive a transition from a bool variable
+- `set_transition_rule_comparison(path, machine, source, dest, float_var, op, value)` - Numeric comparison rule (greater/less/greater_equal/less_equal/equal/not_equal)
+- `set_transition_rule_automatic(path, machine, source, dest, trigger_time)` - Auto-fire when the source state's animation is (almost) finished (one-shots)
+- `clear_transition_rule(path, machine, source, dest)` - Non-destructively reset a transition's rule
 
 **State Machine Management:**
 - `add_state_machine(path, name, x, y)` - Add state machine to AnimGraph
@@ -712,14 +723,17 @@ AnimGraphService provides comprehensive Animation Blueprint manipulation for sta
 **State Management:**
 - `add_state(path, machine, name, x, y)` - Add state to state machine
 - `remove_state(path, machine, name, remove_transitions)` - Remove state
+- `set_entry_state(path, machine, state)` - Set the entry/default state (non-destructive re-link)
 - `list_states_in_machine(path, machine)` - List all states and transitions
 - `get_state_info(path, machine, state)` - Get detailed state info
 - `open_anim_state(path, machine, state)` - Open state in editor
 
 **Transition Management:**
-- `add_transition(path, machine, source, dest, blend_duration)` - Add transition
+- `add_transition(path, machine, source, dest, blend_duration)` - Add transition (remember to set a rule!)
 - `remove_transition(path, machine, source, dest)` - Remove transition
-- `get_state_transitions(path, machine, state)` - Get transitions for state
+- `set_transition_priority(path, machine, source, dest, priority)` - Set priority order (lower wins)
+- `set_transition_blend(path, machine, source, dest, blend_duration, blend_mode)` - Set crossfade duration / blend mode
+- `get_state_transitions(path, machine, state)` - Get transitions for state (now includes rule_type/rule_summary/has_rule)
 - `open_transition(path, machine, source, dest)` - Open transition rule in editor
 
 **Conduit Management:**

--- a/Source/VibeUE/Private/Chat/VibeUEAPIClient.cpp
+++ b/Source/VibeUE/Private/Chat/VibeUEAPIClient.cpp
@@ -199,9 +199,12 @@ TSharedPtr<IHttpRequest, ESPMode::ThreadSafe> FVibeUEAPIClient::BuildHttpRequest
     // Disable keep-alive to prevent stale connections causing stuck requests
     Request->SetHeader(TEXT("Connection"), TEXT("close"));
     Request->SetContentAsString(RequestBodyString);
-    // Set timeout to 120 seconds - LLM inference with tools and large context can take time
-    // especially with chain-of-thought reasoning enabled
-    Request->SetTimeout(120.0f);
+    // Reasoning models with large tool sets can take a long time to emit the first token
+    // (DeepSeek V4 Pro, etc.). 300s leaves headroom before the 3-retry path fires.
+    Request->SetTimeout(300.0f);
+    // Activity timeout is separate from overall timeout: UE/curl aborts the request if no
+    // bytes arrive for this long. Default is ~30s, which DeepSeek V4 Pro TTFT exceeds.
+    Request->SetActivityTimeout(300.0f);
 
     return Request;
 }

--- a/Source/VibeUE/Private/PythonAPI/UAnimGraphService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UAnimGraphService.cpp
@@ -19,6 +19,7 @@
 #include "AnimGraphNode_ModifyBone.h"
 #include "AnimGraphNode_Root.h"
 #include "AnimGraphNode_StateResult.h"
+#include "AnimGraphNode_TransitionResult.h"
 #include "AnimStateNode.h"
 #include "AnimStateNodeBase.h"
 #include "AnimStateConduitNode.h"
@@ -45,6 +46,16 @@
 #include "Kismet2/KismetEditorUtilities.h"
 #include "Kismet2/Kismet2NameValidators.h"
 #include "GraphEditorActions.h"
+#include "K2Node_VariableGet.h"
+#include "K2Node_CallFunction.h"
+#include "EdGraphSchema_K2.h"
+#include "Kismet/KismetMathLibrary.h"
+#include "AlphaBlend.h"
+#include "ScopedTransaction.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "UObject/UnrealType.h"
 
 // ============================================================================
 // PRIVATE HELPERS
@@ -681,6 +692,7 @@ TArray<FAnimTransitionInfo> UAnimGraphService::GetStateTransitions(const FString
 		Info.Priority = TransitionNode->PriorityOrder;
 		Info.BlendDuration = TransitionNode->CrossfadeDuration;
 		Info.bIsAutomatic = TransitionNode->bAutomaticRuleBasedOnSequencePlayerInState;
+		DescribeTransitionRule(TransitionNode, Info);
 
 		Transitions.Add(Info);
 	}
@@ -2014,4 +2026,1064 @@ FString UAnimGraphService::AddModifyBoneNode(const FString& AnimBlueprintPath, c
 
 	UE_LOG(LogTemp, Log, TEXT("AddModifyBoneNode: Created in '%s' for bone '%s'"), *GraphName, *BoneName);
 	return NewNode->NodeGuid.ToString();
+}
+
+// ============================================================================
+// FILE-LOCAL HELPERS (transition rule authoring)
+// ============================================================================
+
+namespace
+{
+	/** Get the single value output pin of a pure variable-get node. */
+	UEdGraphPin* GetVariableValuePin(UK2Node_VariableGet* VarNode)
+	{
+		if (!VarNode)
+		{
+			return nullptr;
+		}
+		for (UEdGraphPin* Pin : VarNode->Pins)
+		{
+			if (Pin && Pin->Direction == EGPD_Output && Pin->PinName != UEdGraphSchema_K2::PN_Self)
+			{
+				return Pin;
+			}
+		}
+		return nullptr;
+	}
+
+	/** Map a comparison keyword to a KismetMathLibrary function name. Empty string = unknown op. */
+	FString ComparisonToFunctionName(const FString& Op)
+	{
+		const FString S = Op.ToLower();
+		if (S == TEXT("greater") || S == TEXT(">")) return TEXT("Greater_DoubleDouble");
+		if (S == TEXT("less") || S == TEXT("<")) return TEXT("Less_DoubleDouble");
+		if (S == TEXT("greater_equal") || S == TEXT(">=") || S == TEXT("gequal")) return TEXT("GreaterEqual_DoubleDouble");
+		if (S == TEXT("less_equal") || S == TEXT("<=") || S == TEXT("lequal")) return TEXT("LessEqual_DoubleDouble");
+		if (S == TEXT("equal") || S == TEXT("==")) return TEXT("EqualEqual_DoubleDouble");
+		if (S == TEXT("not_equal") || S == TEXT("!=")) return TEXT("NotEqual_DoubleDouble");
+		return FString();
+	}
+
+	/** Map a KismetMathLibrary comparison function name back to an operator symbol (for introspection). */
+	FString FunctionNameToSymbol(const FString& FnName)
+	{
+		if (FnName == TEXT("Greater_DoubleDouble")) return TEXT(">");
+		if (FnName == TEXT("Less_DoubleDouble")) return TEXT("<");
+		if (FnName == TEXT("GreaterEqual_DoubleDouble")) return TEXT(">=");
+		if (FnName == TEXT("LessEqual_DoubleDouble")) return TEXT("<=");
+		if (FnName == TEXT("EqualEqual_DoubleDouble")) return TEXT("==");
+		if (FnName == TEXT("NotEqual_DoubleDouble")) return TEXT("!=");
+		return FnName;
+	}
+
+	/** Parse an alpha-blend keyword into EAlphaBlendOption (defaults to Linear). */
+	EAlphaBlendOption ParseBlendOption(const FString& In)
+	{
+		const FString S = In.ToLower();
+		if (S == TEXT("cubic")) return EAlphaBlendOption::Cubic;
+		if (S == TEXT("hermitecubic") || S == TEXT("hermite")) return EAlphaBlendOption::HermiteCubic;
+		if (S == TEXT("sinusoidal") || S == TEXT("sin")) return EAlphaBlendOption::Sinusoidal;
+		if (S == TEXT("quadraticinout") || S == TEXT("quadratic")) return EAlphaBlendOption::QuadraticInOut;
+		if (S == TEXT("cubicinout")) return EAlphaBlendOption::CubicInOut;
+		if (S == TEXT("expinout") || S == TEXT("exp")) return EAlphaBlendOption::ExpInOut;
+		if (S == TEXT("circularin")) return EAlphaBlendOption::CircularIn;
+		if (S == TEXT("circularout")) return EAlphaBlendOption::CircularOut;
+		if (S == TEXT("circularinout")) return EAlphaBlendOption::CircularInOut;
+		return EAlphaBlendOption::Linear;
+	}
+}
+
+// ============================================================================
+// PRIVATE HELPERS (state machine authoring)
+// ============================================================================
+
+UAnimStateTransitionNode* UAnimGraphService::ResolveTransition(const FString& AnimBlueprintPath, const FString& StateMachineName,
+	const FString& SourceStateName, const FString& DestStateName, UAnimBlueprint*& OutBlueprint)
+{
+	OutBlueprint = nullptr;
+	UAnimBlueprint* AnimBlueprint = LoadAnimBlueprint(AnimBlueprintPath);
+	if (!AnimBlueprint)
+	{
+		return nullptr;
+	}
+	UAnimGraphNode_StateMachine* StateMachineNode = FindStateMachineNode(AnimBlueprint, StateMachineName);
+	if (!StateMachineNode || !StateMachineNode->EditorStateMachineGraph)
+	{
+		return nullptr;
+	}
+	UAnimStateTransitionNode* Transition = FindTransitionNode(StateMachineNode->EditorStateMachineGraph, SourceStateName, DestStateName);
+	if (!Transition)
+	{
+		return nullptr;
+	}
+	OutBlueprint = AnimBlueprint;
+	return Transition;
+}
+
+UAnimGraphNode_TransitionResult* UAnimGraphService::GetTransitionResultNode(UAnimStateTransitionNode* Transition)
+{
+	if (!Transition)
+	{
+		return nullptr;
+	}
+	UAnimationTransitionGraph* TransitionGraph = Cast<UAnimationTransitionGraph>(Transition->BoundGraph);
+	if (!TransitionGraph)
+	{
+		return nullptr;
+	}
+	return TransitionGraph->GetResultNode();
+}
+
+void UAnimGraphService::ResetTransitionRule(UAnimStateTransitionNode* Transition)
+{
+	if (!Transition)
+	{
+		return;
+	}
+
+	Transition->bAutomaticRuleBasedOnSequencePlayerInState = false;
+
+	UAnimationTransitionGraph* TransitionGraph = Cast<UAnimationTransitionGraph>(Transition->BoundGraph);
+	if (!TransitionGraph)
+	{
+		return;
+	}
+
+	UAnimGraphNode_TransitionResult* ResultNode = TransitionGraph->GetResultNode();
+	if (ResultNode)
+	{
+		if (UEdGraphPin* CanEnterPin = ResultNode->FindPin(TEXT("bCanEnterTransition"), EGPD_Input))
+		{
+			CanEnterPin->BreakAllPinLinks();
+			CanEnterPin->DefaultValue = TEXT("false");
+		}
+	}
+
+	// Remove every rule-logic node, leaving only the result node intact.
+	TArray<UEdGraphNode*> NodesToRemove;
+	for (UEdGraphNode* Node : TransitionGraph->Nodes)
+	{
+		if (Node && Node != ResultNode)
+		{
+			NodesToRemove.Add(Node);
+		}
+	}
+	for (UEdGraphNode* Node : NodesToRemove)
+	{
+		TransitionGraph->RemoveNode(Node);
+	}
+}
+
+UAnimGraphNode_Base* UAnimGraphService::FindStateAssetPlayer(UAnimStateNodeBase* StateNode)
+{
+	if (!StateNode)
+	{
+		return nullptr;
+	}
+	UEdGraph* StateGraph = StateNode->GetBoundGraph();
+	if (!StateGraph)
+	{
+		return nullptr;
+	}
+	for (UEdGraphNode* Node : StateGraph->Nodes)
+	{
+		if (UAnimGraphNode_SequencePlayer* SeqPlayer = Cast<UAnimGraphNode_SequencePlayer>(Node))
+		{
+			return SeqPlayer;
+		}
+	}
+	for (UEdGraphNode* Node : StateGraph->Nodes)
+	{
+		if (UAnimGraphNode_BlendSpacePlayer* BSPlayer = Cast<UAnimGraphNode_BlendSpacePlayer>(Node))
+		{
+			return BSPlayer;
+		}
+	}
+	return nullptr;
+}
+
+void UAnimGraphService::DescribeTransitionRule(UAnimStateTransitionNode* Transition, FAnimTransitionInfo& OutInfo)
+{
+	OutInfo.RuleType = TEXT("None");
+	OutInfo.RuleVariable = TEXT("");
+	OutInfo.RuleSummary = TEXT("inert (never fires)");
+	OutInfo.bHasRule = false;
+
+	if (!Transition)
+	{
+		return;
+	}
+
+	if (Transition->bAutomaticRuleBasedOnSequencePlayerInState)
+	{
+		OutInfo.RuleType = TEXT("Automatic");
+		OutInfo.RuleSummary = TEXT("auto (asset player time remaining)");
+		OutInfo.bHasRule = true;
+		return;
+	}
+
+	UAnimGraphNode_TransitionResult* ResultNode = GetTransitionResultNode(Transition);
+	if (!ResultNode)
+	{
+		return;
+	}
+	UEdGraphPin* CanEnterPin = ResultNode->FindPin(TEXT("bCanEnterTransition"), EGPD_Input);
+	if (!CanEnterPin)
+	{
+		return;
+	}
+
+	if (CanEnterPin->LinkedTo.Num() == 0)
+	{
+		if (CanEnterPin->DefaultValue.ToLower() == TEXT("true"))
+		{
+			OutInfo.RuleType = TEXT("Custom");
+			OutInfo.RuleSummary = TEXT("always true");
+			OutInfo.bHasRule = true;
+		}
+		return;
+	}
+
+	UEdGraphPin* SourcePin = CanEnterPin->LinkedTo[0];
+	UEdGraphNode* SourceNode = SourcePin ? SourcePin->GetOwningNodeUnchecked() : nullptr;
+
+	if (UK2Node_VariableGet* VarGet = Cast<UK2Node_VariableGet>(SourceNode))
+	{
+		OutInfo.RuleType = TEXT("Bool");
+		OutInfo.RuleVariable = VarGet->GetVarName().ToString();
+		OutInfo.RuleSummary = FString::Printf(TEXT("%s == true"), *OutInfo.RuleVariable);
+		OutInfo.bHasRule = true;
+		return;
+	}
+
+	if (UK2Node_CallFunction* CallFn = Cast<UK2Node_CallFunction>(SourceNode))
+	{
+		const FString FnName = CallFn->FunctionReference.GetMemberName().ToString();
+
+		if (FnName == TEXT("Not_PreBool"))
+		{
+			FString VarName;
+			if (UEdGraphPin* APin = CallFn->FindPin(TEXT("A"), EGPD_Input))
+			{
+				if (APin->LinkedTo.Num() > 0)
+				{
+					if (UK2Node_VariableGet* VG = Cast<UK2Node_VariableGet>(APin->LinkedTo[0]->GetOwningNodeUnchecked()))
+					{
+						VarName = VG->GetVarName().ToString();
+					}
+				}
+			}
+			OutInfo.RuleType = TEXT("Bool");
+			OutInfo.RuleVariable = VarName;
+			OutInfo.RuleSummary = VarName.IsEmpty() ? TEXT("NOT (bool)") : FString::Printf(TEXT("%s == false"), *VarName);
+			OutInfo.bHasRule = true;
+			return;
+		}
+
+		// Treat as a numeric comparison.
+		FString VarName;
+		if (UEdGraphPin* APin = CallFn->FindPin(TEXT("A"), EGPD_Input))
+		{
+			if (APin->LinkedTo.Num() > 0)
+			{
+				if (UK2Node_VariableGet* VG = Cast<UK2Node_VariableGet>(APin->LinkedTo[0]->GetOwningNodeUnchecked()))
+				{
+					VarName = VG->GetVarName().ToString();
+				}
+			}
+		}
+		FString BVal;
+		if (UEdGraphPin* BPin = CallFn->FindPin(TEXT("B"), EGPD_Input))
+		{
+			BVal = BPin->DefaultValue;
+		}
+		OutInfo.RuleType = TEXT("Comparison");
+		OutInfo.RuleVariable = VarName;
+		OutInfo.RuleSummary = FString::Printf(TEXT("%s %s %s"), *VarName, *FunctionNameToSymbol(FnName), *BVal);
+		OutInfo.bHasRule = true;
+		return;
+	}
+
+	OutInfo.RuleType = TEXT("Custom");
+	OutInfo.RuleSummary = TEXT("custom rule graph");
+	OutInfo.bHasRule = true;
+}
+
+// ============================================================================
+// ENTRY STATE / TRANSITION SETTINGS
+// ============================================================================
+
+bool UAnimGraphService::SetEntryState(const FString& AnimBlueprintPath, const FString& StateMachineName, const FString& StateName)
+{
+	UAnimBlueprint* AnimBlueprint = LoadAnimBlueprint(AnimBlueprintPath);
+	if (!AnimBlueprint)
+	{
+		return false;
+	}
+
+	UAnimGraphNode_StateMachine* StateMachineNode = FindStateMachineNode(AnimBlueprint, StateMachineName);
+	if (!StateMachineNode || !StateMachineNode->EditorStateMachineGraph)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetEntryState: State machine '%s' not found"), *StateMachineName);
+		return false;
+	}
+
+	UAnimationStateMachineGraph* SMGraph = Cast<UAnimationStateMachineGraph>(StateMachineNode->EditorStateMachineGraph);
+	if (!SMGraph || !SMGraph->EntryNode)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetEntryState: State machine '%s' has no entry node"), *StateMachineName);
+		return false;
+	}
+
+	UAnimStateNodeBase* TargetState = FindStateNode(SMGraph, StateName);
+	if (!TargetState)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetEntryState: State '%s' not found"), *StateName);
+		return false;
+	}
+
+	UEdGraphPin* EntryOutPin = SMGraph->EntryNode->GetOutputPin();
+	UEdGraphPin* StateInPin = TargetState->GetInputPin();
+	if (!EntryOutPin || !StateInPin)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetEntryState: Could not resolve entry/state pins"));
+		return false;
+	}
+
+	EntryOutPin->BreakAllPinLinks();
+	EntryOutPin->MakeLinkTo(StateInPin);
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(AnimBlueprint);
+	UE_LOG(LogTemp, Log, TEXT("SetEntryState: '%s' is now the entry state of '%s'"), *StateName, *StateMachineName);
+	return true;
+}
+
+bool UAnimGraphService::SetTransitionPriority(const FString& AnimBlueprintPath, const FString& StateMachineName,
+	const FString& SourceStateName, const FString& DestStateName, int32 Priority)
+{
+	UAnimBlueprint* AnimBlueprint = nullptr;
+	UAnimStateTransitionNode* Transition = ResolveTransition(AnimBlueprintPath, StateMachineName, SourceStateName, DestStateName, AnimBlueprint);
+	if (!Transition || !AnimBlueprint)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetTransitionPriority: transition '%s'->'%s' not found"), *SourceStateName, *DestStateName);
+		return false;
+	}
+
+	Transition->PriorityOrder = Priority;
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(AnimBlueprint);
+	UE_LOG(LogTemp, Log, TEXT("SetTransitionPriority: '%s'->'%s' priority = %d"), *SourceStateName, *DestStateName, Priority);
+	return true;
+}
+
+bool UAnimGraphService::SetTransitionBlend(const FString& AnimBlueprintPath, const FString& StateMachineName,
+	const FString& SourceStateName, const FString& DestStateName, float BlendDuration, const FString& BlendMode)
+{
+	UAnimBlueprint* AnimBlueprint = nullptr;
+	UAnimStateTransitionNode* Transition = ResolveTransition(AnimBlueprintPath, StateMachineName, SourceStateName, DestStateName, AnimBlueprint);
+	if (!Transition || !AnimBlueprint)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetTransitionBlend: transition '%s'->'%s' not found"), *SourceStateName, *DestStateName);
+		return false;
+	}
+
+	Transition->CrossfadeDuration = FMath::Max(0.0f, BlendDuration);
+	Transition->BlendMode = ParseBlendOption(BlendMode);
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(AnimBlueprint);
+	UE_LOG(LogTemp, Log, TEXT("SetTransitionBlend: '%s'->'%s' blend %.2fs (%s)"), *SourceStateName, *DestStateName, BlendDuration, *BlendMode);
+	return true;
+}
+
+// ============================================================================
+// TRANSITION RULES
+// ============================================================================
+
+bool UAnimGraphService::SetTransitionRuleFromBool(const FString& AnimBlueprintPath, const FString& StateMachineName,
+	const FString& SourceStateName, const FString& DestStateName, const FString& BoolVariableName, bool bInvert)
+{
+	UAnimBlueprint* AnimBlueprint = nullptr;
+	UAnimStateTransitionNode* Transition = ResolveTransition(AnimBlueprintPath, StateMachineName, SourceStateName, DestStateName, AnimBlueprint);
+	if (!Transition || !AnimBlueprint)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetTransitionRuleFromBool: transition '%s'->'%s' not found in '%s'"), *SourceStateName, *DestStateName, *StateMachineName);
+		return false;
+	}
+
+	UClass* VarClass = AnimBlueprint->SkeletonGeneratedClass ? AnimBlueprint->SkeletonGeneratedClass : AnimBlueprint->GeneratedClass;
+	FProperty* Prop = VarClass ? VarClass->FindPropertyByName(FName(*BoolVariableName)) : nullptr;
+	if (!Prop || !Prop->IsA<FBoolProperty>())
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetTransitionRuleFromBool: bool variable '%s' not found on AnimBP (add it and compile first)"), *BoolVariableName);
+		return false;
+	}
+
+	ResetTransitionRule(Transition);
+
+	UAnimGraphNode_TransitionResult* ResultNode = GetTransitionResultNode(Transition);
+	UEdGraph* RuleGraph = Transition->BoundGraph;
+	if (!ResultNode || !RuleGraph)
+	{
+		return false;
+	}
+	UEdGraphPin* CanEnterPin = ResultNode->FindPin(TEXT("bCanEnterTransition"), EGPD_Input);
+	if (!CanEnterPin)
+	{
+		return false;
+	}
+
+	FGraphNodeCreator<UK2Node_VariableGet> VarCreator(*RuleGraph);
+	UK2Node_VariableGet* VarNode = VarCreator.CreateNode();
+	VarNode->VariableReference.SetSelfMember(FName(*BoolVariableName));
+	VarNode->NodePosX = ResultNode->NodePosX - (bInvert ? 500 : 280);
+	VarNode->NodePosY = ResultNode->NodePosY;
+	VarCreator.Finalize();
+
+	UEdGraphPin* VarOutPin = GetVariableValuePin(VarNode);
+	if (!VarOutPin)
+	{
+		RuleGraph->RemoveNode(VarNode);
+		UE_LOG(LogTemp, Error, TEXT("SetTransitionRuleFromBool: failed to resolve value pin for '%s'"), *BoolVariableName);
+		return false;
+	}
+
+	if (bInvert)
+	{
+		UFunction* NotFn = UKismetMathLibrary::StaticClass()->FindFunctionByName(FName(TEXT("Not_PreBool")));
+		if (!NotFn)
+		{
+			RuleGraph->RemoveNode(VarNode);
+			return false;
+		}
+		FGraphNodeCreator<UK2Node_CallFunction> FnCreator(*RuleGraph);
+		UK2Node_CallFunction* NotNode = FnCreator.CreateNode();
+		NotNode->SetFromFunction(NotFn);
+		NotNode->NodePosX = ResultNode->NodePosX - 250;
+		NotNode->NodePosY = ResultNode->NodePosY;
+		FnCreator.Finalize();
+
+		UEdGraphPin* APin = NotNode->FindPin(TEXT("A"), EGPD_Input);
+		UEdGraphPin* RetPin = NotNode->GetReturnValuePin();
+		if (!APin || !RetPin)
+		{
+			return false;
+		}
+		VarOutPin->MakeLinkTo(APin);
+		RetPin->MakeLinkTo(CanEnterPin);
+	}
+	else
+	{
+		VarOutPin->MakeLinkTo(CanEnterPin);
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(AnimBlueprint);
+	UE_LOG(LogTemp, Log, TEXT("SetTransitionRuleFromBool: '%s'->'%s' driven by %s%s"),
+		*SourceStateName, *DestStateName, bInvert ? TEXT("NOT ") : TEXT(""), *BoolVariableName);
+	return true;
+}
+
+bool UAnimGraphService::SetTransitionRuleComparison(const FString& AnimBlueprintPath, const FString& StateMachineName,
+	const FString& SourceStateName, const FString& DestStateName, const FString& FloatVariableName, const FString& Comparison, float Threshold)
+{
+	const FString FnName = ComparisonToFunctionName(Comparison);
+	if (FnName.IsEmpty())
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetTransitionRuleComparison: unknown comparison '%s' (use greater/less/greater_equal/less_equal/equal/not_equal)"), *Comparison);
+		return false;
+	}
+
+	UAnimBlueprint* AnimBlueprint = nullptr;
+	UAnimStateTransitionNode* Transition = ResolveTransition(AnimBlueprintPath, StateMachineName, SourceStateName, DestStateName, AnimBlueprint);
+	if (!Transition || !AnimBlueprint)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetTransitionRuleComparison: transition '%s'->'%s' not found"), *SourceStateName, *DestStateName);
+		return false;
+	}
+
+	UClass* VarClass = AnimBlueprint->SkeletonGeneratedClass ? AnimBlueprint->SkeletonGeneratedClass : AnimBlueprint->GeneratedClass;
+	FProperty* Prop = VarClass ? VarClass->FindPropertyByName(FName(*FloatVariableName)) : nullptr;
+	if (!Prop || !Prop->IsA<FNumericProperty>())
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetTransitionRuleComparison: numeric variable '%s' not found on AnimBP (add it and compile first)"), *FloatVariableName);
+		return false;
+	}
+
+	UFunction* CmpFn = UKismetMathLibrary::StaticClass()->FindFunctionByName(FName(*FnName));
+	if (!CmpFn)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetTransitionRuleComparison: math function '%s' not found"), *FnName);
+		return false;
+	}
+
+	ResetTransitionRule(Transition);
+
+	UAnimGraphNode_TransitionResult* ResultNode = GetTransitionResultNode(Transition);
+	UEdGraph* RuleGraph = Transition->BoundGraph;
+	if (!ResultNode || !RuleGraph)
+	{
+		return false;
+	}
+	UEdGraphPin* CanEnterPin = ResultNode->FindPin(TEXT("bCanEnterTransition"), EGPD_Input);
+	if (!CanEnterPin)
+	{
+		return false;
+	}
+
+	FGraphNodeCreator<UK2Node_VariableGet> VarCreator(*RuleGraph);
+	UK2Node_VariableGet* VarNode = VarCreator.CreateNode();
+	VarNode->VariableReference.SetSelfMember(FName(*FloatVariableName));
+	VarNode->NodePosX = ResultNode->NodePosX - 550;
+	VarNode->NodePosY = ResultNode->NodePosY;
+	VarCreator.Finalize();
+
+	UEdGraphPin* VarOutPin = GetVariableValuePin(VarNode);
+	if (!VarOutPin)
+	{
+		RuleGraph->RemoveNode(VarNode);
+		UE_LOG(LogTemp, Error, TEXT("SetTransitionRuleComparison: failed to resolve value pin for '%s'"), *FloatVariableName);
+		return false;
+	}
+
+	FGraphNodeCreator<UK2Node_CallFunction> FnCreator(*RuleGraph);
+	UK2Node_CallFunction* CmpNode = FnCreator.CreateNode();
+	CmpNode->SetFromFunction(CmpFn);
+	CmpNode->NodePosX = ResultNode->NodePosX - 280;
+	CmpNode->NodePosY = ResultNode->NodePosY;
+	FnCreator.Finalize();
+
+	UEdGraphPin* APin = CmpNode->FindPin(TEXT("A"), EGPD_Input);
+	UEdGraphPin* BPin = CmpNode->FindPin(TEXT("B"), EGPD_Input);
+	UEdGraphPin* RetPin = CmpNode->GetReturnValuePin();
+	if (!APin || !BPin || !RetPin)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetTransitionRuleComparison: comparison node pins missing"));
+		return false;
+	}
+
+	VarOutPin->MakeLinkTo(APin);
+	BPin->DefaultValue = FString::SanitizeFloat(Threshold);
+	RetPin->MakeLinkTo(CanEnterPin);
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(AnimBlueprint);
+	UE_LOG(LogTemp, Log, TEXT("SetTransitionRuleComparison: '%s'->'%s' rule = %s %s %.3f"),
+		*SourceStateName, *DestStateName, *FloatVariableName, *FunctionNameToSymbol(FnName), Threshold);
+	return true;
+}
+
+bool UAnimGraphService::SetTransitionRuleAutomatic(const FString& AnimBlueprintPath, const FString& StateMachineName,
+	const FString& SourceStateName, const FString& DestStateName, float TriggerTime)
+{
+	UAnimBlueprint* AnimBlueprint = nullptr;
+	UAnimStateTransitionNode* Transition = ResolveTransition(AnimBlueprintPath, StateMachineName, SourceStateName, DestStateName, AnimBlueprint);
+	if (!Transition || !AnimBlueprint)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetTransitionRuleAutomatic: transition '%s'->'%s' not found"), *SourceStateName, *DestStateName);
+		return false;
+	}
+
+	ResetTransitionRule(Transition);
+	Transition->bAutomaticRuleBasedOnSequencePlayerInState = true;
+	Transition->AutomaticRuleTriggerTime = TriggerTime;
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(AnimBlueprint);
+	UE_LOG(LogTemp, Log, TEXT("SetTransitionRuleAutomatic: '%s'->'%s' auto (trigger %.3f)"), *SourceStateName, *DestStateName, TriggerTime);
+	return true;
+}
+
+bool UAnimGraphService::ClearTransitionRule(const FString& AnimBlueprintPath, const FString& StateMachineName,
+	const FString& SourceStateName, const FString& DestStateName)
+{
+	UAnimBlueprint* AnimBlueprint = nullptr;
+	UAnimStateTransitionNode* Transition = ResolveTransition(AnimBlueprintPath, StateMachineName, SourceStateName, DestStateName, AnimBlueprint);
+	if (!Transition || !AnimBlueprint)
+	{
+		UE_LOG(LogTemp, Error, TEXT("ClearTransitionRule: transition '%s'->'%s' not found"), *SourceStateName, *DestStateName);
+		return false;
+	}
+
+	ResetTransitionRule(Transition);
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(AnimBlueprint);
+	UE_LOG(LogTemp, Log, TEXT("ClearTransitionRule: cleared '%s'->'%s'"), *SourceStateName, *DestStateName);
+	return true;
+}
+
+// ============================================================================
+// HIGH-LEVEL STATE AUTHORING
+// ============================================================================
+
+FString UAnimGraphService::SetStateAnimation(const FString& AnimBlueprintPath, const FString& StateMachineName,
+	const FString& StateName, const FString& AnimSequencePath, bool bLoop, float PlayRate)
+{
+	UAnimBlueprint* AnimBlueprint = LoadAnimBlueprint(AnimBlueprintPath);
+	if (!AnimBlueprint)
+	{
+		return FString();
+	}
+
+	UAnimGraphNode_StateMachine* StateMachineNode = FindStateMachineNode(AnimBlueprint, StateMachineName);
+	if (!StateMachineNode || !StateMachineNode->EditorStateMachineGraph)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetStateAnimation: state machine '%s' not found"), *StateMachineName);
+		return FString();
+	}
+
+	UAnimStateNode* StateNode = Cast<UAnimStateNode>(FindStateNode(StateMachineNode->EditorStateMachineGraph, StateName));
+	if (!StateNode)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetStateAnimation: state '%s' not found (or is a conduit)"), *StateName);
+		return FString();
+	}
+
+	UEdGraph* StateGraph = StateNode->GetBoundGraph();
+	if (!StateGraph)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetStateAnimation: state '%s' has no graph"), *StateName);
+		return FString();
+	}
+
+	UAnimSequence* Sequence = Cast<UAnimSequence>(UEditorAssetLibrary::LoadAsset(AnimSequencePath));
+	if (!Sequence)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetStateAnimation: could not load sequence '%s'"), *AnimSequencePath);
+		return FString();
+	}
+
+	UAnimGraphNode_SequencePlayer* SeqPlayer = Cast<UAnimGraphNode_SequencePlayer>(FindStateAssetPlayer(StateNode));
+	if (!SeqPlayer)
+	{
+		FGraphNodeCreator<UAnimGraphNode_SequencePlayer> Creator(*StateGraph);
+		SeqPlayer = Creator.CreateNode();
+		SeqPlayer->NodePosX = -350;
+		SeqPlayer->NodePosY = 0;
+		Creator.Finalize();
+	}
+
+	SeqPlayer->Node.SetSequence(Sequence);
+	SeqPlayer->Node.SetLoopAnimation(bLoop);
+	SeqPlayer->Node.SetPlayRate(PlayRate);
+
+	// Wire the player's pose output to the state's Output Pose (result) node.
+	UAnimGraphNode_StateResult* ResultNode = nullptr;
+	for (UEdGraphNode* Node : StateGraph->Nodes)
+	{
+		if (UAnimGraphNode_StateResult* Result = Cast<UAnimGraphNode_StateResult>(Node))
+		{
+			ResultNode = Result;
+			break;
+		}
+	}
+	if (ResultNode)
+	{
+		UEdGraphPin* OutPin = nullptr;
+		for (UEdGraphPin* Pin : SeqPlayer->Pins)
+		{
+			if (Pin && Pin->Direction == EGPD_Output)
+			{
+				OutPin = Pin;
+				break;
+			}
+		}
+		UEdGraphPin* InPin = nullptr;
+		for (UEdGraphPin* Pin : ResultNode->Pins)
+		{
+			if (Pin && Pin->Direction == EGPD_Input)
+			{
+				InPin = Pin;
+				break;
+			}
+		}
+		if (OutPin && InPin && !OutPin->LinkedTo.Contains(InPin))
+		{
+			InPin->BreakAllPinLinks();
+			OutPin->MakeLinkTo(InPin);
+		}
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(AnimBlueprint);
+	UE_LOG(LogTemp, Log, TEXT("SetStateAnimation: '%s' in '%s' -> %s (loop=%d, rate=%.2f)"),
+		*StateName, *StateMachineName, *AnimSequencePath, bLoop ? 1 : 0, PlayRate);
+	return SeqPlayer->NodeGuid.ToString();
+}
+
+FString UAnimGraphService::BuildStateMachine(const FString& AnimBlueprintPath, const FString& StateMachineName,
+	const FString& SpecJson, float PosX, float PosY)
+{
+	TArray<FString> Errors;
+	int32 StatesCreated = 0;
+	int32 TransitionsCreated = 0;
+
+	auto MakeReport = [&](bool bSuccess) -> FString
+	{
+		TSharedRef<FJsonObject> Report = MakeShared<FJsonObject>();
+		Report->SetBoolField(TEXT("success"), bSuccess);
+		Report->SetStringField(TEXT("machine"), StateMachineName);
+		Report->SetNumberField(TEXT("states_created"), StatesCreated);
+		Report->SetNumberField(TEXT("transitions_created"), TransitionsCreated);
+		TArray<TSharedPtr<FJsonValue>> ErrArr;
+		for (const FString& E : Errors)
+		{
+			ErrArr.Add(MakeShared<FJsonValueString>(E));
+		}
+		Report->SetArrayField(TEXT("errors"), ErrArr);
+		FString Out;
+		TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Report, Writer);
+		return Out;
+	};
+
+	UAnimBlueprint* AnimBlueprint = LoadAnimBlueprint(AnimBlueprintPath);
+	if (!AnimBlueprint)
+	{
+		Errors.Add(TEXT("Failed to load AnimBlueprint"));
+		return MakeReport(false);
+	}
+
+	TSharedPtr<FJsonObject> Root;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(SpecJson);
+	if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())
+	{
+		Errors.Add(TEXT("Invalid JSON spec"));
+		return MakeReport(false);
+	}
+
+	FScopedTransaction Transaction(NSLOCTEXT("VibeUE", "BuildStateMachine", "VibeUE: Build State Machine"));
+
+	if (!FindStateMachineNode(AnimBlueprint, StateMachineName))
+	{
+		const FString NewMachineId = AddStateMachine(AnimBlueprintPath, StateMachineName, PosX, PosY);
+		if (NewMachineId.IsEmpty())
+		{
+			Errors.Add(FString::Printf(TEXT("Failed to create state machine '%s'"), *StateMachineName));
+			return MakeReport(false);
+		}
+	}
+
+	FString FirstStateName;
+
+	// --- States ---
+	const TArray<TSharedPtr<FJsonValue>>* StatesArr = nullptr;
+	if (Root->TryGetArrayField(TEXT("states"), StatesArr) && StatesArr)
+	{
+		for (const TSharedPtr<FJsonValue>& Value : *StatesArr)
+		{
+			if (!Value.IsValid() || Value->Type != EJson::Object)
+			{
+				continue;
+			}
+			TSharedPtr<FJsonObject> StateObj = Value->AsObject();
+			if (!StateObj.IsValid())
+			{
+				continue;
+			}
+
+			FString SName;
+			if (!StateObj->TryGetStringField(TEXT("name"), SName) || SName.IsEmpty())
+			{
+				Errors.Add(TEXT("State entry missing 'name'"));
+				continue;
+			}
+			if (FirstStateName.IsEmpty())
+			{
+				FirstStateName = SName;
+			}
+
+			float SX = PosX;
+			float SY = PosY;
+			const TArray<TSharedPtr<FJsonValue>>* PosArr = nullptr;
+			if (StateObj->TryGetArrayField(TEXT("pos"), PosArr) && PosArr && PosArr->Num() >= 2)
+			{
+				SX = (float)(*PosArr)[0]->AsNumber();
+				SY = (float)(*PosArr)[1]->AsNumber();
+			}
+
+			UAnimGraphNode_StateMachine* SMNode = FindStateMachineNode(AnimBlueprint, StateMachineName);
+			UEdGraph* SMGraph = SMNode ? SMNode->EditorStateMachineGraph : nullptr;
+			if (!SMGraph || !FindStateNode(SMGraph, SName))
+			{
+				const FString StateId = AddState(AnimBlueprintPath, StateMachineName, SName, SX, SY);
+				if (StateId.IsEmpty())
+				{
+					Errors.Add(FString::Printf(TEXT("Failed to add state '%s'"), *SName));
+					continue;
+				}
+				StatesCreated++;
+			}
+
+			FString Anim;
+			if (StateObj->TryGetStringField(TEXT("animation"), Anim) && !Anim.IsEmpty())
+			{
+				bool bLoop = true;
+				StateObj->TryGetBoolField(TEXT("loop"), bLoop);
+				double Rate = 1.0;
+				StateObj->TryGetNumberField(TEXT("play_rate"), Rate);
+				if (SetStateAnimation(AnimBlueprintPath, StateMachineName, SName, Anim, bLoop, (float)Rate).IsEmpty())
+				{
+					Errors.Add(FString::Printf(TEXT("Failed to set animation '%s' on state '%s'"), *Anim, *SName));
+				}
+			}
+		}
+	}
+
+	// --- Transitions ---
+	const TArray<TSharedPtr<FJsonValue>>* TransArr = nullptr;
+	if (Root->TryGetArrayField(TEXT("transitions"), TransArr) && TransArr)
+	{
+		for (const TSharedPtr<FJsonValue>& Value : *TransArr)
+		{
+			if (!Value.IsValid() || Value->Type != EJson::Object)
+			{
+				continue;
+			}
+			TSharedPtr<FJsonObject> TransObj = Value->AsObject();
+			if (!TransObj.IsValid())
+			{
+				continue;
+			}
+
+			FString From;
+			FString To;
+			if (!TransObj->TryGetStringField(TEXT("from"), From) || !TransObj->TryGetStringField(TEXT("to"), To))
+			{
+				Errors.Add(TEXT("Transition entry missing 'from'/'to'"));
+				continue;
+			}
+
+			double Blend = 0.2;
+			TransObj->TryGetNumberField(TEXT("blend"), Blend);
+
+			UAnimGraphNode_StateMachine* SMNode = FindStateMachineNode(AnimBlueprint, StateMachineName);
+			UEdGraph* SMGraph = SMNode ? SMNode->EditorStateMachineGraph : nullptr;
+			if (!SMGraph || !FindTransitionNode(SMGraph, From, To))
+			{
+				const FString TransId = AddTransition(AnimBlueprintPath, StateMachineName, From, To, (float)Blend);
+				if (TransId.IsEmpty())
+				{
+					Errors.Add(FString::Printf(TEXT("Failed to add transition '%s'->'%s'"), *From, *To));
+					continue;
+				}
+				TransitionsCreated++;
+			}
+			else
+			{
+				SetTransitionBlend(AnimBlueprintPath, StateMachineName, From, To, (float)Blend, TEXT("Linear"));
+			}
+
+			double PriorityD = 0.0;
+			if (TransObj->TryGetNumberField(TEXT("priority"), PriorityD))
+			{
+				SetTransitionPriority(AnimBlueprintPath, StateMachineName, From, To, (int32)PriorityD);
+			}
+
+			const TSharedPtr<FJsonObject>* RuleObjPtr = nullptr;
+			if (TransObj->TryGetObjectField(TEXT("rule"), RuleObjPtr) && RuleObjPtr && RuleObjPtr->IsValid())
+			{
+				const TSharedPtr<FJsonObject> RuleObj = *RuleObjPtr;
+				FString RType;
+				RuleObj->TryGetStringField(TEXT("type"), RType);
+				RType = RType.ToLower();
+
+				if (RType == TEXT("bool"))
+				{
+					FString Var;
+					bool bInv = false;
+					RuleObj->TryGetStringField(TEXT("variable"), Var);
+					RuleObj->TryGetBoolField(TEXT("invert"), bInv);
+					if (!SetTransitionRuleFromBool(AnimBlueprintPath, StateMachineName, From, To, Var, bInv))
+					{
+						Errors.Add(FString::Printf(TEXT("Failed bool rule on '%s'->'%s' (variable '%s')"), *From, *To, *Var));
+					}
+				}
+				else if (RType == TEXT("comparison"))
+				{
+					FString Var;
+					FString Op;
+					double Val = 0.0;
+					RuleObj->TryGetStringField(TEXT("variable"), Var);
+					RuleObj->TryGetStringField(TEXT("op"), Op);
+					RuleObj->TryGetNumberField(TEXT("value"), Val);
+					if (!SetTransitionRuleComparison(AnimBlueprintPath, StateMachineName, From, To, Var, Op, (float)Val))
+					{
+						Errors.Add(FString::Printf(TEXT("Failed comparison rule on '%s'->'%s'"), *From, *To));
+					}
+				}
+				else if (RType == TEXT("automatic"))
+				{
+					double Trig = -1.0;
+					RuleObj->TryGetNumberField(TEXT("trigger_time"), Trig);
+					SetTransitionRuleAutomatic(AnimBlueprintPath, StateMachineName, From, To, (float)Trig);
+				}
+				else if (RType == TEXT("always"))
+				{
+					UAnimBlueprint* RuleBP = nullptr;
+					UAnimStateTransitionNode* RuleTrans = ResolveTransition(AnimBlueprintPath, StateMachineName, From, To, RuleBP);
+					if (RuleTrans)
+					{
+						ResetTransitionRule(RuleTrans);
+						if (UAnimGraphNode_TransitionResult* RN = GetTransitionResultNode(RuleTrans))
+						{
+							if (UEdGraphPin* CEP = RN->FindPin(TEXT("bCanEnterTransition"), EGPD_Input))
+							{
+								CEP->DefaultValue = TEXT("true");
+							}
+						}
+						if (RuleBP)
+						{
+							FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(RuleBP);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// --- Entry ---
+	FString Entry;
+	if (!Root->TryGetStringField(TEXT("entry"), Entry) || Entry.IsEmpty())
+	{
+		Entry = FirstStateName;
+	}
+	if (!Entry.IsEmpty())
+	{
+		if (!SetEntryState(AnimBlueprintPath, StateMachineName, Entry))
+		{
+			Errors.Add(FString::Printf(TEXT("Failed to set entry state '%s'"), *Entry));
+		}
+	}
+
+	FKismetEditorUtilities::CompileBlueprint(AnimBlueprint);
+
+	return MakeReport(Errors.Num() == 0);
+}
+
+FAnimStateMachineValidationResult UAnimGraphService::ValidateStateMachine(const FString& AnimBlueprintPath, const FString& StateMachineName)
+{
+	FAnimStateMachineValidationResult Result;
+
+	UAnimBlueprint* AnimBlueprint = LoadAnimBlueprint(AnimBlueprintPath);
+	if (!AnimBlueprint)
+	{
+		Result.Errors.Add(TEXT("Failed to load AnimBlueprint"));
+		return Result;
+	}
+
+	UAnimGraphNode_StateMachine* StateMachineNode = FindStateMachineNode(AnimBlueprint, StateMachineName);
+	if (!StateMachineNode || !StateMachineNode->EditorStateMachineGraph)
+	{
+		Result.Errors.Add(FString::Printf(TEXT("State machine '%s' not found"), *StateMachineName));
+		return Result;
+	}
+
+	UAnimationStateMachineGraph* SMGraph = Cast<UAnimationStateMachineGraph>(StateMachineNode->EditorStateMachineGraph);
+	if (!SMGraph)
+	{
+		Result.Errors.Add(TEXT("State machine graph is invalid"));
+		return Result;
+	}
+
+	TArray<UAnimStateNode*> States;
+	TArray<UAnimStateTransitionNode*> Transitions;
+	for (UEdGraphNode* Node : SMGraph->Nodes)
+	{
+		if (UAnimStateNode* State = Cast<UAnimStateNode>(Node))
+		{
+			States.Add(State);
+		}
+		else if (UAnimStateTransitionNode* Transition = Cast<UAnimStateTransitionNode>(Node))
+		{
+			Transitions.Add(Transition);
+		}
+	}
+	Result.StateCount = States.Num();
+	Result.TransitionCount = Transitions.Num();
+
+	// Entry state
+	UAnimStateNodeBase* EntryTarget = nullptr;
+	if (SMGraph->EntryNode)
+	{
+		if (UEdGraphPin* EntryOut = SMGraph->EntryNode->GetOutputPin())
+		{
+			if (EntryOut->LinkedTo.Num() > 0 && EntryOut->LinkedTo[0])
+			{
+				EntryTarget = Cast<UAnimStateNodeBase>(EntryOut->LinkedTo[0]->GetOwningNodeUnchecked());
+			}
+		}
+	}
+	if (!EntryTarget)
+	{
+		Result.Errors.Add(TEXT("No entry state set (state machine has no default state, will not run)"));
+	}
+
+	// States with no animation/pose
+	for (UAnimStateNode* State : States)
+	{
+		bool bHasPose = false;
+		if (UEdGraph* StateGraph = State->GetBoundGraph())
+		{
+			for (UEdGraphNode* Node : StateGraph->Nodes)
+			{
+				if (UAnimGraphNode_StateResult* ResultNode = Cast<UAnimGraphNode_StateResult>(Node))
+				{
+					for (UEdGraphPin* Pin : ResultNode->Pins)
+					{
+						if (Pin && Pin->Direction == EGPD_Input && Pin->LinkedTo.Num() > 0)
+						{
+							bHasPose = true;
+							break;
+						}
+					}
+				}
+			}
+		}
+		if (!bHasPose)
+		{
+			Result.Warnings.Add(FString::Printf(TEXT("State '%s' has no animation connected to its Output Pose"), *State->GetStateName()));
+		}
+	}
+
+	// Inert transitions
+	for (UAnimStateTransitionNode* Transition : Transitions)
+	{
+		FAnimTransitionInfo Info;
+		DescribeTransitionRule(Transition, Info);
+		if (!Info.bHasRule)
+		{
+			UAnimStateNodeBase* Prev = Transition->GetPreviousState();
+			UAnimStateNodeBase* Next = Transition->GetNextState();
+			Result.Errors.Add(FString::Printf(TEXT("Transition '%s'->'%s' is inert (no rule) and will never fire"),
+				Prev ? *Prev->GetStateName() : TEXT("?"), Next ? *Next->GetStateName() : TEXT("?")));
+		}
+	}
+
+	// Reachability from entry
+	if (EntryTarget)
+	{
+		TSet<UAnimStateNodeBase*> Reachable;
+		TArray<UAnimStateNodeBase*> Stack;
+		Reachable.Add(EntryTarget);
+		Stack.Add(EntryTarget);
+		while (Stack.Num() > 0)
+		{
+			UAnimStateNodeBase* Current = Stack.Pop();
+			for (UAnimStateTransitionNode* Transition : Transitions)
+			{
+				if (Transition->GetPreviousState() == Current)
+				{
+					UAnimStateNodeBase* Next = Transition->GetNextState();
+					if (Next && !Reachable.Contains(Next))
+					{
+						Reachable.Add(Next);
+						Stack.Add(Next);
+					}
+				}
+			}
+		}
+		for (UAnimStateNode* State : States)
+		{
+			if (!Reachable.Contains(State))
+			{
+				Result.Warnings.Add(FString::Printf(TEXT("State '%s' is unreachable from the entry state"), *State->GetStateName()));
+			}
+		}
+	}
+
+	Result.bIsValid = (Result.Errors.Num() == 0);
+	return Result;
 }

--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -8180,15 +8180,7 @@ FString UBlueprintService::AddDelegateBindNode(
 	}
 	else
 	{
-		OwnerClass = FindFirstObject<UClass>(*TargetClass, EFindFirstObjectOptions::ExactClass);
-		if (!OwnerClass)
-		{
-			OwnerClass = FindFirstObject<UClass>(*FString::Printf(TEXT("U%s"), *TargetClass), EFindFirstObjectOptions::ExactClass);
-		}
-		if (!OwnerClass)
-		{
-			OwnerClass = FindFirstObject<UClass>(*FString::Printf(TEXT("A%s"), *TargetClass), EFindFirstObjectOptions::ExactClass);
-		}
+		OwnerClass = ResolveClassByName(TargetClass);
 	}
 
 	if (!OwnerClass)
@@ -8226,6 +8218,141 @@ FString UBlueprintService::AddDelegateBindNode(
 
 	FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
 	UE_LOG(LogTemp, Log, TEXT("AddDelegateBindNode: Added bind node for %s::%s in %s"), *OwnerClass->GetName(), *DelegateName, *GraphName);
+
+	return DelegateNode->NodeGuid.ToString();
+}
+
+FString UBlueprintService::AddDelegateBindOnVariable(
+	const FString& BlueprintPath,
+	const FString& GraphName,
+	const FString& VariableName,
+	const FString& DelegateName,
+	float PosX,
+	float PosY)
+{
+	UBlueprint* Blueprint = LoadBlueprint(BlueprintPath);
+	if (!Blueprint)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddDelegateBindOnVariable: Failed to load blueprint: %s"), *BlueprintPath);
+		return FString();
+	}
+
+	UEdGraph* Graph = FindGraph(Blueprint, GraphName);
+	if (!Graph)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddDelegateBindOnVariable: Graph '%s' not found in %s"), *GraphName, *BlueprintPath);
+		return FString();
+	}
+
+	if (!Blueprint->GeneratedClass)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddDelegateBindOnVariable: Blueprint '%s' has no GeneratedClass — compile it first"), *BlueprintPath);
+		return FString();
+	}
+
+	// Resolve the variable's owner class via its property on the GeneratedClass.
+	FProperty* VarProperty = Blueprint->GeneratedClass->FindPropertyByName(FName(*VariableName));
+	if (!VarProperty)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddDelegateBindOnVariable: Variable '%s' not found on %s"), *VariableName, *BlueprintPath);
+		return FString();
+	}
+
+	UClass* OwnerClass = nullptr;
+	if (FObjectProperty* ObjProp = CastField<FObjectProperty>(VarProperty))
+	{
+		OwnerClass = ObjProp->PropertyClass;
+	}
+	else if (FClassProperty* ClassProp = CastField<FClassProperty>(VarProperty))
+	{
+		OwnerClass = ClassProp->MetaClass;
+	}
+
+	if (!OwnerClass)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddDelegateBindOnVariable: Variable '%s' is not an object reference — cannot bind to a delegate on it"), *VariableName);
+		return FString();
+	}
+
+	// Find the multicast delegate on the owner class (case-insensitive).
+	FMulticastDelegateProperty* DelegateProp = nullptr;
+	for (TFieldIterator<FMulticastDelegateProperty> PropIt(OwnerClass); PropIt; ++PropIt)
+	{
+		if (PropIt->GetName().Equals(DelegateName, ESearchCase::IgnoreCase))
+		{
+			DelegateProp = *PropIt;
+			break;
+		}
+	}
+
+	if (!DelegateProp)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddDelegateBindOnVariable: Delegate '%s' not found on class '%s' (from variable '%s')"), *DelegateName, *OwnerClass->GetName(), *VariableName);
+		return FString();
+	}
+
+	// Create the bind node (Target is NOT self — it's the variable's class).
+	UK2Node_AddDelegate* DelegateNode = NewObject<UK2Node_AddDelegate>(Graph);
+	DelegateNode->SetFromProperty(DelegateProp, /*bSelfContext=*/false, OwnerClass);
+	Graph->AddNode(DelegateNode, false, false);
+	DelegateNode->CreateNewGuid();
+	DelegateNode->PostPlacedNewNode();
+	DelegateNode->AllocateDefaultPins();
+	DelegateNode->NodePosX = PosX;
+	DelegateNode->NodePosY = PosY;
+
+	// Create a Get node for the variable to the left of the bind node.
+	UK2Node_VariableGet* GetterNode = NewObject<UK2Node_VariableGet>(Graph);
+	GetterNode->VariableReference.SetSelfMember(FName(*VariableName));
+	Graph->AddNode(GetterNode, false, false);
+	GetterNode->CreateNewGuid();
+	GetterNode->PostPlacedNewNode();
+	GetterNode->AllocateDefaultPins();
+	GetterNode->NodePosX = PosX - 250.0f;
+	GetterNode->NodePosY = PosY + 16.0f;
+
+	// Wire variable output -> bind node's Target (self) pin.
+	UEdGraphPin* VarOutPin = nullptr;
+	for (UEdGraphPin* Pin : GetterNode->Pins)
+	{
+		if (Pin && Pin->Direction == EGPD_Output)
+		{
+			VarOutPin = Pin;
+			break;
+		}
+	}
+
+	UEdGraphPin* SelfPin = DelegateNode->FindPin(UEdGraphSchema_K2::PN_Self, EGPD_Input);
+	if (!SelfPin)
+	{
+		// Fallback: first input object pin (some delegate node variants name it differently).
+		for (UEdGraphPin* Pin : DelegateNode->Pins)
+		{
+			if (Pin && Pin->Direction == EGPD_Input && Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Object)
+			{
+				SelfPin = Pin;
+				break;
+			}
+		}
+	}
+
+	if (VarOutPin && SelfPin)
+	{
+		const UEdGraphSchema* Schema = Graph->GetSchema();
+		Schema->TryCreateConnection(VarOutPin, SelfPin);
+	}
+	else
+	{
+		UE_LOG(LogTemp, Warning, TEXT("AddDelegateBindOnVariable: Created nodes but could not auto-wire Target pin for %s::%s (var pin: %s, self pin: %s)"),
+			*OwnerClass->GetName(), *DelegateName,
+			VarOutPin ? TEXT("ok") : TEXT("missing"),
+			SelfPin ? TEXT("ok") : TEXT("missing"));
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+	UE_LOG(LogTemp, Log, TEXT("AddDelegateBindOnVariable: %s::%s bound via variable '%s' in %s — bind=%s, getter=%s"),
+		*OwnerClass->GetName(), *DelegateName, *VariableName, *GraphName,
+		*DelegateNode->NodeGuid.ToString(), *GetterNode->NodeGuid.ToString());
 
 	return DelegateNode->NodeGuid.ToString();
 }

--- a/Source/VibeUE/Public/PythonAPI/UAnimGraphService.h
+++ b/Source/VibeUE/Public/PythonAPI/UAnimGraphService.h
@@ -99,6 +99,51 @@ struct FAnimTransitionInfo
 	/** Whether this is an automatic transition */
 	UPROPERTY(BlueprintReadWrite, Category = "Animation")
 	bool bIsAutomatic = false;
+
+	/** Classification of the rule driving this transition: "None" (inert), "Bool", "Comparison", "Automatic", "Custom" */
+	UPROPERTY(BlueprintReadWrite, Category = "Animation")
+	FString RuleType;
+
+	/** Name of the bound variable driving the rule (if RuleType is "Bool" or "Comparison"), else empty */
+	UPROPERTY(BlueprintReadWrite, Category = "Animation")
+	FString RuleVariable;
+
+	/** Human-readable description of the rule (e.g. "bIsDead == true", "Speed > 150", "auto (time remaining)") */
+	UPROPERTY(BlueprintReadWrite, Category = "Animation")
+	FString RuleSummary;
+
+	/** True when the transition has functional rule logic and can actually fire. False = inert (never fires). */
+	UPROPERTY(BlueprintReadWrite, Category = "Animation")
+	bool bHasRule = false;
+};
+
+/**
+ * Result of validating a state machine for common authoring mistakes.
+ */
+USTRUCT(BlueprintType)
+struct FAnimStateMachineValidationResult
+{
+	GENERATED_BODY()
+
+	/** True when there are no blocking errors (warnings may still be present) */
+	UPROPERTY(BlueprintReadWrite, Category = "Animation")
+	bool bIsValid = false;
+
+	/** Number of states found (excludes entry/conduit) */
+	UPROPERTY(BlueprintReadWrite, Category = "Animation")
+	int32 StateCount = 0;
+
+	/** Number of transitions found */
+	UPROPERTY(BlueprintReadWrite, Category = "Animation")
+	int32 TransitionCount = 0;
+
+	/** Blocking problems that make the machine non-functional (e.g. inert transitions, no entry state) */
+	UPROPERTY(BlueprintReadWrite, Category = "Animation")
+	TArray<FString> Errors;
+
+	/** Non-blocking issues worth attention (e.g. unreachable states, states with no animation) */
+	UPROPERTY(BlueprintReadWrite, Category = "Animation")
+	TArray<FString> Warnings;
 };
 
 /**
@@ -719,6 +764,251 @@ public:
 		const FString& SourceStateName,
 		const FString& DestStateName);
 
+	/**
+	 * Set which state the state machine's Entry node points to.
+	 * Non-destructively re-links the entry: breaks the old entry link and links to the chosen state.
+	 *
+	 * @param AnimBlueprintPath - Full path to the Animation Blueprint
+	 * @param StateMachineName - Name of the state machine
+	 * @param StateName - Name of the state to make the entry/default state
+	 * @return True if successful
+	 *
+	 * Example:
+	 *   unreal.AnimGraphService.set_entry_state("/Game/ABP_Character", "Locomotion", "Idle")
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Animation|StateMachine")
+	static bool SetEntryState(
+		const FString& AnimBlueprintPath,
+		const FString& StateMachineName,
+		const FString& StateName);
+
+	/**
+	 * Set the priority order of a transition (lower = higher priority when several rules go true at once).
+	 *
+	 * @param AnimBlueprintPath - Full path to the Animation Blueprint
+	 * @param StateMachineName - Name of the state machine
+	 * @param SourceStateName - Source state
+	 * @param DestStateName - Destination state
+	 * @param Priority - Priority order (default 1; smaller wins)
+	 * @return True if successful
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Animation|StateMachine")
+	static bool SetTransitionPriority(
+		const FString& AnimBlueprintPath,
+		const FString& StateMachineName,
+		const FString& SourceStateName,
+		const FString& DestStateName,
+		int32 Priority = 1);
+
+	/**
+	 * Set the crossfade/blend settings of a transition.
+	 *
+	 * @param AnimBlueprintPath - Full path to the Animation Blueprint
+	 * @param StateMachineName - Name of the state machine
+	 * @param SourceStateName - Source state
+	 * @param DestStateName - Destination state
+	 * @param BlendDuration - Crossfade duration in seconds
+	 * @param BlendMode - Alpha blend option: "Linear", "Cubic", "HermiteCubic", "Sinusoidal",
+	 *                    "QuadraticInOut", "CubicInOut", "ExpInOut" (default "Linear")
+	 * @return True if successful
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Animation|StateMachine")
+	static bool SetTransitionBlend(
+		const FString& AnimBlueprintPath,
+		const FString& StateMachineName,
+		const FString& SourceStateName,
+		const FString& DestStateName,
+		float BlendDuration = 0.2f,
+		const FString& BlendMode = TEXT("Linear"));
+
+	// ============================================================================
+	// TRANSITION RULES
+	// ============================================================================
+
+	/**
+	 * Drive a transition's "Can Enter Transition" result from a Blueprint bool variable.
+	 * This is what makes a transition actually fire. Without a rule the transition is inert.
+	 * Non-destructive: clears any prior rule logic in the transition graph first, then wires the variable.
+	 *
+	 * @param AnimBlueprintPath - Full path to the Animation Blueprint
+	 * @param StateMachineName - Name of the state machine
+	 * @param SourceStateName - Source state
+	 * @param DestStateName - Destination state
+	 * @param BoolVariableName - Name of an existing bool member variable on the AnimBP (e.g. "bIsDead")
+	 * @param bInvert - If true, transition fires when the variable is FALSE (inserts a NOT)
+	 * @return True if successful
+	 *
+	 * Example:
+	 *   unreal.AnimGraphService.set_transition_rule_from_bool(
+	 *       "/Game/ABP_Character", "Locomotion", "Idle", "Dead", "bIsDead")
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Animation|TransitionRules")
+	static bool SetTransitionRuleFromBool(
+		const FString& AnimBlueprintPath,
+		const FString& StateMachineName,
+		const FString& SourceStateName,
+		const FString& DestStateName,
+		const FString& BoolVariableName,
+		bool bInvert = false);
+
+	/**
+	 * Drive a transition from a numeric comparison against a Blueprint float variable
+	 * (e.g. Speed > 150). Non-destructive: clears prior rule logic first.
+	 *
+	 * @param AnimBlueprintPath - Full path to the Animation Blueprint
+	 * @param StateMachineName - Name of the state machine
+	 * @param SourceStateName - Source state
+	 * @param DestStateName - Destination state
+	 * @param FloatVariableName - Name of an existing float member variable (e.g. "Speed")
+	 * @param Comparison - One of "greater", "less", "greater_equal", "less_equal", "equal", "not_equal"
+	 * @param Threshold - The constant to compare against
+	 * @return True if successful
+	 *
+	 * Example:
+	 *   unreal.AnimGraphService.set_transition_rule_comparison(
+	 *       "/Game/ABP_Character", "Locomotion", "Idle", "Walk", "Speed", "greater", 10.0)
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Animation|TransitionRules")
+	static bool SetTransitionRuleComparison(
+		const FString& AnimBlueprintPath,
+		const FString& StateMachineName,
+		const FString& SourceStateName,
+		const FString& DestStateName,
+		const FString& FloatVariableName,
+		const FString& Comparison,
+		float Threshold);
+
+	/**
+	 * Make a transition fire automatically based on the source state's most relevant asset
+	 * player remaining time. Ideal for one-shot animations (attack -> idle, hit-react -> idle).
+	 *
+	 * @param AnimBlueprintPath - Full path to the Animation Blueprint
+	 * @param StateMachineName - Name of the state machine
+	 * @param SourceStateName - Source state (must contain a sequence/asset player)
+	 * @param DestStateName - Destination state
+	 * @param TriggerTime - Seconds before the asset ends to trigger. < 0 means trigger
+	 *                      'CrossfadeDuration' seconds before end (default -1.0)
+	 * @return True if successful
+	 *
+	 * Example:
+	 *   unreal.AnimGraphService.set_transition_rule_automatic(
+	 *       "/Game/ABP_Character", "Combat", "Attack", "Idle")
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Animation|TransitionRules")
+	static bool SetTransitionRuleAutomatic(
+		const FString& AnimBlueprintPath,
+		const FString& StateMachineName,
+		const FString& SourceStateName,
+		const FString& DestStateName,
+		float TriggerTime = -1.0f);
+
+	/**
+	 * Remove the rule logic from a transition (non-destructive reset of the rule graph).
+	 * Breaks the link into the result node and clears the automatic flag, leaving the
+	 * transition node and its source/dest connections intact.
+	 *
+	 * @param AnimBlueprintPath - Full path to the Animation Blueprint
+	 * @param StateMachineName - Name of the state machine
+	 * @param SourceStateName - Source state
+	 * @param DestStateName - Destination state
+	 * @return True if successful
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Animation|TransitionRules")
+	static bool ClearTransitionRule(
+		const FString& AnimBlueprintPath,
+		const FString& StateMachineName,
+		const FString& SourceStateName,
+		const FString& DestStateName);
+
+	// ============================================================================
+	// HIGH-LEVEL STATE AUTHORING
+	// ============================================================================
+
+	/**
+	 * Set the animation for a state in one call: ensures a sequence player exists inside the
+	 * state's graph, assigns the animation, sets loop/play-rate, and connects it to the state's
+	 * Output Pose. Non-destructive: reuses an existing sequence player if the state already has one.
+	 *
+	 * @param AnimBlueprintPath - Full path to the Animation Blueprint
+	 * @param StateMachineName - Name of the state machine
+	 * @param StateName - Name of the state
+	 * @param AnimSequencePath - Path to the animation sequence asset
+	 * @param bLoop - Whether the animation should loop (default true)
+	 * @param PlayRate - Playback rate multiplier (default 1.0)
+	 * @return Node GUID of the sequence player if successful, empty string otherwise
+	 *
+	 * Example:
+	 *   unreal.AnimGraphService.set_state_animation(
+	 *       "/Game/ABP_Character", "Locomotion", "Idle", "/Game/Anims/Idle_Loop", True)
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Animation|StateAuthoring")
+	static FString SetStateAnimation(
+		const FString& AnimBlueprintPath,
+		const FString& StateMachineName,
+		const FString& StateName,
+		const FString& AnimSequencePath,
+		bool bLoop = true,
+		float PlayRate = 1.0f);
+
+	/**
+	 * Build (or extend) an entire state machine from a single JSON spec in one atomic transaction.
+	 * Idempotent: existing states/transitions are reused, not duplicated. Compiles at the end and
+	 * returns a JSON report of what was created and any errors.
+	 *
+	 * Spec format:
+	 * {
+	 *   "states": [
+	 *     {"name": "Idle",   "animation": "/Game/Anims/Idle",   "loop": true,  "pos": [0, 0]},
+	 *     {"name": "Walk",   "animation": "/Game/Anims/Walk",   "loop": true,  "pos": [300, 0]},
+	 *     {"name": "Attack", "animation": "/Game/Anims/Attack", "loop": false, "pos": [600, 0]}
+	 *   ],
+	 *   "transitions": [
+	 *     {"from": "Idle",   "to": "Walk",   "rule": {"type": "comparison", "variable": "Speed", "op": "greater", "value": 10}, "blend": 0.2},
+	 *     {"from": "Walk",   "to": "Idle",   "rule": {"type": "comparison", "variable": "Speed", "op": "less_equal", "value": 10}},
+	 *     {"from": "Idle",   "to": "Attack", "rule": {"type": "bool", "variable": "bAttack"}},
+	 *     {"from": "Attack", "to": "Idle",   "rule": {"type": "automatic"}}
+	 *   ],
+	 *   "entry": "Idle"
+	 * }
+	 *
+	 * rule.type is one of: "bool" (uses "variable", optional "invert"),
+	 *   "comparison" (uses "variable", "op", "value"), "automatic" (optional "trigger_time"),
+	 *   "always" (always-true), or omit "rule" to leave the transition inert.
+	 *
+	 * @param AnimBlueprintPath - Full path to the Animation Blueprint
+	 * @param StateMachineName - Name of the state machine (created if it does not exist)
+	 * @param SpecJson - JSON string describing states, transitions and entry
+	 * @param PosX - X position of the state machine node in the AnimGraph if it must be created
+	 * @param PosY - Y position of the state machine node in the AnimGraph if it must be created
+	 * @return JSON report string: {"success", "machine", "states_created", "transitions_created", "errors": [...]}
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Animation|StateAuthoring")
+	static FString BuildStateMachine(
+		const FString& AnimBlueprintPath,
+		const FString& StateMachineName,
+		const FString& SpecJson,
+		float PosX = 0.0f,
+		float PosY = 0.0f);
+
+	/**
+	 * Validate a state machine for the most common authoring mistakes and return a structured report.
+	 * Flags: no entry state, inert transitions (rule graph drives nothing -> never fires),
+	 * states with no animation wired to Output Pose, and unreachable states.
+	 *
+	 * @param AnimBlueprintPath - Full path to the Animation Blueprint
+	 * @param StateMachineName - Name of the state machine
+	 * @return Validation result with errors/warnings
+	 *
+	 * Example:
+	 *   result = unreal.AnimGraphService.validate_state_machine("/Game/ABP_Character", "Locomotion")
+	 *   if not result.is_valid:
+	 *       for err in result.errors: print(err)
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Animation|StateAuthoring")
+	static FAnimStateMachineValidationResult ValidateStateMachine(
+		const FString& AnimBlueprintPath,
+		const FString& StateMachineName);
+
 	// ============================================================================
 	// ANIMGRAPH CONNECTIONS
 	// ============================================================================
@@ -915,4 +1205,24 @@ private:
 
 	/** Get the editor for an Animation Blueprint, opening it if necessary */
 	static class IAnimationBlueprintEditor* GetAnimBlueprintEditor(class UAnimBlueprint* AnimBlueprint);
+
+	/** Resolve blueprint + state machine graph + transition node in one step. Returns null on any failure. */
+	static class UAnimStateTransitionNode* ResolveTransition(
+		const FString& AnimBlueprintPath,
+		const FString& StateMachineName,
+		const FString& SourceStateName,
+		const FString& DestStateName,
+		class UAnimBlueprint*& OutBlueprint);
+
+	/** Get the transition result node ("Can Enter Transition") for a transition's rule graph. */
+	static class UAnimGraphNode_TransitionResult* GetTransitionResultNode(class UAnimStateTransitionNode* Transition);
+
+	/** Non-destructively clear a transition's rule graph: break the result input link, remove rule logic nodes, reset automatic flag. */
+	static void ResetTransitionRule(class UAnimStateTransitionNode* Transition);
+
+	/** Find the sequence/asset player node inside a state's graph that feeds (directly) the Output Pose, if any. */
+	static class UAnimGraphNode_Base* FindStateAssetPlayer(class UAnimStateNodeBase* StateNode);
+
+	/** Describe the rule driving a transition (for introspection). Fills RuleType/RuleVariable/RuleSummary/bHasRule. */
+	static void DescribeTransitionRule(class UAnimStateTransitionNode* Transition, FAnimTransitionInfo& OutInfo);
 };

--- a/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
+++ b/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
@@ -2729,7 +2729,11 @@ public:
 	 *
 	 * @param BlueprintPath - Full path to the blueprint
 	 * @param GraphName - Name of the graph (e.g. "EventGraph")
-	 * @param TargetClass - Class that owns the delegate. Use "Self" or "" for the blueprint's own class.
+	 * @param TargetClass - Class that owns the delegate. Accepts:
+	 *   - "Self" or "" for the blueprint's own class
+	 *   - A native class name with or without U/A prefix (e.g. "Actor", "UButton")
+	 *   - A Blueprint asset path (e.g. "/Game/StateTree/BP_Cube")
+	 *   - A short Blueprint name with or without _C suffix (e.g. "BP_Cube", "BP_Cube_C")
 	 * @param DelegateName - Name of the multicast delegate property (e.g. "OnActorBeginOverlap")
 	 * @param PosX - X position in the graph
 	 * @param PosY - Y position in the graph
@@ -2738,12 +2742,56 @@ public:
 	 * Example:
 	 *   node_id = unreal.BlueprintService.add_delegate_bind_node("/Game/BP_Player", "EventGraph", "Self", "OnDamageTaken", 200, 100)
 	 *   node_id = unreal.BlueprintService.add_delegate_bind_node("/Game/WBP_HUD", "EventGraph", "UButton", "OnClicked", 300, 200)
+	 *   node_id = unreal.BlueprintService.add_delegate_bind_node("/Game/STT_LookAt", "EventGraph", "BP_Cube", "FinishedLooking", 960, 0)
 	 */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|Blueprints")
 	static FString AddDelegateBindNode(
 		const FString& BlueprintPath,
 		const FString& GraphName,
 		const FString& TargetClass,
+		const FString& DelegateName,
+		float PosX = 0.0f,
+		float PosY = 0.0f
+	);
+
+	/**
+	 * Convenience: bind to an event dispatcher declared on a Blueprint variable's class in one shot.
+	 *
+	 * Resolves the variable's type to its owner class (e.g. variable "Cube : BP_Cube_C" -> BP_Cube_C),
+	 * finds the named multicast delegate on that class, creates a "Bind Event to <Delegate>" node and
+	 * a Get node for the variable, and wires the variable's output pin into the bind node's Target (self).
+	 *
+	 * The variable must be an object-reference type (UObject subclass). For inherited variables the
+	 * owner class is read from the GeneratedClass property, so this works for variables defined on
+	 * parent classes too.
+	 *
+	 * After calling this you still need to:
+	 *   - Wire the bind node's exec input ("execute") from your upstream node
+	 *   - Wire a Custom Event's "OutputDelegate" pin into the bind node's "Delegate" pin
+	 *
+	 * @param BlueprintPath - Full path to the blueprint that contains the graph
+	 * @param GraphName     - Name of the graph (e.g. "EventGraph")
+	 * @param VariableName  - Variable on this blueprint whose type owns the event dispatcher
+	 * @param DelegateName  - Multicast delegate (event dispatcher) on the variable's class
+	 * @param PosX          - X position for the bind node
+	 * @param PosY          - Y position for the bind node
+	 * @return Node ID (GUID) of the bind node if successful, empty string otherwise
+	 *
+	 * Example:
+	 *   # Cube is a BP_Cube_C variable on STT_LookInRandomDirection.
+	 *   # BP_Cube has an event dispatcher "FinishedLooking".
+	 *   bind_id = unreal.BlueprintService.add_delegate_bind_on_variable(
+	 *       "/Game/StateTree/Tasks/STT_LookInRandomDirection",
+	 *       "EventGraph",
+	 *       "Cube",
+	 *       "FinishedLooking",
+	 *       960, 0)
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Blueprints")
+	static FString AddDelegateBindOnVariable(
+		const FString& BlueprintPath,
+		const FString& GraphName,
+		const FString& VariableName,
 		const FString& DelegateName,
 		float PosX = 0.0f,
 		float PosY = 0.0f

--- a/test_prompts/animation-blueprint/animation_blueprint.md
+++ b/test_prompts/animation-blueprint/animation_blueprint.md
@@ -397,4 +397,100 @@ Get complete information about SandboxCharacter_CMC_ABP including all variables,
 
 Compare ABP_TestCharacter with SandboxCharacter_CMC_ABP and list what's missing.
 
+---
+
+# State Machine Authoring & Transition Rules (issue #389)
+
+These prompts exercise the authoring API that makes a state machine actually *run*:
+transition rules, entry state, one-call state animation, the declarative builder, and validation.
+
+## 63 - Set State Animation in One Call
+
+In ABP_TestCharacter's Locomotion machine, set the Idle state's animation to an idle loop
+in a single call (it should create the sequence player inside the state AND connect it to the
+Output Pose). Verify the state now has a pose connected.
+
+---
+
+## 64 - Set the Entry / Default State
+
+Make "Idle" the entry (default) state of the Locomotion state machine. Verify the entry node
+now points at Idle.
+
+---
+
+## 65 - Bool Transition Rule
+
+Add a bool variable `bIsMoving` to ABP_TestCharacter and compile. Then set the Idle→Moving
+transition rule so it fires when `bIsMoving` is true. Confirm the transition reports
+`has_rule = true` and `rule_summary` mentions bIsMoving.
+
+---
+
+## 66 - Inverted Bool Rule
+
+Set the Moving→Idle transition to fire when `bIsMoving` is **false** (inverted bool rule).
+
+---
+
+## 67 - Comparison Transition Rule
+
+Add a float variable `Speed` and compile. Set Idle→Moving to fire when `Speed > 10`, using a
+comparison rule. Confirm the rule summary reads like `Speed > 10`.
+
+---
+
+## 68 - Automatic (Time-Remaining) Rule
+
+Add an "Attack" state with a non-looping attack montage/sequence, plus an Attack→Idle
+transition. Make Attack→Idle automatic so it fires when the attack animation is nearly done.
+
+---
+
+## 69 - Transition Priority
+
+Give Idle→Moving a higher priority (lower number) than any other transition out of Idle.
+
+---
+
+## 70 - Detect Inert Transitions (Rule Introspection)
+
+List every transition in the Locomotion machine and report which ones are inert (have no rule
+and will never fire). Use the rule_type / has_rule fields.
+
+---
+
+## 71 - Validate the State Machine
+
+Validate the Locomotion state machine. Report is_valid plus all errors and warnings
+(inert transitions, missing entry state, states with no animation, unreachable states).
+Then fix any errors and validate again until it is valid.
+
+---
+
+## 72 - Build a Whole State Machine Declaratively
+
+Using a single declarative build call, create a "CombatLocomotion" state machine on
+ABP_TestCharacter with: Idle (loop), Walk (loop), Run (loop), Attack (one-shot). Wire it up:
+Idle→Walk when Speed > 10, Walk→Run when Speed > 350, Run→Walk when Speed <= 350,
+Walk→Idle when Speed <= 10, Idle→Attack when bAttack, Attack→Idle automatic. Entry = Idle.
+Add the Speed (float) and bAttack (bool) variables and compile first. Report the JSON result,
+then validate the machine and confirm it is valid with zero errors.
+
+---
+
+## 73 - Re-run the Build (Idempotency)
+
+Run the exact same declarative build from #72 again. Confirm it does NOT duplicate any states
+or transitions (states_created and transitions_created should both be 0) and the machine still
+validates clean.
+
+---
+
+## 74 - Non-Destructive Rule Edit
+
+Change the Idle→Walk rule from `Speed > 10` to `Speed > 25` without removing/recreating the
+transition. Confirm the source/dest connections and blend duration are unchanged and only the
+threshold updated.
+
 


### PR DESCRIPTION
## Summary

Merges the `5-7` line into `master`. Headline feature is the AnimGraph state machine **authoring** layer that closes #389 — previously transitions could be created but had no rule, so they were inert and never fired.

## What's included

**AnimGraph authoring (closes #389)** — `AnimGraphService` 38 → 48 methods:
- Transition rules: `set_transition_rule_from_bool` (+invert), `set_transition_rule_comparison` (greater/less/…/not_equal), `set_transition_rule_automatic` (time-remaining one-shots), `clear_transition_rule`
- `set_entry_state`, `set_transition_priority`, `set_transition_blend`
- `set_state_animation` — one call creates/assigns the state's sequence player and wires it to Output Pose
- `build_state_machine` — declarative JSON spec → states + animations + transitions + rules + entry, built atomically/idempotently, compiles, returns a JSON report
- `validate_state_machine` — flags inert transitions, missing entry, animation-less states, unreachable states
- `get_state_transitions` now reports `rule_type` / `rule_variable` / `rule_summary` / `has_rule`
- Skill, test prompts, and README updated

**Also in this branch:**
- BlueprintService: `AddDelegateBindOnVariable` + broader `AddDelegateBindNode` class resolution
- Chat: request timeout bumped to 300s + activity timeout
- Docs: FAB / service-count refresh
- `MakePlugin.ps1`: exclude the MCP proxy tooling (`vibeue-proxy.py`, `start-vibeue-proxy.bat`, `Content/Python/`) from the FAB package (Epic review flagged it)

## Verification
- `StateTreeEditor` compiles & links cleanly (`UnrealEditor-VibeUE.dll`)
- New AnimGraph API runtime-tested via live MCP: declarative build, validation (clean + inert detection), all rule types incl. inverted bool, idempotent re-run, non-destructive rule edit, graceful failure on missing variable — temp asset created and deleted, no residue
- FAB package rebuilt and confirmed to contain zero proxy files

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)