### PR TITLE
feat(BlueprintService): add ListGraphs to enumerate all graph tabs

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -548,6 +548,47 @@ TArray<FBlueprintFunctionInfo> UBlueprintService::ListFunctions(const FString& B
 	return Functions;
 }
 
+TArray<FBlueprintGraphInfo> UBlueprintService::ListGraphs(const FString& BlueprintPath)
+{
+	TArray<FBlueprintGraphInfo> Graphs;
+
+	UBlueprint* Blueprint = LoadBlueprint(BlueprintPath);
+	if (!Blueprint)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("UBlueprintService::ListGraphs: Failed to load blueprint: %s"), *BlueprintPath);
+		return Graphs;
+	}
+
+	// Emit one FBlueprintGraphInfo per graph in a given collection
+	auto AppendGraphs = [&Graphs](const TArray<UEdGraph*>& Source, const TCHAR* Kind)
+	{
+		for (UEdGraph* Graph : Source)
+		{
+			if (!Graph)
+			{
+				continue;
+			}
+
+			FBlueprintGraphInfo Info;
+			Info.GraphName = Graph->GetName();
+			Info.GraphKind = Kind;
+			Info.NodeCount = Graph->Nodes.Num();
+			Graphs.Add(MoveTemp(Info));
+		}
+	};
+
+	// UbergraphPages = the event-graph tabs (default "EventGraph" + any user-added pages).
+	// FunctionGraphs = user functions, overrides, and auto-generated input event functions.
+	// MacroGraphs   = blueprint macros.
+	// DelegateSignatureGraphs = event dispatcher signature graphs.
+	AppendGraphs(Blueprint->UbergraphPages,          TEXT("Ubergraph"));
+	AppendGraphs(Blueprint->FunctionGraphs,          TEXT("Function"));
+	AppendGraphs(Blueprint->MacroGraphs,             TEXT("Macro"));
+	AppendGraphs(Blueprint->DelegateSignatureGraphs, TEXT("DelegateSignature"));
+
+	return Graphs;
+}
+
 bool UBlueprintService::OpenFunctionGraph(const FString& BlueprintPath, const FString& FunctionName)
 {
 	UBlueprint* Blueprint = LoadBlueprint(BlueprintPath);

--- a/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
+++ b/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
@@ -35,6 +35,29 @@ struct FBlueprintVariableInfo
 };
 
 /**
+ * Information about a single UEdGraph attached to a Blueprint.
+ * Returned by ListGraphs — one entry per graph tab visible in the
+ * Blueprint editor (ubergraph pages, functions, macros, delegate signatures).
+ */
+USTRUCT(BlueprintType)
+struct FBlueprintGraphInfo
+{
+	GENERATED_BODY()
+
+	/** Tab name as shown in the My Blueprint panel (e.g. "EventGraph", "Graph_PlayerInput", "MyFunction") */
+	UPROPERTY(BlueprintReadWrite, Category = "Blueprint")
+	FString GraphName;
+
+	/** "Ubergraph" | "Function" | "Macro" | "DelegateSignature" */
+	UPROPERTY(BlueprintReadWrite, Category = "Blueprint")
+	FString GraphKind;
+
+	/** Number of nodes in this graph (cheap to compute, useful as a sanity signal) */
+	UPROPERTY(BlueprintReadWrite, Category = "Blueprint")
+	int32 NodeCount = 0;
+};
+
+/**
  * Detailed information about a blueprint variable (for get_info action)
  */
 USTRUCT(BlueprintType)
@@ -984,6 +1007,26 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|Blueprints")
 	static TArray<FBlueprintFunctionInfo> ListFunctions(const FString& BlueprintPath);
+
+	/**
+	 * Enumerate every UEdGraph attached to a Blueprint — ubergraph pages, functions,
+	 * macros, and delegate signature graphs.
+	 *
+	 * Use this when you don't know the exact name of a graph tab. The default
+	 * Blueprint editor only exposes "EventGraph" by name; user-created ubergraph
+	 * pages (e.g. "Graph_PlayerInput") and inherited function graphs are invisible
+	 * without this enumeration.
+	 *
+	 * @param BlueprintPath - Full path to the blueprint (e.g., "/Game/Blueprints/BP_Player_Test")
+	 * @return Array of FBlueprintGraphInfo, one per graph
+	 *
+	 * Example:
+	 *   graphs = unreal.BlueprintService.list_graphs("/Game/Blueprints/BP_Player_Test")
+	 *   for g in graphs:
+	 *       print(f"{g.graph_kind:20}  {g.graph_name:30}  ({g.node_count} nodes)")
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Blueprints")
+	static TArray<FBlueprintGraphInfo> ListGraphs(const FString& BlueprintPath);
 
 	/**
 	 * Open a blueprint and navigate to a specific function graph.


### PR DESCRIPTION
## Problem

`get_nodes_in_graph` requires the exact graph tab name up front. Blueprints that use multiple Ubergraph pages (user-created via right-click in the *My Blueprint* panel) have names that are invisible to the MCP API — the editor shows them visually but there was no way to enumerate them programmatically. Agents were left guessing names like `Graph_PlayerInput` and hitting silent failures.

Closes #403.

## Solution

Adds `FBlueprintGraphInfo` struct and `ListGraphs(BlueprintPath)` → `TArray<FBlueprintGraphInfo>`, which enumerates all four `UEdGraph*` collections on the `UBlueprint*` object:

| Collection | `graph_kind` value |
|---|---|
| `UBlueprint::UbergraphPages` | `Ubergraph` |
| `UBlueprint::FunctionGraphs` | `Function` |
| `UBlueprint::MacroGraphs` | `Macro` |
| `UBlueprint::DelegateSignatureGraphs` | `DelegateSignature` |

Each entry carries `graph_name`, `graph_kind`, and `node_count` (O(1), no asset loading).

## Files changed

- `Source/VibeUE/Public/PythonAPI/UBlueprintService.h` — new `FBlueprintGraphInfo` USTRUCT + `ListGraphs` UFUNCTION declaration
- `Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp` — `ListGraphs` implementation (~41 lines)

## Python usage

```python
# Discover all graph tabs before querying nodes
for g in unreal.BlueprintService.list_graphs('/Game/Blueprints/Spaceships/BP_Ship'):
    print(f"{g.graph_kind:20}  {g.graph_name:35}  ({g.node_count} nodes)")

# Then target the right graph by name
nodes = unreal.BlueprintService.get_nodes_in_graph(
    '/Game/Blueprints/Spaceships/BP_Ship', 'Graph_PlayerInput')
```

**Verified output** against a real project Blueprint (UE 5.7):

```
Ubergraph             EventGraph                           (99 nodes)
Ubergraph             Graph_PlayerInput                    (378 nodes)
Ubergraph             Graph_Init                           (3 nodes)
Function              UserConstructionScript               (8 nodes)
DelegateSignature     OnPossessed                          (1 nodes)
```

## Notes

- Read-only introspection — no graph mutation, no compile triggered.
- Tested on UE 5.7. The four collections enumerated are stable across UE 5.x.
- `node_count` uses `Graph->Nodes.Num()` which is O(1) and does not load node assets.
