### PR TITLE
Merge 5-7 → master: add ListGraphs to BlueprintService

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -548,6 +548,47 @@ TArray<FBlueprintFunctionInfo> UBlueprintService::ListFunctions(const FString& B
 	return Functions;
 }
 
+TArray<FBlueprintGraphInfo> UBlueprintService::ListGraphs(const FString& BlueprintPath)
+{
+	TArray<FBlueprintGraphInfo> Graphs;
+
+	UBlueprint* Blueprint = LoadBlueprint(BlueprintPath);
+	if (!Blueprint)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("UBlueprintService::ListGraphs: Failed to load blueprint: %s"), *BlueprintPath);
+		return Graphs;
+	}
+
+	// Emit one FBlueprintGraphInfo per graph in a given collection
+	auto AppendGraphs = [&Graphs](const TArray<UEdGraph*>& Source, const TCHAR* Kind)
+	{
+		for (UEdGraph* Graph : Source)
+		{
+			if (!Graph)
+			{
+				continue;
+			}
+
+			FBlueprintGraphInfo Info;
+			Info.GraphName = Graph->GetName();
+			Info.GraphKind = Kind;
+			Info.NodeCount = Graph->Nodes.Num();
+			Graphs.Add(MoveTemp(Info));
+		}
+	};
+
+	// UbergraphPages = the event-graph tabs (default "EventGraph" + any user-added pages).
+	// FunctionGraphs = user functions, overrides, and auto-generated input event functions.
+	// MacroGraphs   = blueprint macros.
+	// DelegateSignatureGraphs = event dispatcher signature graphs.
+	AppendGraphs(Blueprint->UbergraphPages,          TEXT("Ubergraph"));
+	AppendGraphs(Blueprint->FunctionGraphs,          TEXT("Function"));
+	AppendGraphs(Blueprint->MacroGraphs,             TEXT("Macro"));
+	AppendGraphs(Blueprint->DelegateSignatureGraphs, TEXT("DelegateSignature"));
+
+	return Graphs;
+}
+
 bool UBlueprintService::OpenFunctionGraph(const FString& BlueprintPath, const FString& FunctionName)
 {
 	UBlueprint* Blueprint = LoadBlueprint(BlueprintPath);

--- a/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
+++ b/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
@@ -35,6 +35,29 @@ struct FBlueprintVariableInfo
 };
 
 /**
+ * Information about a single UEdGraph attached to a Blueprint.
+ * Returned by ListGraphs — one entry per graph tab visible in the
+ * Blueprint editor (ubergraph pages, functions, macros, delegate signatures).
+ */
+USTRUCT(BlueprintType)
+struct FBlueprintGraphInfo
+{
+	GENERATED_BODY()
+
+	/** Tab name as shown in the My Blueprint panel (e.g. "EventGraph", "Graph_PlayerInput", "MyFunction") */
+	UPROPERTY(BlueprintReadWrite, Category = "Blueprint")
+	FString GraphName;
+
+	/** "Ubergraph" | "Function" | "Macro" | "DelegateSignature" */
+	UPROPERTY(BlueprintReadWrite, Category = "Blueprint")
+	FString GraphKind;
+
+	/** Number of nodes in this graph (cheap to compute, useful as a sanity signal) */
+	UPROPERTY(BlueprintReadWrite, Category = "Blueprint")
+	int32 NodeCount = 0;
+};
+
+/**
  * Detailed information about a blueprint variable (for get_info action)
  */
 USTRUCT(BlueprintType)
@@ -984,6 +1007,26 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|Blueprints")
 	static TArray<FBlueprintFunctionInfo> ListFunctions(const FString& BlueprintPath);
+
+	/**
+	 * Enumerate every UEdGraph attached to a Blueprint — ubergraph pages, functions,
+	 * macros, and delegate signature graphs.
+	 *
+	 * Use this when you don't know the exact name of a graph tab. The default
+	 * Blueprint editor only exposes "EventGraph" by name; user-created ubergraph
+	 * pages (e.g. "Graph_PlayerInput") and inherited function graphs are invisible
+	 * without this enumeration.
+	 *
+	 * @param BlueprintPath - Full path to the blueprint (e.g., "/Game/Blueprints/BP_Player_Test")
+	 * @return Array of FBlueprintGraphInfo, one per graph
+	 *
+	 * Example:
+	 *   graphs = unreal.BlueprintService.list_graphs("/Game/Blueprints/BP_Player_Test")
+	 *   for g in graphs:
+	 *       print(f"{g.graph_kind:20}  {g.graph_name:30}  ({g.node_count} nodes)")
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Blueprints")
+	static TArray<FBlueprintGraphInfo> ListGraphs(const FString& BlueprintPath);
 
 	/**
 	 * Open a blueprint and navigate to a specific function graph.


### PR DESCRIPTION
## Summary
- Brings `5-7` up to `master` with the `BlueprintService::ListGraphs` feature (PR #404 by @kazeofkami)
- `ListGraphs(BlueprintPath)` enumerates every `UEdGraph` on a Blueprint (UbergraphPages / FunctionGraphs / MacroGraphs / DelegateSignatureGraphs), returning `FBlueprintGraphInfo { graph_name, graph_kind, node_count }` per graph
- Fixes silent-failure pattern where `get_nodes_in_graph` needed an exact graph tab name but user-created ubergraph pages were invisible to MCP callers (closes #403)

## Net change vs master
Two commits ahead, +84 LOC across 2 files (UBlueprintService.h/.cpp). Pure additive — no existing APIs touched, no behavior changes, read-only operation (no asset mutation).

## Test plan
- [ ] Build `SlashEditor` (Win64 Development) — verify UHT generates reflection for the new `FBlueprintGraphInfo` USTRUCT
- [ ] In a clean editor session, on any Blueprint with multiple ubergraph pages, call `unreal.BlueprintService.list_graphs("/Game/Blueprints/<asset>")` and confirm the returned array contains one entry per graph tab visible in the My Blueprint panel
- [ ] Spot-check the `graph_kind` values match `"Ubergraph" | "Function" | "Macro" | "DelegateSignature"`
- [ ] Confirm `node_count` matches what you see in the editor for at least one graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)