### PR TITLE
fix(proxy): fix stale setup guide paths and improve first-time setup routing

### DIFF
--- a/Content/Python/vibeue-proxy.py
+++ b/Content/Python/vibeue-proxy.py
@@ -96,22 +96,26 @@ def handle_vibeue_status(req_id) -> dict:
         )
     else:
         steps = []
-        if not ue_running:
-            steps.append("1. Launch Unreal Engine with the VibeUE plugin enabled.")
+        n = 1
         if not token_set:
             steps.append(
-                "2. Set a bearer token:\n"
-                "     a) Open vibeue-proxy.json (plugin root) and set \"bearer_token\": \"<your-token>\"\n"
-                "     b) In UE: Project Settings -> Plugins -> VibeUE -> API Key — set the same value.\n"
-                "     c) Restart the proxy after editing vibeue-proxy.json."
+                f"{n}. Set a bearer token:\n"
+                f"     a) Open Plugins/VibeUE/vibeue-proxy.json and set \"bearer_token\": \"<your-token>\"\n"
+                f"     b) In UE: Project Settings -> Plugins -> VibeUE -> API Key — set the same value.\n"
+                f"     c) Restart the proxy after editing vibeue-proxy.json."
             )
+            n += 1
+        if not ue_running:
+            steps.append(f"{n}. Launch Unreal Engine with the VibeUE plugin enabled.")
+            n += 1
         if not manifest_found:
             steps.append(
-                f"3. Launch UE once with VibeUE enabled to generate the tool manifest at:\n"
+                f"{n}. Launch UE once with VibeUE enabled to generate the tool manifest at:\n"
                 f"     {MANIFEST_PATH}"
             )
         text = (
-            "VibeUE setup incomplete. Complete the following steps:\n\n"
+            "VibeUE setup incomplete. For guided setup follow: Plugins/VibeUE/Content/Setup/Claude_MCP_Setup.md\n\n"
+            "Remaining steps:\n"
             + "\n".join(steps)
         )
 
@@ -320,13 +324,13 @@ def ue_error_response(req_id, tool_name: str, ue_message: str = "") -> dict:
             f"Unreal Engine rejected the request: {ue_message}\n"
             f"Check that the bearer token in Plugins/VibeUE/vibeue-proxy.json matches "
             f"UE Project Settings -> Plugins -> VibeUE -> API Key.\n"
-            f"For full setup instructions read: Plugins/VibeUE/VIBEUE_MCP_SETUP.md"
+            f"For full setup instructions read: Plugins/VibeUE/Content/Setup/Claude_MCP_Setup.md"
         )
     else:
         text = (
             f"Unreal Engine is not running.\n"
             f"Please launch UE with the VibeUE plugin enabled, then retry '{tool_name}'.\n"
-            f"If this is a first-time setup, read: Plugins/VibeUE/VIBEUE_MCP_SETUP.md"
+            f"If this is a first-time setup, follow: Plugins/VibeUE/Content/Setup/Claude_MCP_Setup.md"
         )
     return {
         "jsonrpc": "2.0",
@@ -426,7 +430,8 @@ class ProxyHandler(BaseHTTPRequestHandler):
                         "Quick-start rules: "
                         "(1) To inspect a Widget Blueprint, call execute_python_code immediately with unreal.WidgetService.get_widget_snapshot(path) — no skill or discovery step needed. "
                         "(2) To find/open/move assets, use manage_asset, not Python. "
-                        "(3) If tools are not working or this is a first-time setup, call vibeue_status."
+                        "(3) If this is a first-time setup, read Plugins/VibeUE/Content/Setup/Claude_MCP_Setup.md and follow it. "
+                        "If tools are not working after setup, call vibeue_status to diagnose."
                     ),
                 },
             })

--- a/Content/Python/vibeue-proxy.py
+++ b/Content/Python/vibeue-proxy.py
@@ -143,14 +143,25 @@ TOOL_HINTS: dict[str, str] = {
 
 IMMEDIATE ACTIONS — go straight to these, no skill or discovery step needed:
 
-  User asks to inspect / list / show / describe a Widget Blueprint (WBP):
+  User asks to list / show / describe components in a Widget Blueprint (WBP):
+      import unreal
+      components = unreal.WidgetService.list_components("/Game/path/WBP_X")
+      print(components)
+      Returns Array[WidgetInfo]: hierarchy + parent/child relationships, lightweight.
+      USE THIS as the default for "what's in this widget" questions.
+      DO NOT use get_hierarchy (names only) or get_widget_snapshot (full props, token-heavy) for hierarchy queries.
+
+  User needs widget PROPERTIES (bindings, slot anchors, visibility, is_variable etc.):
       import unreal
       snapshot = unreal.WidgetService.get_widget_snapshot("/Game/path/WBP_X")
       print(snapshot)
-      Returns full hierarchy + slot info + ALL properties in one call.
-      DO NOT call manage_asset, discover_python_class, or manage_skills first.
-      DO NOT use get_hierarchy (names only, forces extra round-trips).
-      Property access: snapshot.properties[i].property_name / .current_value
+      Returns full hierarchy + slot info + ALL properties — use only when property data is needed.
+      Snapshot format: flat list of widget dicts. children are NAME STRINGS, not nested objects.
+      Build a lookup dict to traverse:
+          lookup = {w["name"]: w for w in snapshot}
+          def children_of(name): return [lookup[c] for c in lookup[name]["children"] if c in lookup]
+      Property access: snapshot[i]["properties"] → list of {name, value} dicts
+      is_variable=True means the widget is a BindWidget target in C++.
 
   User asks to compile a Blueprint:
       import unreal
@@ -172,7 +183,7 @@ KEY RULES:
 SKILL INDEX — load BEFORE executing tasks in that domain:
 
 UI / Widgets
-  umg-widgets          → Widget Blueprint creation, widget inspection (get_widget_snapshot)
+  umg-widgets          → Widget Blueprint creation and authoring (get_widget_snapshot needs no skill)
 
 Blueprints
   blueprints           → Blueprint assets, variables, functions, components


### PR DESCRIPTION
## Summary

- **Stale path in `ue_error_response`**: updated from deleted `VIBEUE_MCP_SETUP.md` to `Content/Setup/Claude_MCP_Setup.md` (broken after the doc reorg in #407)
- **`vibeue_status` step ordering**: when setup is incomplete, now leads with the setup guide path and puts token setup before "launch UE" — Claude was blocking on "Unreal not running" even though the proxy can be fully configured without UE
- **`initialize` instructions rule (3)**: now points Claude to the setup guide for first-time setup instead of calling `vibeue_status`, which fed straight back into the "launch UE" block

## Test plan

- [ ] Fresh session with proxy running but UE not running — Claude should follow setup guide flow, not block on "launch UE"
- [ ] `vibeue_status` with token unset — should list token step before UE step
- [ ] `ue_error_response` path — verify it references `Content/Setup/Claude_MCP_Setup.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)