### PR TITLE
feat: add editor_control MCP tool and profiling skill

### DIFF
--- a/Content/Skills/profiling/SKILL.md
+++ b/Content/Skills/profiling/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: profiling
+display_name: Profiling & Performance
+description: Control Unreal Insights traces, sample live frame times, and annotate performance captures — all from Python with no C++ required
+unreal_classes:
+  - TraceUtilLibrary
+keywords:
+  - profiling
+  - performance
+  - trace
+  - unreal insights
+  - frame time
+  - fps
+  - cpu
+  - gpu
+  - memory
+  - frame rate
+  - bottleneck
+  - budget
+  - slow
+  - hitch
+  - spike
+  - benchmark
+  - capture
+  - utrace
+---
+
+# Profiling Skill
+
+Full Unreal Insights integration and live frame time sampling are available from Python
+with no C++ required. `TraceUtilLibrary` gives complete trace control;
+`register_ticker_callback` delivers real frame deltas every engine tick.
+
+## ⚠️ Gotchas — read before writing any code
+
+1. **`AutomationPerformaceHelper` crashes** — it requires a FunctionalTest outer world.
+   Do NOT instantiate it. Use the patterns in this skill instead.
+
+2. **Channel names use the `*Channel` suffix for `start_trace_to_file`** — pass
+   `'CpuChannel'` not `'Cpu'`. `get_enabled_channels()` returns short names (`'Cpu'`);
+   `get_all_channels()` returns full names (`'CpuChannel'`). They are the same channel,
+   just different representations.
+
+3. **`start_trace_to_file` adds default channels automatically** — even if you only
+   request `['FrameChannel']`, UE will also enable Gpu, Screenshot, Region, Bookmark,
+   Log, etc. You get more than you asked for; that's fine.
+
+4. **Trace files are large** — a ~10 second trace with default channels is 30–50 MB.
+   Store in `Saved/Profiling/` (already excluded from source control).
+
+5. **Ticker callback handle must stay in scope** — if the variable holding the handle
+   is garbage collected, the callback silently stops firing. Store in a module-level
+   variable or a list when doing multi-step sampling.
+
+6. **`is_tracing()` may return `True` briefly after `stop_tracing()`** — there is a
+   small flush delay. The `.utrace` file is valid and complete once stop returns `True`.
+
+---
+
+## Trace Control
+
+### Start a trace
+```python
+import unreal
+
+saved = unreal.Paths.project_saved_dir()  # relative, resolves to Saved/
+trace_path = saved + 'Profiling/my_capture'  # no extension — .utrace added automatically
+
+channels = ['FrameChannel', 'CpuChannel', 'GpuChannel', 'StatsChannel']
+ok = unreal.TraceUtilLibrary.start_trace_to_file(trace_path, channels)
+print('started:', ok)  # True on success
+print('is_tracing:', unreal.TraceUtilLibrary.is_tracing())
+```
+
+### Stop a trace
+```python
+import unreal
+ok = unreal.TraceUtilLibrary.stop_tracing()
+print('stopped:', ok)
+# File is at: <project>/Saved/Profiling/my_capture.utrace
+```
+
+### Pause / resume (keep file open, stop writing temporarily)
+```python
+unreal.TraceUtilLibrary.pause_tracing()
+# ... do something you don't want in the trace ...
+unreal.TraceUtilLibrary.resume_tracing()
+```
+
+### Check status and active channels
+```python
+import unreal
+print('tracing:', unreal.TraceUtilLibrary.is_tracing())
+enabled = [str(c) for c in unreal.TraceUtilLibrary.get_enabled_channels()]
+print('enabled:', enabled)
+```
+
+### Toggle a specific channel mid-trace
+```python
+unreal.TraceUtilLibrary.toggle_channel('MemAllocChannel', True)   # enable
+unreal.TraceUtilLibrary.toggle_channel('NiagaraChannel', False)  # disable
+```
+
+---
+
+## Annotations — Mark Regions and Bookmarks
+
+Use these **while tracing** to label interesting moments in the Unreal Insights timeline.
+
+```python
+import unreal
+
+# Single point-in-time bookmark (shows as a vertical line in Insights)
+unreal.TraceUtilLibrary.trace_bookmark('spawn_wave_3')
+
+# Named region (shows as a coloured span)
+unreal.TraceUtilLibrary.trace_mark_region_start('loading_level')
+# ... trigger the thing you want to measure ...
+unreal.TraceUtilLibrary.trace_mark_region_end('loading_level')
+
+# Screenshot embedded in the trace
+unreal.TraceUtilLibrary.trace_screenshot('before_explosion', show_ui=False)
+```
+
+---
+
+## Live Frame Time Sampling
+
+Use `register_ticker_callback` to collect real frame deltas over a duration.
+This is a **two-step pattern** because the callback fires asynchronously on engine ticks
+between Python requests.
+
+### Step 1 — Start sampling (call this first)
+```python
+import unreal
+
+_ft_samples = []
+_ft_handle = None
+
+def _frame_sampler(dt):
+    _ft_samples.append(dt)
+    return True  # keep ticking — stop by calling unregister or returning False
+
+_ft_handle = unreal.register_ticker_callback(_frame_sampler)
+print('sampling started, handle:', _ft_handle)
+```
+
+### Step 2 — Collect results (call after waiting N seconds)
+```python
+import unreal, statistics
+
+samples = _ft_samples[:]  # snapshot
+if _ft_handle:
+    unreal.unregister_ticker_callback(_ft_handle)
+
+if not samples:
+    print('no samples collected — did you wait long enough?')
+else:
+    ms = [s * 1000 for s in samples]
+    print(f'frames:  {len(ms)}')
+    print(f'avg:     {statistics.mean(ms):.2f} ms  ({1000/statistics.mean(ms):.1f} fps)')
+    print(f'median:  {statistics.median(ms):.2f} ms')
+    print(f'p95:     {sorted(ms)[int(len(ms)*0.95)]:.2f} ms')
+    print(f'max:     {max(ms):.2f} ms  (worst hitch)')
+    print(f'min:     {min(ms):.2f} ms')
+```
+
+### Single-call version (auto-stops after N frames)
+```python
+import unreal, statistics
+
+_samples = []
+_handle_ref = [None]
+
+def _sampler(dt):
+    _samples.append(dt * 1000)
+    if len(_samples) >= 300:  # ~5 sec at 60fps
+        return False  # unregisters automatically
+    return True
+
+_handle_ref[0] = unreal.register_ticker_callback(_sampler)
+print(f'collecting 300 frames... check _samples list when done')
+# In a follow-up call: analyse _samples
+```
+
+---
+
+## Channel Reference
+
+| Channel | What it captures | Use for |
+|---|---|---|
+| `FrameChannel` | Frame boundaries, wall time | Always include — baseline for everything |
+| `CpuChannel` | CPU named scopes (TRACE_CPUPROFILER_EVENT_SCOPE) | CPU hotspots, Blueprint tick |
+| `GpuChannel` | GPU pass timings | GPU bound? Where are draw calls going? |
+| `StatsChannel` | UE stat counters (stat unit values etc.) | Actor/component counts, frame budget |
+| `LogChannel` | Log output embedded in trace | Correlate log spam with frame spikes |
+| `MemAllocChannel` | Per-allocation callstacks | Memory churn, GC pressure |
+| `MemTagChannel` | High-level memory category totals | Which system is eating RAM? |
+| `ObjectChannel` | UObject create/destroy | Asset streaming, actor spawning |
+| `NiagaraChannel` | Niagara system tick | Particle perf |
+| `AnimationChannel` | Animation graph evaluation | Anim Blueprint cost |
+| `NetChannel` | Replication, RPC timing | Multiplayer performance |
+| `SlateChannel` | UI widget tick and paint | UI overhead |
+| `TaskChannel` | Task Graph threads | Async task scheduling |
+| `LoadTimeChannel` | Asset streaming / load events | Load hitches |
+| `BookmarkChannel` | `trace_bookmark()` calls | Always included when annotating |
+| `RegionChannel` | `trace_mark_region_*()` calls | Always included when annotating |
+| `ScreenshotChannel` | `trace_screenshot()` captures | Visual reference in Insights |
+
+---
+
+## Common Presets
+
+### General performance capture (balanced)
+```python
+channels = ['FrameChannel', 'CpuChannel', 'GpuChannel', 'StatsChannel', 'LogChannel']
+```
+
+### Memory investigation
+```python
+channels = ['FrameChannel', 'MemAllocChannel', 'MemTagChannel', 'ObjectChannel', 'LoadTimeChannel']
+```
+
+### Animation / character perf
+```python
+channels = ['FrameChannel', 'CpuChannel', 'AnimationChannel', 'StatsChannel']
+```
+
+### UI / Slate overhead
+```python
+channels = ['FrameChannel', 'CpuChannel', 'SlateChannel', 'StatsChannel']
+```
+
+### Niagara / VFX
+```python
+channels = ['FrameChannel', 'CpuChannel', 'GpuChannel', 'NiagaraChannel']
+```
+
+### Multiplayer / networking
+```python
+channels = ['FrameChannel', 'CpuChannel', 'NetChannel', 'StatsChannel']
+```
+
+### Load time / streaming hitches
+```python
+channels = ['FrameChannel', 'LoadTimeChannel', 'ObjectChannel', 'LogChannel']
+```
+
+---
+
+## Full Workflow Example
+
+```python
+import unreal, time
+
+saved = unreal.Paths.project_saved_dir()
+trace_path = saved + 'Profiling/combat_encounter'
+
+# Start
+channels = ['FrameChannel', 'CpuChannel', 'GpuChannel', 'StatsChannel', 'LogChannel']
+unreal.TraceUtilLibrary.start_trace_to_file(trace_path, channels)
+unreal.TraceUtilLibrary.trace_bookmark('capture_start')
+
+# Mark a region around the thing you care about
+unreal.TraceUtilLibrary.trace_mark_region_start('wave_spawn')
+# (trigger the gameplay here)
+unreal.TraceUtilLibrary.trace_mark_region_end('wave_spawn')
+
+unreal.TraceUtilLibrary.trace_bookmark('capture_end')
+unreal.TraceUtilLibrary.stop_tracing()
+
+import os
+abs_path = os.path.abspath(trace_path + '.utrace')
+size_mb = os.path.getsize(abs_path) / 1024 / 1024
+print(f'Trace saved: {abs_path}  ({size_mb:.1f} MB)')
+print('Open with: UnrealInsights.exe or from Editor > Tools > Run Unreal Insights')
+```
+
+---
+
+## Opening Traces
+
+Traces can be opened from within the editor:
+```
+Editor menu: Tools → Run Unreal Insights
+```
+
+Or from the command line:
+```
+"<UE install>/Engine/Binaries/Win64/UnrealInsights.exe" "<path>/my_capture.utrace"
+```
+
+The trace file path is always:
+```
+<project root>/Saved/Profiling/<name>.utrace
+```

--- a/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
+++ b/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
@@ -11,9 +11,6 @@
 #include "PlayInEditorDataTypes.h"
 #include "Editor.h"
 #include "HAL/PlatformProcess.h"
-#include "Windows/AllowWindowsPlatformTypes.h"
-#include <TlHelp32.h>
-#include "Windows/HideWindowsPlatformTypes.h"
 #include "TraceServices/ITraceServicesModule.h"
 #include "TraceServices/AnalysisService.h"
 #include "TraceServices/Model/AnalysisSession.h"
@@ -27,8 +24,9 @@ DEFINE_LOG_CATEGORY_STATIC(LogEditorControl, Log, All);
 
 static FString GLastTraceFilePath;
 static FString GLastLogFilePath;
-static bool    GStandaloneRunning = false;
-static uint32  GStandaloneProcessId = 0;
+static bool           GStandaloneRunning = false;
+static FProcHandle    GStandaloneProcess;
+static FDelegateHandle GStandalonePlayDelegateHandle;
 
 // ---------------------------------------------------------------------------
 // Param helpers
@@ -241,7 +239,13 @@ static FString AnalyseTrace(const FString& TraceFile)
 						}
 					});
 
-				double AvgMs = TotalMs / (double)FrameCount;
+				if (AllMs.IsEmpty())
+				{
+					Root->SetStringField(TEXT("warning"), TEXT("All frames were filtered (invalid timestamps) — no frame stats available."));
+				}
+				else
+				{
+				double AvgMs = TotalMs / (double)AllMs.Num();
 				Root->SetNumberField(TEXT("avg_frame_ms"), FMath::RoundToFloat(AvgMs * 100.0f) / 100.0f);
 				Root->SetNumberField(TEXT("avg_fps"), FMath::RoundToFloat(1000.0f / (float)AvgMs * 10.0f) / 10.0f);
 				Root->SetNumberField(TEXT("max_frame_ms"), FMath::RoundToFloat(MaxMs * 100.0f) / 100.0f);
@@ -252,6 +256,7 @@ static FString AnalyseTrace(const FString& TraceFile)
 				AllMs.Sort();
 				int32 P95Idx = FMath::Clamp((int32)(AllMs.Num() * 0.95), 0, AllMs.Num() - 1);
 				Root->SetNumberField(TEXT("p95_frame_ms"), FMath::RoundToFloat(AllMs[P95Idx] * 100.0f) / 100.0f);
+				} // end AllMs non-empty
 
 				// Worst 10 frames
 				TArray<TSharedPtr<FJsonValue>> WorstArr;
@@ -474,6 +479,15 @@ REGISTER_VIBEUE_TOOL(editor_control,
 			GEditor->RequestPlaySession(P);
 			GStandaloneRunning = true;
 
+			// Capture the child PID when the process starts so stop_standalone can
+			// terminate it without enumerating all system processes.
+			GStandalonePlayDelegateHandle = FEditorDelegates::BeginStandaloneLocalPlay.AddLambda([](uint32 PID)
+			{
+				GStandaloneProcess = FPlatformProcess::OpenProcess(PID);
+				FEditorDelegates::BeginStandaloneLocalPlay.Remove(GStandalonePlayDelegateHandle);
+				GStandalonePlayDelegateHandle.Reset();
+			});
+
 			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
 			R->SetStringField(TEXT("status"), TEXT("standalone start requested"));
 			R->SetStringField(TEXT("trace_file"), GLastTraceFilePath);
@@ -488,80 +502,32 @@ REGISTER_VIBEUE_TOOL(editor_control,
 			if (!GStandaloneRunning) return ErrJson(TEXT("NOT_RUNNING"), TEXT("No standalone session tracked. Did you call start_standalone?"));
 			if (GEditor) GEditor->RequestEndPlayMap();
 
-			// RequestEndPlayMap does not terminate a standalone (NewProcess) game.
-			// Find all UnrealEditor.exe instances that aren't us, send WM_CLOSE to their
-			// main window for a clean shutdown. Terminate as a fallback after 5 seconds.
+			// Remove the PID-capture delegate if the process never finished launching.
+			if (GStandalonePlayDelegateHandle.IsValid())
 			{
-				uint32 OurPID = FPlatformProcess::GetCurrentProcessId();
+				FEditorDelegates::BeginStandaloneLocalPlay.Remove(GStandalonePlayDelegateHandle);
+				GStandalonePlayDelegateHandle.Reset();
+			}
 
-				// Collect target PIDs
-				TArray<DWORD> TargetPIDs;
-				HANDLE hSnap = ::CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-				if (hSnap != INVALID_HANDLE_VALUE)
-				{
-					PROCESSENTRY32W Entry;
-					Entry.dwSize = sizeof(Entry);
-					if (::Process32FirstW(hSnap, &Entry))
-					{
-						do
-						{
-							if (FCString::Stricmp(Entry.szExeFile, TEXT("UnrealEditor.exe")) == 0
-								&& Entry.th32ProcessID != OurPID)
-							{
-								TargetPIDs.Add(Entry.th32ProcessID);
-							}
-						}
-						while (::Process32NextW(hSnap, &Entry));
-					}
-					::CloseHandle(hSnap);
-				}
-
-				// Send WM_CLOSE to each target's main window
-				struct FEnumData { TArray<DWORD>* PIDs; };
-				FEnumData EnumData{ &TargetPIDs };
-				::EnumWindows([](HWND hWnd, LPARAM lParam) -> BOOL
-				{
-					FEnumData* Data = reinterpret_cast<FEnumData*>(lParam);
-					DWORD WndPID = 0;
-					::GetWindowThreadProcessId(hWnd, &WndPID);
-					if (Data->PIDs->Contains(WndPID) && ::IsWindowVisible(hWnd))
-					{
-						::PostMessageW(hWnd, WM_CLOSE, 0, 0);
-					}
-					return 1; // TRUE
-				}, (LPARAM)&EnumData);
-
-				// Give it 5 seconds to exit cleanly, then force-terminate
+			// RequestEndPlayMap does not terminate a standalone (NewProcess) game.
+			// Use the handle captured from BeginStandaloneLocalPlay to wait for a clean
+			// exit (up to 5 s) then force-terminate if needed.
+			if (GStandaloneProcess.IsValid())
+			{
 				double StartTime = FPlatformTime::Seconds();
-				bool bDone = false;
-				while (!bDone && (FPlatformTime::Seconds() - StartTime) < 5.0)
+				while (FPlatformProcess::IsProcRunning(GStandaloneProcess)
+					   && (FPlatformTime::Seconds() - StartTime) < 5.0)
 				{
 					FPlatformProcess::Sleep(0.2f);
-					bDone = true;
-					for (DWORD PID : TargetPIDs)
-					{
-						HANDLE hProc = ::OpenProcess(SYNCHRONIZE, false, PID);
-						if (hProc)
-						{
-							bDone = (::WaitForSingleObject(hProc, 0) == WAIT_OBJECT_0);
-							::CloseHandle(hProc);
-							if (!bDone) break;
-						}
-					}
 				}
-
-				// Force-terminate anything still running
-				if (!bDone)
+				if (FPlatformProcess::IsProcRunning(GStandaloneProcess))
 				{
-					for (DWORD PID : TargetPIDs)
-					{
-						HANDLE hProc = ::OpenProcess(PROCESS_TERMINATE, false, PID);
-						if (hProc) { ::TerminateProcess(hProc, 0); ::CloseHandle(hProc); }
-					}
+					FPlatformProcess::TerminateProc(GStandaloneProcess);
 				}
+				FPlatformProcess::CloseProc(GStandaloneProcess);
 			}
+
 			GStandaloneRunning = false;
-			GStandaloneProcessId = 0;
 
 			// Prefer the UTS store — standalone uses -tracehost so the file lands there
 			FString UTSTrace = FindLatestUTSTrace();

--- a/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
+++ b/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
@@ -10,6 +10,10 @@
 #include "ProfilingDebugging/MiscTrace.h"
 #include "PlayInEditorDataTypes.h"
 #include "Editor.h"
+#include "HAL/PlatformProcess.h"
+#include "Windows/AllowWindowsPlatformTypes.h"
+#include <TlHelp32.h>
+#include "Windows/HideWindowsPlatformTypes.h"
 #include "TraceServices/ITraceServicesModule.h"
 #include "TraceServices/AnalysisService.h"
 #include "TraceServices/Model/AnalysisSession.h"
@@ -24,6 +28,7 @@ DEFINE_LOG_CATEGORY_STATIC(LogEditorControl, Log, All);
 static FString GLastTraceFilePath;
 static FString GLastLogFilePath;
 static bool    GStandaloneRunning = false;
+static uint32  GStandaloneProcessId = 0;
 
 // ---------------------------------------------------------------------------
 // Param helpers
@@ -349,17 +354,25 @@ static FString AnalyseBoth(const FString& TraceFile, const FString& LogFile)
 	FString TraceResult = AnalyseTrace(TraceFile);
 	FString LogResult   = AnalyseLogs(LogFile);
 
-	TSharedPtr<FJsonObject> TraceData, LogData;
-	TSharedRef<TJsonReader<>> TR = TJsonReaderFactory<>::Create(TraceResult);
-	TSharedRef<TJsonReader<>> LR = TJsonReaderFactory<>::Create(LogResult);
-	FJsonSerializer::Deserialize(TR, TraceData);
-	FJsonSerializer::Deserialize(LR, LogData);
+	auto ParseOrError = [](const FString& Json, const FString& Label) -> TSharedPtr<FJsonObject>
+	{
+		TSharedPtr<FJsonObject> Obj;
+		TSharedRef<TJsonReader<>> R = TJsonReaderFactory<>::Create(Json);
+		if (!FJsonSerializer::Deserialize(R, Obj) || !Obj.IsValid())
+		{
+			Obj = MakeShared<FJsonObject>();
+			Obj->SetBoolField(TEXT("success"), false);
+			Obj->SetStringField(TEXT("error"), FString::Printf(TEXT("%s result was not valid JSON"), *Label));
+			Obj->SetStringField(TEXT("raw"), Json.Left(200));
+		}
+		return Obj;
+	};
 
 	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
 	Root->SetBoolField(TEXT("success"), true);
 	Root->SetStringField(TEXT("source"), TEXT("both"));
-	if (TraceData.IsValid()) Root->SetObjectField(TEXT("trace"), TraceData);
-	if (LogData.IsValid())   Root->SetObjectField(TEXT("logs"),  LogData);
+	Root->SetObjectField(TEXT("trace"), ParseOrError(TraceResult, TEXT("trace")));
+	Root->SetObjectField(TEXT("logs"),  ParseOrError(LogResult,   TEXT("logs")));
 
 	FString Out;
 	TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
@@ -468,7 +481,38 @@ REGISTER_VIBEUE_TOOL(editor_control,
 		{
 			if (!GStandaloneRunning) return ErrJson(TEXT("NOT_RUNNING"), TEXT("No standalone session tracked. Did you call start_standalone?"));
 			if (GEditor) GEditor->RequestEndPlayMap();
+
+			// RequestEndPlayMap does not terminate a standalone (NewProcess) game.
+			// Scan for UnrealEditor.exe processes, exclude our own PID, kill any others.
+			{
+				uint32 OurPID = FPlatformProcess::GetCurrentProcessId();
+				HANDLE hSnap = ::CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+				if (hSnap != INVALID_HANDLE_VALUE)
+				{
+					PROCESSENTRY32W Entry;
+					Entry.dwSize = sizeof(Entry);
+					if (::Process32FirstW(hSnap, &Entry))
+					{
+						do
+						{
+							if (FCString::Stricmp(Entry.szExeFile, TEXT("UnrealEditor.exe")) == 0
+								&& Entry.th32ProcessID != OurPID)
+							{
+								HANDLE hProc = ::OpenProcess(PROCESS_TERMINATE, false, Entry.th32ProcessID);
+								if (hProc)
+								{
+									::TerminateProcess(hProc, 0);
+									::CloseHandle(hProc);
+								}
+							}
+						}
+						while (::Process32NextW(hSnap, &Entry));
+					}
+					::CloseHandle(hSnap);
+				}
+			}
 			GStandaloneRunning = false;
+			GStandaloneProcessId = 0;
 
 			// Prefer the UTS store — standalone uses -tracehost so the file lands there
 			FString UTSTrace = FindLatestUTSTrace();

--- a/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
+++ b/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
@@ -31,10 +31,24 @@ static bool    GStandaloneRunning = false;
 
 static FString GetParam(const TMap<FString, FString>& Params, const FString& Key, const FString& Default = TEXT(""))
 {
+	// Direct key
 	if (const FString* V = Params.Find(Key)) return *V;
+	// Capitalized variant (MCPServer capitalizes "action" → "Action")
 	FString Cap = Key;
 	if (Cap.Len() > 0) Cap[0] = FChar::ToUpper(Cap[0]);
 	if (const FString* V = Params.Find(Cap)) return *V;
+	// Remaining params are packed into ParamsJson by MCPServer when an action key is present
+	const FString* JsonStr = Params.Find(TEXT("ParamsJson"));
+	if (JsonStr)
+	{
+		TSharedPtr<FJsonObject> Obj;
+		TSharedRef<TJsonReader<>> R = TJsonReaderFactory<>::Create(*JsonStr);
+		if (FJsonSerializer::Deserialize(R, Obj) && Obj.IsValid())
+		{
+			FString Val;
+			if (Obj->TryGetStringField(Key, Val)) return Val;
+		}
+	}
 	return Default;
 }
 
@@ -88,9 +102,14 @@ static const TCHAR* DefaultTraceChannels()
 	return TEXT("frame,cpu,gpu,log,loadtime,object,stats,bookmark,region");
 }
 
+static FString ProjectSavedDirAbs()
+{
+	return FPaths::ConvertRelativePathToFull(FPaths::ProjectSavedDir());
+}
+
 static FString BuildTraceFilePath(const FString& Name)
 {
-	FString Dir = FPaths::ProjectSavedDir() / TEXT("Profiling");
+	FString Dir = ProjectSavedDirAbs() / TEXT("Profiling");
 	IPlatformFile::GetPlatformPhysical().CreateDirectoryTree(*Dir);
 	return Dir / Name;
 }
@@ -331,7 +350,7 @@ REGISTER_VIBEUE_TOOL(editor_control,
 			GEditor->RequestPlaySession(P);
 
 			// Record the log file path for this session
-			GLastLogFilePath = FPaths::ProjectSavedDir() / TEXT("Logs") / (FApp::GetProjectName() + FString(TEXT(".log")));
+			GLastLogFilePath = ProjectSavedDirAbs() / TEXT("Logs") / (FApp::GetProjectName() + FString(TEXT(".log")));
 
 			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
 			R->SetStringField(TEXT("status"), TEXT("PIE start requested"));
@@ -369,7 +388,7 @@ REGISTER_VIBEUE_TOOL(editor_control,
 			FString Channels  = GetParam(Params, TEXT("channels"), DefaultTraceChannels());
 			FString TracePath = BuildTraceFilePath(TraceName);
 			GLastTraceFilePath = TracePath + TEXT(".utrace");
-			GLastLogFilePath   = FPaths::ProjectSavedDir() / TEXT("Logs") / (FApp::GetProjectName() + FString(TEXT(".log")));
+			GLastLogFilePath   = ProjectSavedDirAbs() / TEXT("Logs") / (FApp::GetProjectName() + FString(TEXT(".log")));
 
 			// Standalone receives trace channels via -trace= and connects back to the
 			// editor's Unreal Trace Server on localhost:1985
@@ -425,7 +444,7 @@ REGISTER_VIBEUE_TOOL(editor_control,
 			FString Channels  = GetParam(Params, TEXT("channels"), DefaultTraceChannels());
 			FString TracePath = BuildTraceFilePath(TraceName);
 			GLastTraceFilePath = TracePath + TEXT(".utrace");
-			GLastLogFilePath   = FPaths::ProjectSavedDir() / TEXT("Logs") / (FApp::GetProjectName() + FString(TEXT(".log")));
+			GLastLogFilePath   = ProjectSavedDirAbs() / TEXT("Logs") / (FApp::GetProjectName() + FString(TEXT(".log")));
 
 			if (FTraceAuxiliary::IsConnected())
 			{
@@ -532,7 +551,7 @@ REGISTER_VIBEUE_TOOL(editor_control,
 
 			if (LogFile.IsEmpty())
 			{
-				LogFile = FPaths::ProjectSavedDir() / TEXT("Logs") / (FApp::GetProjectName() + FString(TEXT(".log")));
+				LogFile = ProjectSavedDirAbs() / TEXT("Logs") / (FApp::GetProjectName() + FString(TEXT(".log")));
 			}
 
 			if (Source == TEXT("trace"))

--- a/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
+++ b/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
@@ -227,7 +227,10 @@ static FString AnalyseTrace(const FString& TraceFile)
 				Frames->EnumerateFrames(ETraceFrameType::TraceFrameType_Game, 0, FrameCount,
 					[&](const TraceServices::FFrame& F)
 					{
+						// Skip frames with no valid end time (trace cut mid-frame)
+						if (F.EndTime <= F.StartTime) return;
 						double DurationMs = (F.EndTime - F.StartTime) * 1000.0;
+						if (!FMath::IsFinite(DurationMs) || DurationMs > 120000.0) return;
 						AllMs.Add(DurationMs);
 						TotalMs += DurationMs;
 						if (DurationMs > MaxMs)
@@ -259,7 +262,10 @@ static FString AnalyseTrace(const FString& TraceFile)
 				Frames->EnumerateFrames(ETraceFrameType::TraceFrameType_Game, 0, FrameCount,
 					[&](const TraceServices::FFrame& F)
 					{
-						Entries.Add({ (F.EndTime - F.StartTime) * 1000.0, F.Index, F.StartTime });
+						if (F.EndTime <= F.StartTime) return;
+						double Ms = (F.EndTime - F.StartTime) * 1000.0;
+						if (!FMath::IsFinite(Ms) || Ms > 120000.0) return;
+						Entries.Add({ Ms, F.Index, F.StartTime });
 					});
 				Entries.Sort([](const FFrameEntry& A, const FFrameEntry& B) { return A.Ms > B.Ms; });
 				int32 WorstCount = FMath::Min(10, Entries.Num());
@@ -517,6 +523,27 @@ REGISTER_VIBEUE_TOOL(editor_control,
 			// Prefer the UTS store — standalone uses -tracehost so the file lands there
 			FString UTSTrace = FindLatestUTSTrace();
 			if (!UTSTrace.IsEmpty()) GLastTraceFilePath = UTSTrace;
+
+			// Standalone writes its own log (e.g. PROTEUS_2.log) — find the newest one
+			{
+				FString LogDir = ProjectSavedDirAbs() / TEXT("Logs");
+				FString NewestLog;
+				FDateTime NewestTime = FDateTime::MinValue();
+				IFileManager::Get().IterateDirectory(*LogDir, [&](const TCHAR* Path, bool bDir) -> bool
+				{
+					if (!bDir && FPaths::GetExtension(Path).Equals(TEXT("log"), ESearchCase::IgnoreCase))
+					{
+						FString Fname = FPaths::GetCleanFilename(Path);
+						if (!Fname.Contains(TEXT("backup")) && !Fname.Contains(TEXT("cef")))
+						{
+							FDateTime T = IFileManager::Get().GetTimeStamp(Path);
+							if (T > NewestTime) { NewestTime = T; NewestLog = Path; }
+						}
+					}
+					return true;
+				});
+				if (!NewestLog.IsEmpty()) GLastLogFilePath = NewestLog;
+			}
 
 			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
 			R->SetStringField(TEXT("status"),     TEXT("standalone stop requested"));

--- a/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
+++ b/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
@@ -489,9 +489,13 @@ REGISTER_VIBEUE_TOOL(editor_control,
 			if (GEditor) GEditor->RequestEndPlayMap();
 
 			// RequestEndPlayMap does not terminate a standalone (NewProcess) game.
-			// Scan for UnrealEditor.exe processes, exclude our own PID, kill any others.
+			// Find all UnrealEditor.exe instances that aren't us, send WM_CLOSE to their
+			// main window for a clean shutdown. Terminate as a fallback after 5 seconds.
 			{
 				uint32 OurPID = FPlatformProcess::GetCurrentProcessId();
+
+				// Collect target PIDs
+				TArray<DWORD> TargetPIDs;
 				HANDLE hSnap = ::CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
 				if (hSnap != INVALID_HANDLE_VALUE)
 				{
@@ -504,17 +508,56 @@ REGISTER_VIBEUE_TOOL(editor_control,
 							if (FCString::Stricmp(Entry.szExeFile, TEXT("UnrealEditor.exe")) == 0
 								&& Entry.th32ProcessID != OurPID)
 							{
-								HANDLE hProc = ::OpenProcess(PROCESS_TERMINATE, false, Entry.th32ProcessID);
-								if (hProc)
-								{
-									::TerminateProcess(hProc, 0);
-									::CloseHandle(hProc);
-								}
+								TargetPIDs.Add(Entry.th32ProcessID);
 							}
 						}
 						while (::Process32NextW(hSnap, &Entry));
 					}
 					::CloseHandle(hSnap);
+				}
+
+				// Send WM_CLOSE to each target's main window
+				struct FEnumData { TArray<DWORD>* PIDs; };
+				FEnumData EnumData{ &TargetPIDs };
+				::EnumWindows([](HWND hWnd, LPARAM lParam) -> BOOL
+				{
+					FEnumData* Data = reinterpret_cast<FEnumData*>(lParam);
+					DWORD WndPID = 0;
+					::GetWindowThreadProcessId(hWnd, &WndPID);
+					if (Data->PIDs->Contains(WndPID) && ::IsWindowVisible(hWnd))
+					{
+						::PostMessageW(hWnd, WM_CLOSE, 0, 0);
+					}
+					return 1; // TRUE
+				}, (LPARAM)&EnumData);
+
+				// Give it 5 seconds to exit cleanly, then force-terminate
+				double StartTime = FPlatformTime::Seconds();
+				bool bDone = false;
+				while (!bDone && (FPlatformTime::Seconds() - StartTime) < 5.0)
+				{
+					FPlatformProcess::Sleep(0.2f);
+					bDone = true;
+					for (DWORD PID : TargetPIDs)
+					{
+						HANDLE hProc = ::OpenProcess(SYNCHRONIZE, false, PID);
+						if (hProc)
+						{
+							bDone = (::WaitForSingleObject(hProc, 0) == WAIT_OBJECT_0);
+							::CloseHandle(hProc);
+							if (!bDone) break;
+						}
+					}
+				}
+
+				// Force-terminate anything still running
+				if (!bDone)
+				{
+					for (DWORD PID : TargetPIDs)
+					{
+						HANDLE hProc = ::OpenProcess(PROCESS_TERMINATE, false, PID);
+						if (hProc) { ::TerminateProcess(hProc, 0); ::CloseHandle(hProc); }
+					}
 				}
 			}
 			GStandaloneRunning = false;

--- a/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
+++ b/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
@@ -1,0 +1,598 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#include "Core/ToolRegistry.h"
+#include "Json.h"
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "HAL/FileManager.h"
+#include "Modules/ModuleManager.h"
+#include "ProfilingDebugging/TraceAuxiliary.h"
+#include "ProfilingDebugging/MiscTrace.h"
+#include "PlayInEditorDataTypes.h"
+#include "Editor.h"
+#include "TraceServices/ITraceServicesModule.h"
+#include "TraceServices/AnalysisService.h"
+#include "TraceServices/Model/AnalysisSession.h"
+#include "TraceServices/Model/Frames.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogEditorControl, Log, All);
+
+// ---------------------------------------------------------------------------
+// Session state — persists across MCP requests within an editor session
+// ---------------------------------------------------------------------------
+
+static FString GLastTraceFilePath;
+static FString GLastLogFilePath;
+static bool    GStandaloneRunning = false;
+
+// ---------------------------------------------------------------------------
+// Param helpers
+// ---------------------------------------------------------------------------
+
+static FString GetParam(const TMap<FString, FString>& Params, const FString& Key, const FString& Default = TEXT(""))
+{
+	if (const FString* V = Params.Find(Key)) return *V;
+	FString Cap = Key;
+	if (Cap.Len() > 0) Cap[0] = FChar::ToUpper(Cap[0]);
+	if (const FString* V = Params.Find(Cap)) return *V;
+	return Default;
+}
+
+static bool GetBoolParam(const TMap<FString, FString>& Params, const FString& Key, bool Default = false)
+{
+	FString V = GetParam(Params, Key);
+	if (V.IsEmpty()) return Default;
+	return V.Equals(TEXT("true"), ESearchCase::IgnoreCase) || V == TEXT("1");
+}
+
+// ---------------------------------------------------------------------------
+// JSON response helpers
+// ---------------------------------------------------------------------------
+
+static FString OkJson(TSharedPtr<FJsonObject> Obj)
+{
+	Obj->SetBoolField(TEXT("success"), true);
+	FString Out;
+	TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+	FJsonSerializer::Serialize(Obj.ToSharedRef(), W);
+	return Out;
+}
+
+static FString ErrJson(const FString& Code, const FString& Msg)
+{
+	TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+	Obj->SetBoolField(TEXT("success"), false);
+	Obj->SetStringField(TEXT("error_code"), Code);
+	Obj->SetStringField(TEXT("error"), Msg);
+	FString Out;
+	TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+	FJsonSerializer::Serialize(Obj.ToSharedRef(), W);
+	return Out;
+}
+
+// ---------------------------------------------------------------------------
+// PIE helpers
+// ---------------------------------------------------------------------------
+
+static bool IsPIERunning()
+{
+	return GEditor && GEditor->PlayWorld != nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Default channel set
+// ---------------------------------------------------------------------------
+
+static const TCHAR* DefaultTraceChannels()
+{
+	return TEXT("frame,cpu,gpu,log,loadtime,object,stats,bookmark,region");
+}
+
+static FString BuildTraceFilePath(const FString& Name)
+{
+	FString Dir = FPaths::ProjectSavedDir() / TEXT("Profiling");
+	IPlatformFile::GetPlatformPhysical().CreateDirectoryTree(*Dir);
+	return Dir / Name;
+}
+
+// ---------------------------------------------------------------------------
+// Trace analysis
+// ---------------------------------------------------------------------------
+
+static FString AnalyseTrace(const FString& TraceFile)
+{
+	if (!FPaths::FileExists(TraceFile))
+	{
+		return ErrJson(TEXT("FILE_NOT_FOUND"), FString::Printf(TEXT("Trace file not found: %s"), *TraceFile));
+	}
+
+	ITraceServicesModule* TraceModule = FModuleManager::LoadModulePtr<ITraceServicesModule>("TraceServices");
+	if (!TraceModule)
+	{
+		return ErrJson(TEXT("MODULE_NOT_FOUND"), TEXT("TraceServices module not available."));
+	}
+
+	TSharedPtr<TraceServices::IAnalysisService> AnalysisService = TraceModule->GetAnalysisService();
+	if (!AnalysisService)
+	{
+		return ErrJson(TEXT("SERVICE_NOT_FOUND"), TEXT("Could not get TraceServices analysis service."));
+	}
+
+	UE_LOG(LogEditorControl, Log, TEXT("Analysing trace: %s"), *TraceFile);
+	TSharedPtr<const TraceServices::IAnalysisSession> Session = AnalysisService->Analyze(*TraceFile);
+	if (!Session)
+	{
+		return ErrJson(TEXT("ANALYSIS_FAILED"), TEXT("Failed to analyse trace file."));
+	}
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("trace_file"), TraceFile);
+	Root->SetNumberField(TEXT("duration_seconds"), Session->GetDurationSeconds());
+
+	// --- Frame analysis ---
+	{
+		TraceServices::FAnalysisSessionReadScope Scope(*Session);
+		const TraceServices::IFrameProvider* Frames = Session->ReadProvider<TraceServices::IFrameProvider>(TraceServices::GetFrameProviderName());
+
+		if (Frames)
+		{
+			uint64 FrameCount = Frames->GetFrameCount(ETraceFrameType::TraceFrameType_Game);
+			Root->SetNumberField(TEXT("frame_count"), (double)FrameCount);
+
+			if (FrameCount > 0)
+			{
+				double TotalMs = 0.0;
+				double MaxMs = 0.0;
+				uint64 MaxFrame = 0;
+				double MaxFrameTime = 0.0;
+				TArray<double> AllMs;
+				AllMs.Reserve((int32)FMath::Min(FrameCount, (uint64)10000));
+
+				Frames->EnumerateFrames(ETraceFrameType::TraceFrameType_Game, 0, FrameCount,
+					[&](const TraceServices::FFrame& F)
+					{
+						double DurationMs = (F.EndTime - F.StartTime) * 1000.0;
+						AllMs.Add(DurationMs);
+						TotalMs += DurationMs;
+						if (DurationMs > MaxMs)
+						{
+							MaxMs = DurationMs;
+							MaxFrame = F.Index;
+							MaxFrameTime = F.StartTime;
+						}
+					});
+
+				double AvgMs = TotalMs / (double)FrameCount;
+				Root->SetNumberField(TEXT("avg_frame_ms"), FMath::RoundToFloat(AvgMs * 100.0f) / 100.0f);
+				Root->SetNumberField(TEXT("avg_fps"), FMath::RoundToFloat(1000.0f / (float)AvgMs * 10.0f) / 10.0f);
+				Root->SetNumberField(TEXT("max_frame_ms"), FMath::RoundToFloat(MaxMs * 100.0f) / 100.0f);
+				Root->SetNumberField(TEXT("max_frame_index"), (double)MaxFrame);
+				Root->SetNumberField(TEXT("max_frame_timestamp"), MaxFrameTime);
+
+				// p95
+				AllMs.Sort();
+				int32 P95Idx = FMath::Clamp((int32)(AllMs.Num() * 0.95), 0, AllMs.Num() - 1);
+				Root->SetNumberField(TEXT("p95_frame_ms"), FMath::RoundToFloat(AllMs[P95Idx] * 100.0f) / 100.0f);
+
+				// Worst 10 frames
+				TArray<TSharedPtr<FJsonValue>> WorstArr;
+				// Re-enumerate to find top 10 — build sorted list of (ms, index, time)
+				struct FFrameEntry { double Ms; uint64 Index; double StartTime; };
+				TArray<FFrameEntry> Entries;
+				Entries.Reserve((int32)FMath::Min(FrameCount, (uint64)10000));
+				Frames->EnumerateFrames(ETraceFrameType::TraceFrameType_Game, 0, FrameCount,
+					[&](const TraceServices::FFrame& F)
+					{
+						Entries.Add({ (F.EndTime - F.StartTime) * 1000.0, F.Index, F.StartTime });
+					});
+				Entries.Sort([](const FFrameEntry& A, const FFrameEntry& B) { return A.Ms > B.Ms; });
+				int32 WorstCount = FMath::Min(10, Entries.Num());
+				for (int32 i = 0; i < WorstCount; ++i)
+				{
+					TSharedPtr<FJsonObject> FObj = MakeShared<FJsonObject>();
+					FObj->SetNumberField(TEXT("frame"), (double)Entries[i].Index);
+					FObj->SetNumberField(TEXT("ms"), FMath::RoundToFloat(Entries[i].Ms * 100.0f) / 100.0f);
+					FObj->SetNumberField(TEXT("timestamp"), Entries[i].StartTime);
+					WorstArr.Add(MakeShared<FJsonValueObject>(FObj));
+				}
+				Root->SetArrayField(TEXT("worst_frames"), WorstArr);
+			}
+		}
+	}
+
+	return OkJson(Root);
+}
+
+// ---------------------------------------------------------------------------
+// Log analysis
+// ---------------------------------------------------------------------------
+
+static FString AnalyseLogs(const FString& LogFile)
+{
+	FString Content;
+	if (!FFileHelper::LoadFileToString(Content, *LogFile))
+	{
+		return ErrJson(TEXT("LOG_NOT_FOUND"), FString::Printf(TEXT("Log file not found: %s"), *LogFile));
+	}
+
+	TArray<FString> Lines;
+	Content.ParseIntoArrayLines(Lines);
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("log_file"), LogFile);
+	Root->SetNumberField(TEXT("total_lines"), Lines.Num());
+
+	TArray<TSharedPtr<FJsonValue>> Notable;
+	int32 PSOHitches = 0;
+	int32 ErrorCount = 0;
+	int32 WarningCount = 0;
+
+	static const TArray<FString> NotablePatterns = {
+		TEXT("hitch"), TEXT("Hitch"),
+		TEXT("PSO"), TEXT("RTPSO"),
+		TEXT("blocking load"), TEXT("Blocking Load"),
+		TEXT("took "), TEXT(" ms."),
+		TEXT("LogShaderCompilers"), TEXT("NiagaraSystem"),
+		TEXT("async load"), TEXT("Async Load"),
+		TEXT("streamable"), TEXT("Streamable"),
+		TEXT("OutOfMemory"), TEXT("out of memory"),
+	};
+
+	for (const FString& Line : Lines)
+	{
+		bool bError   = Line.Contains(TEXT("] Error:"))   || Line.Contains(TEXT(":Error:"));
+		bool bWarning = Line.Contains(TEXT("] Warning:")) || Line.Contains(TEXT(":Warning:"));
+		if (bError)   ++ErrorCount;
+		if (bWarning) ++WarningCount;
+
+		if (Line.Contains(TEXT("PSO creation hitch"))) ++PSOHitches;
+
+		bool bNotable = bError;
+		if (!bNotable)
+		{
+			for (const FString& Pat : NotablePatterns)
+			{
+				if (Line.Contains(Pat)) { bNotable = true; break; }
+			}
+		}
+		if (bNotable && Notable.Num() < 40)
+		{
+			Notable.Add(MakeShared<FJsonValueString>(Line.TrimStartAndEnd()));
+		}
+	}
+
+	Root->SetNumberField(TEXT("errors"), ErrorCount);
+	Root->SetNumberField(TEXT("warnings"), WarningCount);
+	Root->SetNumberField(TEXT("pso_hitches"), PSOHitches);
+	Root->SetArrayField(TEXT("notable_lines"), Notable);
+
+	return OkJson(Root);
+}
+
+// ---------------------------------------------------------------------------
+// Combined analyse — merges trace + log into one report
+// ---------------------------------------------------------------------------
+
+static FString AnalyseBoth(const FString& TraceFile, const FString& LogFile)
+{
+	FString TraceResult = AnalyseTrace(TraceFile);
+	FString LogResult   = AnalyseLogs(LogFile);
+
+	TSharedPtr<FJsonObject> TraceData, LogData;
+	TSharedRef<TJsonReader<>> TR = TJsonReaderFactory<>::Create(TraceResult);
+	TSharedRef<TJsonReader<>> LR = TJsonReaderFactory<>::Create(LogResult);
+	FJsonSerializer::Deserialize(TR, TraceData);
+	FJsonSerializer::Deserialize(LR, LogData);
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetBoolField(TEXT("success"), true);
+	Root->SetStringField(TEXT("source"), TEXT("both"));
+	if (TraceData.IsValid()) Root->SetObjectField(TEXT("trace"), TraceData);
+	if (LogData.IsValid())   Root->SetObjectField(TEXT("logs"),  LogData);
+
+	FString Out;
+	TSharedRef<TJsonWriter<>> W = TJsonWriterFactory<>::Create(&Out);
+	FJsonSerializer::Serialize(Root.ToSharedRef(), W);
+	return Out;
+}
+
+// ---------------------------------------------------------------------------
+// Tool registration
+// ---------------------------------------------------------------------------
+
+REGISTER_VIBEUE_TOOL(editor_control,
+	"Control the Unreal Editor and profiler. Actions: start_pie, stop_pie, pie_status, "
+	"start_standalone (launches game as separate process with trace attached), stop_standalone, standalone_status, "
+	"profiler_start (begin Unreal Insights trace to file), profiler_stop, profiler_status, "
+	"profiler_bookmark (drop named point in trace), profiler_region_start, profiler_region_end, "
+	"analyse (read trace + logs and return perf summary — source: trace|logs|both), help.",
+	"Editor",
+	TOOL_PARAMS(
+		TOOL_PARAM("action",   "Action to perform — see tool description for full list", "string", true),
+		TOOL_PARAM("name",     "[profiler_start|bookmark|region_*] Trace file name (profiler_start) or label (bookmark/region)", "string", false),
+		TOOL_PARAM("channels", "[profiler_start|start_standalone] Comma-separated trace channels. Default: frame,cpu,gpu,log,loadtime,object,stats", "string", false),
+		TOOL_PARAM("source",   "[analyse] What to read: trace, logs, or both (default: both)", "string", false),
+		TOOL_PARAM("file",     "[analyse] Override trace or log file path", "string", false)
+	),
+	{
+		FString Action = GetParam(Params, TEXT("action")).ToLower();
+
+		// -----------------------------------------------------------------------
+		// PIE
+		// -----------------------------------------------------------------------
+		if (Action == TEXT("start_pie"))
+		{
+			if (!GEditor) return ErrJson(TEXT("NO_EDITOR"), TEXT("GEditor not available."));
+			if (IsPIERunning()) return ErrJson(TEXT("ALREADY_RUNNING"), TEXT("PIE is already running. Call stop_pie first."));
+
+			FRequestPlaySessionParams P;
+			P.SessionDestination = EPlaySessionDestinationType::InProcess;
+			P.WorldType = EPlaySessionWorldType::PlayInEditor;
+			GEditor->RequestPlaySession(P);
+
+			// Record the log file path for this session
+			GLastLogFilePath = FPaths::ProjectSavedDir() / TEXT("Logs") / (FApp::GetProjectName() + FString(TEXT(".log")));
+
+			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+			R->SetStringField(TEXT("status"), TEXT("PIE start requested"));
+			R->SetStringField(TEXT("log_file"), GLastLogFilePath);
+			return OkJson(R);
+		}
+
+		if (Action == TEXT("stop_pie"))
+		{
+			if (!GEditor) return ErrJson(TEXT("NO_EDITOR"), TEXT("GEditor not available."));
+			if (!IsPIERunning()) return ErrJson(TEXT("NOT_RUNNING"), TEXT("PIE is not running."));
+			GEditor->RequestEndPlayMap();
+			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+			R->SetStringField(TEXT("status"), TEXT("PIE stop requested"));
+			return OkJson(R);
+		}
+
+		if (Action == TEXT("pie_status"))
+		{
+			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+			R->SetBoolField(TEXT("running"), IsPIERunning());
+			R->SetStringField(TEXT("status"), IsPIERunning() ? TEXT("running") : TEXT("stopped"));
+			return OkJson(R);
+		}
+
+		// -----------------------------------------------------------------------
+		// Standalone
+		// -----------------------------------------------------------------------
+		if (Action == TEXT("start_standalone"))
+		{
+			if (!GEditor) return ErrJson(TEXT("NO_EDITOR"), TEXT("GEditor not available."));
+			if (GStandaloneRunning) return ErrJson(TEXT("ALREADY_RUNNING"), TEXT("Standalone is already running. Call stop_standalone first."));
+
+			FString TraceName = GetParam(Params, TEXT("name"), TEXT("standalone_capture"));
+			FString Channels  = GetParam(Params, TEXT("channels"), DefaultTraceChannels());
+			FString TracePath = BuildTraceFilePath(TraceName);
+			GLastTraceFilePath = TracePath + TEXT(".utrace");
+			GLastLogFilePath   = FPaths::ProjectSavedDir() / TEXT("Logs") / (FApp::GetProjectName() + FString(TEXT(".log")));
+
+			// Standalone receives trace channels via -trace= and connects back to the
+			// editor's Unreal Trace Server on localhost:1985
+			FString ExtraArgs = FString::Printf(
+				TEXT("-tracehost=127.0.0.1 -trace=%s -tracefile=\"%s\""),
+				*Channels, *TracePath);
+
+			FRequestPlaySessionParams P;
+			P.SessionDestination = EPlaySessionDestinationType::NewProcess;
+			P.WorldType = EPlaySessionWorldType::PlayInEditor;
+			P.AdditionalStandaloneCommandLineParameters = ExtraArgs;
+			GEditor->RequestPlaySession(P);
+			GStandaloneRunning = true;
+
+			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+			R->SetStringField(TEXT("status"), TEXT("standalone start requested"));
+			R->SetStringField(TEXT("trace_file"), GLastTraceFilePath);
+			R->SetStringField(TEXT("log_file"),   GLastLogFilePath);
+			R->SetStringField(TEXT("channels"),   Channels);
+			R->SetStringField(TEXT("hint"), TEXT("Call stop_standalone when done, then analyse to read results."));
+			return OkJson(R);
+		}
+
+		if (Action == TEXT("stop_standalone"))
+		{
+			if (!GStandaloneRunning) return ErrJson(TEXT("NOT_RUNNING"), TEXT("No standalone session tracked. Did you call start_standalone?"));
+			if (GEditor) GEditor->RequestEndPlayMap();
+			GStandaloneRunning = false;
+
+			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+			R->SetStringField(TEXT("status"), TEXT("standalone stop requested"));
+			R->SetStringField(TEXT("trace_file"), GLastTraceFilePath);
+			R->SetStringField(TEXT("log_file"),   GLastLogFilePath);
+			R->SetStringField(TEXT("hint"), TEXT("Allow a few seconds for the trace file to finalise, then call analyse."));
+			return OkJson(R);
+		}
+
+		if (Action == TEXT("standalone_status"))
+		{
+			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+			R->SetBoolField(TEXT("running"), GStandaloneRunning);
+			R->SetStringField(TEXT("last_trace_file"), GLastTraceFilePath);
+			R->SetStringField(TEXT("last_log_file"),   GLastLogFilePath);
+			return OkJson(R);
+		}
+
+		// -----------------------------------------------------------------------
+		// Profiler
+		// -----------------------------------------------------------------------
+		if (Action == TEXT("profiler_start"))
+		{
+			FString TraceName = GetParam(Params, TEXT("name"), TEXT("mcp_capture"));
+			FString Channels  = GetParam(Params, TEXT("channels"), DefaultTraceChannels());
+			FString TracePath = BuildTraceFilePath(TraceName);
+			GLastTraceFilePath = TracePath + TEXT(".utrace");
+			GLastLogFilePath   = FPaths::ProjectSavedDir() / TEXT("Logs") / (FApp::GetProjectName() + FString(TEXT(".log")));
+
+			if (FTraceAuxiliary::IsConnected())
+			{
+				return ErrJson(TEXT("ALREADY_TRACING"), TEXT("A trace is already active. Call profiler_stop first."));
+			}
+
+			bool bOk = FTraceAuxiliary::Start(FTraceAuxiliary::EConnectionType::File, *TracePath, *Channels);
+			if (!bOk)
+			{
+				return ErrJson(TEXT("TRACE_FAILED"), FString::Printf(TEXT("Failed to start trace. Path: %s"), *TracePath));
+			}
+
+			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+			R->SetStringField(TEXT("status"),     TEXT("tracing"));
+			R->SetStringField(TEXT("trace_file"), GLastTraceFilePath);
+			R->SetStringField(TEXT("channels"),   Channels);
+			R->SetStringField(TEXT("hint"),       TEXT("Call profiler_stop when done, then analyse to read results."));
+			return OkJson(R);
+		}
+
+		if (Action == TEXT("profiler_stop"))
+		{
+			if (!FTraceAuxiliary::IsConnected())
+			{
+				return ErrJson(TEXT("NOT_TRACING"), TEXT("No trace is active."));
+			}
+			FTraceAuxiliary::Stop();
+
+			int64 FileSizeBytes = 0;
+			if (!GLastTraceFilePath.IsEmpty())
+			{
+				FileSizeBytes = IFileManager::Get().FileSize(*GLastTraceFilePath);
+			}
+
+			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+			R->SetStringField(TEXT("status"),           TEXT("stopped"));
+			R->SetStringField(TEXT("trace_file"),       GLastTraceFilePath);
+			R->SetNumberField(TEXT("file_size_mb"),     FMath::RoundToFloat((float)FileSizeBytes / (1024.f * 1024.f) * 10.f) / 10.f);
+			R->SetStringField(TEXT("hint"),             TEXT("Call analyse to read the results."));
+			return OkJson(R);
+		}
+
+		if (Action == TEXT("profiler_status"))
+		{
+			bool bConnected = FTraceAuxiliary::IsConnected();
+			FString Dest    = FTraceAuxiliary::GetTraceDestinationString();
+			FStringBuilderBase ChannelSB;
+			FTraceAuxiliary::GetActiveChannelsString(ChannelSB);
+
+			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+			R->SetBoolField(TEXT("tracing"),          bConnected);
+			R->SetStringField(TEXT("destination"),    Dest);
+			R->SetStringField(TEXT("active_channels"),ChannelSB.ToString());
+			R->SetStringField(TEXT("last_trace_file"),GLastTraceFilePath);
+			return OkJson(R);
+		}
+
+		// -----------------------------------------------------------------------
+		// Annotations
+		// -----------------------------------------------------------------------
+		if (Action == TEXT("profiler_bookmark"))
+		{
+			FString Name = GetParam(Params, TEXT("name"));
+			if (Name.IsEmpty()) return ErrJson(TEXT("MISSING_NAME"), TEXT("'name' parameter required."));
+			TRACE_BOOKMARK(TEXT("%s"), *Name);
+			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+			R->SetStringField(TEXT("bookmark"), Name);
+			R->SetStringField(TEXT("status"), TEXT("ok"));
+			return OkJson(R);
+		}
+
+		if (Action == TEXT("profiler_region_start"))
+		{
+			FString Name = GetParam(Params, TEXT("name"));
+			if (Name.IsEmpty()) return ErrJson(TEXT("MISSING_NAME"), TEXT("'name' parameter required."));
+			TRACE_BEGIN_REGION(*Name);
+			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+			R->SetStringField(TEXT("region"), Name);
+			R->SetStringField(TEXT("status"), TEXT("started"));
+			return OkJson(R);
+		}
+
+		if (Action == TEXT("profiler_region_end"))
+		{
+			FString Name = GetParam(Params, TEXT("name"));
+			if (Name.IsEmpty()) return ErrJson(TEXT("MISSING_NAME"), TEXT("'name' parameter required."));
+			TRACE_END_REGION(*Name);
+			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+			R->SetStringField(TEXT("region"), Name);
+			R->SetStringField(TEXT("status"), TEXT("ended"));
+			return OkJson(R);
+		}
+
+		// -----------------------------------------------------------------------
+		// Analyse
+		// -----------------------------------------------------------------------
+		if (Action == TEXT("analyse") || Action == TEXT("analyze"))
+		{
+			FString Source    = GetParam(Params, TEXT("source"), TEXT("both")).ToLower();
+			FString FileParam = GetParam(Params, TEXT("file"));
+
+			FString TraceFile = FileParam.IsEmpty() ? GLastTraceFilePath : FileParam;
+			FString LogFile   = GLastLogFilePath;
+
+			if (LogFile.IsEmpty())
+			{
+				LogFile = FPaths::ProjectSavedDir() / TEXT("Logs") / (FApp::GetProjectName() + FString(TEXT(".log")));
+			}
+
+			if (Source == TEXT("trace"))
+			{
+				if (TraceFile.IsEmpty()) return ErrJson(TEXT("NO_TRACE"), TEXT("No trace file known. Run profiler_start first, or pass file=<path>."));
+				return AnalyseTrace(TraceFile);
+			}
+			if (Source == TEXT("logs"))
+			{
+				return AnalyseLogs(LogFile);
+			}
+
+			// both
+			if (TraceFile.IsEmpty()) return AnalyseLogs(LogFile);
+			return AnalyseBoth(TraceFile, LogFile);
+		}
+
+		// -----------------------------------------------------------------------
+		// Help
+		// -----------------------------------------------------------------------
+		if (Action == TEXT("help"))
+		{
+			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+			R->SetStringField(TEXT("tool"), TEXT("editor_control"));
+
+			TArray<TSharedPtr<FJsonValue>> Actions;
+			auto A = [&](const FString& Name, const FString& Desc)
+			{
+				TSharedPtr<FJsonObject> O = MakeShared<FJsonObject>();
+				O->SetStringField(TEXT("action"), Name);
+				O->SetStringField(TEXT("description"), Desc);
+				Actions.Add(MakeShared<FJsonValueObject>(O));
+			};
+
+			A(TEXT("start_pie"),           TEXT("Start Play In Editor. Params: none"));
+			A(TEXT("stop_pie"),            TEXT("Stop Play In Editor."));
+			A(TEXT("pie_status"),          TEXT("Is PIE running?"));
+			A(TEXT("start_standalone"),    TEXT("Launch game as standalone process with trace attached. Params: name (trace file name), channels"));
+			A(TEXT("stop_standalone"),     TEXT("Stop standalone process."));
+			A(TEXT("standalone_status"),   TEXT("Is standalone running? What trace file is it writing to?"));
+			A(TEXT("profiler_start"),      TEXT("Start an Unreal Insights trace to file. Params: name (file name), channels"));
+			A(TEXT("profiler_stop"),       TEXT("Stop the active trace. Returns file path and size."));
+			A(TEXT("profiler_status"),     TEXT("Is a trace active? What channels are enabled?"));
+			A(TEXT("profiler_bookmark"),   TEXT("Drop a named bookmark in the active trace. Params: name (required)"));
+			A(TEXT("profiler_region_start"), TEXT("Begin a named region in the active trace. Params: name (required)"));
+			A(TEXT("profiler_region_end"),   TEXT("End a named region in the active trace. Params: name (required)"));
+			A(TEXT("analyse"),             TEXT("Read and summarise trace + logs. Params: source (trace|logs|both, default both), file (override path)"));
+
+			R->SetArrayField(TEXT("actions"), Actions);
+
+			TSharedPtr<FJsonObject> Workflow = MakeShared<FJsonObject>();
+			Workflow->SetStringField(TEXT("in_editor"),  TEXT("profiler_start → [hit PIE] → profiler_stop → analyse"));
+			Workflow->SetStringField(TEXT("standalone"), TEXT("start_standalone → [game loads] → stop_standalone → analyse"));
+			Workflow->SetStringField(TEXT("pie_only"),   TEXT("start_pie → profiler_start → [play] → profiler_stop → stop_pie → analyse"));
+			R->SetObjectField(TEXT("common_workflows"), Workflow);
+
+			return OkJson(R);
+		}
+
+		return ErrJson(TEXT("UNKNOWN_ACTION"),
+			FString::Printf(TEXT("Unknown action: '%s'. Call action=help for documentation."), *Action));
+	}
+);

--- a/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
+++ b/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
@@ -114,6 +114,58 @@ static FString BuildTraceFilePath(const FString& Name)
 	return Dir / Name;
 }
 
+// Read StoreDir from the Unreal Trace Server settings file.
+// UTS saves traces there when -tracehost is used instead of -tracefile.
+static FString GetUTSStoreDir()
+{
+	FString SettingsPath = FPlatformMisc::GetEnvironmentVariable(TEXT("LOCALAPPDATA"))
+		/ TEXT("UnrealEngine/Common/UnrealTrace/Settings.ini");
+
+	FString Content;
+	if (!FFileHelper::LoadFileToString(Content, *SettingsPath))
+	{
+		return FString();
+	}
+
+	for (const FString& Line : TArray<FString>([&]{ TArray<FString> L; Content.ParseIntoArrayLines(L); return L; }()))
+	{
+		if (Line.StartsWith(TEXT("StoreDir=")))
+		{
+			FString Dir = Line.Mid(9).TrimStartAndEnd();
+			// UTS uses backslashes — normalise
+			FPaths::NormalizeFilename(Dir);
+			return Dir;
+		}
+	}
+	return FString();
+}
+
+// Find the most recently modified .utrace file in the UTS store.
+static FString FindLatestUTSTrace()
+{
+	FString StoreDir = GetUTSStoreDir();
+	if (StoreDir.IsEmpty()) return FString();
+
+	FString Latest;
+	FDateTime LatestTime = FDateTime::MinValue();
+
+	IFileManager::Get().IterateDirectory(*StoreDir, [&](const TCHAR* Path, bool bDir) -> bool
+	{
+		if (!bDir && FPaths::GetExtension(Path).Equals(TEXT("utrace"), ESearchCase::IgnoreCase))
+		{
+			FDateTime T = IFileManager::Get().GetTimeStamp(Path);
+			if (T > LatestTime)
+			{
+				LatestTime = T;
+				Latest = Path;
+			}
+		}
+		return true;
+	});
+
+	return Latest;
+}
+
 // ---------------------------------------------------------------------------
 // Trace analysis
 // ---------------------------------------------------------------------------
@@ -418,11 +470,16 @@ REGISTER_VIBEUE_TOOL(editor_control,
 			if (GEditor) GEditor->RequestEndPlayMap();
 			GStandaloneRunning = false;
 
+			// Prefer the UTS store — standalone uses -tracehost so the file lands there
+			FString UTSTrace = FindLatestUTSTrace();
+			if (!UTSTrace.IsEmpty()) GLastTraceFilePath = UTSTrace;
+
 			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
-			R->SetStringField(TEXT("status"), TEXT("standalone stop requested"));
+			R->SetStringField(TEXT("status"),     TEXT("standalone stop requested"));
 			R->SetStringField(TEXT("trace_file"), GLastTraceFilePath);
 			R->SetStringField(TEXT("log_file"),   GLastLogFilePath);
-			R->SetStringField(TEXT("hint"), TEXT("Allow a few seconds for the trace file to finalise, then call analyse."));
+			R->SetStringField(TEXT("uts_store"),  GetUTSStoreDir());
+			R->SetStringField(TEXT("hint"),       TEXT("Allow a few seconds for the trace file to finalise, then call analyse."));
 			return OkJson(R);
 		}
 
@@ -473,17 +530,24 @@ REGISTER_VIBEUE_TOOL(editor_control,
 			}
 			FTraceAuxiliary::Stop();
 
-			int64 FileSizeBytes = 0;
-			if (!GLastTraceFilePath.IsEmpty())
+			// If UTS has a newer file than our stored path, prefer it
+			FString UTSTrace = FindLatestUTSTrace();
+			if (!UTSTrace.IsEmpty())
 			{
-				FileSizeBytes = IFileManager::Get().FileSize(*GLastTraceFilePath);
+				FDateTime StoredTime = GLastTraceFilePath.IsEmpty() ? FDateTime::MinValue()
+					: IFileManager::Get().GetTimeStamp(*GLastTraceFilePath);
+				FDateTime UTSTime = IFileManager::Get().GetTimeStamp(*UTSTrace);
+				if (UTSTime > StoredTime) GLastTraceFilePath = UTSTrace;
 			}
 
+			int64 FileSizeBytes = GLastTraceFilePath.IsEmpty() ? 0
+				: IFileManager::Get().FileSize(*GLastTraceFilePath);
+
 			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
-			R->SetStringField(TEXT("status"),           TEXT("stopped"));
-			R->SetStringField(TEXT("trace_file"),       GLastTraceFilePath);
-			R->SetNumberField(TEXT("file_size_mb"),     FMath::RoundToFloat((float)FileSizeBytes / (1024.f * 1024.f) * 10.f) / 10.f);
-			R->SetStringField(TEXT("hint"),             TEXT("Call analyse to read the results."));
+			R->SetStringField(TEXT("status"),       TEXT("stopped"));
+			R->SetStringField(TEXT("trace_file"),   GLastTraceFilePath);
+			R->SetNumberField(TEXT("file_size_mb"), FMath::RoundToFloat((float)FileSizeBytes / (1024.f * 1024.f) * 10.f) / 10.f);
+			R->SetStringField(TEXT("hint"),         TEXT("Call analyse to read the results."));
 			return OkJson(R);
 		}
 

--- a/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
+++ b/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
@@ -146,11 +146,11 @@ static FString AnalyseTrace(const FString& TraceFile)
 
 	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
 	Root->SetStringField(TEXT("trace_file"), TraceFile);
-	Root->SetNumberField(TEXT("duration_seconds"), Session->GetDurationSeconds());
 
-	// --- Frame analysis ---
+	// --- Frame analysis (all session reads must be inside the ReadScope) ---
 	{
 		TraceServices::FAnalysisSessionReadScope Scope(*Session);
+		Root->SetNumberField(TEXT("duration_seconds"), Session->GetDurationSeconds());
 		const TraceServices::IFrameProvider* Frames = Session->ReadProvider<TraceServices::IFrameProvider>(TraceServices::GetFrameProviderName());
 
 		if (Frames)

--- a/Source/VibeUE/VibeUE.Build.cs
+++ b/Source/VibeUE/VibeUE.Build.cs
@@ -121,6 +121,7 @@ public class VibeUE : ModuleRules
 					"ContentBrowser",      // For content browser selection queries
 					"MetasoundEditor",     // For UMetaSoundEditorSubsystem (FindOrBeginBuilding, BuildToAsset)
 				"GameplayTagsEditor",  // For IGameplayTagsEditorModule (add/remove/rename tags at editor time)
+				"TraceServices",       // For ITraceServicesModule / IAnalysisService (editor_control analyse action)
 				}
 			);
 		}


### PR DESCRIPTION
## Summary

- Adds a new `editor_control` MCP tool (C++) for controlling PIE, standalone game sessions, and Unreal Insights profiling — all from Claude with no Python required
- Adds a `profiling` skill (`Content/Skills/profiling/SKILL.md`) documenting Python-based trace control and live frame-time sampling patterns
- Replaces Windows-only `TlHelp32` process enumeration with `FEditorDelegates::BeginStandaloneLocalPlay` + `FPlatformProcess` — fully cross-platform, no platform headers
- Fixes a crash in `AnalyseTrace` when all frames are filtered out due to invalid timestamps (e.g. during a long load hitch)
- Fixes avg frame time dividing by raw `FrameCount` instead of the number of valid filtered frames

## Changes

### `Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp` (new)

A single-file tool registration implementing the `editor_control` tool with the following actions:

| Action | Description |
|---|---|
| `start_pie` / `stop_pie` / `pie_status` | Control Play In Editor |
| `start_standalone` / `stop_standalone` / `standalone_status` | Launch/stop game as a separate process with Insights trace attached |
| `profiler_start` / `profiler_stop` / `profiler_status` | Control an Unreal Insights trace to file |
| `profiler_bookmark` | Drop a named bookmark in the active trace |
| `profiler_region_start` / `profiler_region_end` | Named regions in the active trace |
| `analyse` | Read a `.utrace` file and/or log file and return frame stats + notable log lines |
| `help` | Returns full action list and common workflow sequences |

**Cross-platform standalone termination** — `start_standalone` subscribes to `FEditorDelegates::BeginStandaloneLocalPlay` which fires with the child process PID when the game launches. That PID is opened via `FPlatformProcess::OpenProcess` and stored as a `FProcHandle`. `stop_standalone` waits up to 5 seconds via `FPlatformProcess::IsProcRunning`, force-terminates with `TerminateProc` if needed, then releases with `CloseProc`. No `TlHelp32`, no Windows platform headers.

**Trace analysis** — `analyse` loads the `.utrace` via `ITraceServicesModule` / `IAnalysisService` and returns: frame count, avg/max frame time, avg FPS, p95 frame time, and the 10 worst frames with timestamps. Log analysis scans for errors, warnings, PSO hitches, and notable patterns (blocking loads, shader compilers, memory, etc). All frame stats are guarded against empty results (e.g. when the game is stopped before rendering any frames).

### `Source/VibeUE/VibeUE.Build.cs`

Adds `"TraceServices"` to the editor-only module dependencies for `ITraceServicesModule` / `IAnalysisService`.

### `Content/Skills/profiling/SKILL.md` (new)

Claude-facing skill documenting:
- `TraceUtilLibrary` trace control from Python (no C++ required)
- Live frame-time sampling via `register_ticker_callback`
- Known gotchas: `AutomationPerformaceHelper` crashes outside FunctionalTest, channel name suffixes, default channel injection, ticker handle lifetime, `is_tracing()` flush delay
- Full worked examples for benchmark captures, frame budget checks, and hitch detection

## Test Steps

### Prerequisites
- UE editor open with VibeUE plugin loaded
- Proxy running: `cd Plugins/VibeUE/Content/Python && python vibeue-proxy.py`
- Bearer token set in `vibeue-proxy.json` matching Project Settings → Plugins → VibeUE → API Key

### 1. Verify tool appears in the tool list
Call `tools/list` via MCP and confirm `editor_control` is present with its action parameter.

### 2. PIE control
```
editor_control(action="start_pie")
→ expect: {"status": "PIE start requested", "success": true}

editor_control(action="pie_status")
→ expect: {"running": true}

editor_control(action="stop_pie")
→ expect: {"status": "PIE stop requested", "success": true}
```

### 3. Profiler (in-editor)
```
editor_control(action="profiler_start", name="test_capture")
→ expect: {"status": "tracing", "trace_file": "...test_capture.utrace"}

# Start PIE, wait 5–10 seconds, stop PIE

editor_control(action="profiler_stop")
→ expect: {"status": "stopped", "file_size_mb": <non-zero>}

editor_control(action="analyse", source="trace")
→ expect: frame_count > 0, avg_frame_ms and avg_fps populated
```

### 4. Standalone with trace
```
editor_control(action="start_standalone", name="standalone_test")
→ expect: {"status": "standalone start requested", "success": true}

# Wait for the game window to appear and the game to be running
# (may take 30+ seconds on larger projects due to PSO compilation)

editor_control(action="stop_standalone")
→ expect: {"status": "standalone stop requested", "trace_file": "...", "success": true}
# Verify the standalone game window closes within ~5 seconds

editor_control(action="analyse", source="both")
→ expect: trace section has frame_count > 0; logs section has success: true
# The first few frames will be slow (PSO compilation) — this is expected
# Frame 0 may show a very long duration covering the load time — also expected
```

### 5. Empty-frame crash guard
Call `stop_standalone` immediately after `start_standalone` (before the game window appears). The subsequent `analyse` call should return gracefully with a `warning` field rather than crashing the editor.

### 6. Help action
```
editor_control(action="help")
→ expect: actions array with all 13 actions listed, common_workflows object
```

## Notes

- `TraceServices` module dependency is editor-only (inside the existing `#if WITH_EDITOR` block in `Build.cs`)
- The `BeginStandaloneLocalPlay` delegate fires once per session launch and self-removes — no leak
- `analyse` requires the editor to be running (it uses `ITraceServicesModule` loaded into the editor process)
- Standalone traces go to the Unreal Trace Server store when `-tracehost` is used; `stop_standalone` and `profiler_stop` both check UTS for a newer file than the local path and prefer it automatically
- p95 frame time = 95% of frames rendered faster than this value; useful for characterising typical worst-case frame pacing without load-spike outliers skewing the result

🤖 Generated with [Claude Code](https://claude.com/claude-code)