### PR TITLE
5-7 → master: Blueprint auto-layout rewrite, editor_control screenshot + profiling, UE 5.7 build fixes

### DIFF
--- a/Content/Skills/blueprint-graphs/build-graph.md
+++ b/Content/Skills/blueprint-graphs/build-graph.md
@@ -266,12 +266,13 @@ for n in nodes:
 
 ### Auto-Layout (`auto_layout_graph` / `auto_layout_selected_nodes`)
 
-Both methods use the same simplified Sugiyama algorithm:
-- Layers assigned by BFS on execution (exec pin) flow; falls back to data-flow BFS if exec flow is flat
-- Pure data nodes placed one column left of their first exec consumer
-- Independent event chains get separate vertical bands so they never overlap
-- Event/entry nodes sort to the top of each layer
-- Column width: 450 px, Row height: 180 px
+Both methods use the same layered (Sugiyama-style) algorithm:
+- **Columns by dependency depth** — layer = longest path over the combined exec **and** data edge graph, so inputs sit to the left and flow rightward into the exec/Set nodes that consume them (a deep `Get → math → Clamp → Set` chain steps across columns instead of stacking in one).
+- **Cycle-safe** — back-edges (a loop body wired back to its loop, recursion, a Reset re-entry) are detected via DFS and excluded from column assignment, so a cycle can never inflate graph width. The back-edge is still drawn as a wire. DFS is seeded from event entry points so the dropped edge is the genuine loop-back.
+- **Crossing reduction** — median ordering sweeps; fan-out siblings (a branch's then/else, a sequence's outputs, a loop's body/completed) keep their output-pin order top-to-bottom.
+- **Straight backbones** — Y aligns each node to the median center of its neighbors, weighted toward **exec** neighbors, so the execution spine stays horizontal while data feeds in from the side. A branch sits at the midpoint of its then/else targets.
+- **Independent components** get separate non-overlapping vertical bands; rows are spaced by node size (pin count).
+- **Idempotent** — running it twice moves nothing. Column width 420 px.
 
 **`auto_layout_graph`** — repositions **every** node in the graph:
 

--- a/Content/Skills/screenshots/SKILL.md
+++ b/Content/Skills/screenshots/SKILL.md
@@ -15,6 +15,13 @@ keywords:
 
 # Screenshot & Vision Skill
 
+## Which capture path — external MCP client vs. VibeUE internal chat
+
+- **External MCP clients (Claude Code, Cursor, …):** prefer the one-call MCP action `editor_control(action="screenshot")` (params: `mode=editor_window|active_window`, `name`). It captures synchronously and returns a `file_path` you can open/read — no Python, no skill load. Use `mode="active_window"` for a separate PIE/game window.
+- **VibeUE internal chat:** the `editor_control` screenshot action is **NOT for you** — it returns a path that never enters your vision and will refuse internal-chat calls. Capture with the **Python API** below (`unreal.ScreenshotService.capture_editor_window(...)` via `execute_python_code`), then call the `attach_image` tool so the image enters your next turn.
+
+Both paths use the same synchronous Windows capture underneath. The methods below are the Python API for the internal-chat path.
+
 ## Methods
 
 | Method | Use Case |

--- a/Content/instructions/vibeue.instructions.md
+++ b/Content/instructions/vibeue.instructions.md
@@ -2,9 +2,15 @@
 
 You are an AI assistant for Unreal Engine 5.7 development with the VibeUE Python API.
 
-## 📸 Screenshots & Vision
+## 📸 Screenshots & Vision — capture, then review yourself
 
-Load the `screenshots` skill for capture methods, `attach_image` tool usage, camera best practices, and satellite image workflows.
+Seeing what you built is the highest-value verification habit. After a *visible* change (spawned/moved actors, a level, a UI, a material), capture and look before claiming success:
+
+1. `execute_python_code`: `result = unreal.ScreenshotService.capture_editor_window("review")` — **synchronous**, the file is ready immediately. (`capture_viewport` does NOT work from Python.)
+2. Call the `attach_image` **tool** with `file_path=result.file_path` so the image enters your next turn's vision.
+3. Judge it against the request; if it's wrong, fix and re-capture.
+
+**⚠️ Use the Python API — NOT the MCP screenshot action.** The `editor_control(action="screenshot")` MCP action is for **external** clients only and is **not available to you**: it returns a bare file path that never enters your vision (and it will refuse internal-chat calls). You capture via `unreal.ScreenshotService.capture_editor_window(...)` + the `attach_image` tool. Load the `screenshots` skill for capture methods, camera best practices, and satellite image workflows.
 
 ## 🧠 Memory (Persistent Across Sessions)
 

--- a/Content/samples/AGENTS.md.sample
+++ b/Content/samples/AGENTS.md.sample
@@ -16,9 +16,12 @@ This is an Unreal Engine 5.7+ project with the **VibeUE** plugin for AI-powered 
 ### Other Tools
 - `vibeue-skills-manager` - Load domain-specific skill documentation
 - `manage_asset` - Search, open, save, duplicate, move, delete assets
+- `editor_control` - Play-In-Editor (`start_pie`/`stop_pie`/`pie_status`), launch standalone, profile (`frame_timing`/`profiler_*`/`analyse`), **and `screenshot`** — a synchronous PNG of the editor/active window so you can SEE what you built and review it (no skill load, no Python). See Screenshots & Vision below.
 - `read_logs` - Read Unreal log files for errors and warnings
 - `terrain_data` - Generate heightmaps and water splines from real-world data
 - `deep_research` - Research Unreal Engine topics via web search
+
+> VibeUE already covers the **whole loop** — it is not just "Blueprints and Python." Editing/spawning/moving actors (`level-actors` skill), level-viewport camera control (`viewport` skill), running the game (`editor_control` PIE), and seeing the result (`editor_control` `screenshot`) are all here. You do not need a second plugin for "eyes and hands in the viewport."
 
 ## � Build and Launch Workflow
 
@@ -32,9 +35,16 @@ When the user asks to rebuild, relaunch, test, or recover from a compile/live-co
 
 This script is the correct path for normal rebuild-and-test cycles in this repo because it handles the editor shutdown, build, and relaunch workflow automatically.
 
-## �📸 Screenshots & Vision
+## 📸 Screenshots & Vision — Build → Screenshot → Review Yourself → Fix
 
-Load the `screenshots` skill for capture methods, `attach_image` tool usage, camera best practices, and satellite image workflows.
+**Capturing what you built and actually looking at it is the single highest-value habit in this setup.** After any *visible* change (spawned/moved actors, a blocked-out level, a UI, a material), don't just claim success — see it:
+
+1. *(Testing gameplay?)* `editor_control(action="start_pie")`.
+2. `editor_control(action="screenshot")` → returns a `file_path` to a synchronous PNG of the editor window. Use `mode="active_window"` if PIE opened a separate game window.
+3. **Open / read the `file_path`** and judge the image against what the user asked for.
+4. Wrong? Fix it and screenshot again. Loop until it looks right, then report with the evidence.
+
+This needs no skill load and no Python. For framing a specific actor, moving the editor camera, or capturing a specific asset editor, load the `screenshots` and `viewport` skills.
 
 ## 🎯 Skills System (Index + On-Demand Sub-Docs)
 
@@ -390,6 +400,16 @@ AI: "Created BP_Enemy."
 
 **Skill Loading:**
 - Mention when loading a new skill: "Loading blueprints skill for API reference..."
+
+## 🧭 Working Effectively on This Project
+
+- **Screenshot self-review (see above):** after any visible change, capture and look before you say "done."
+- **Git milestones:** ensure the project is a git repo before large changes, and commit at every working milestone (`git add -A && git commit -m "..."`) so a bad experiment reverts cleanly. Prefer many small commits over one big one.
+- **Manage context:** long Unreal sessions fill the context window fast. As you approach the limit, summarize what's done and what's left so work can continue cleanly; prefer a fresh, tightly-scoped task over dragging stale context forward.
+- **Division of labor:** you handle logic, node wiring, Python, and asset organization; the human prepares 3D meshes/audio and the high-level architecture. If a needed asset doesn't exist, say so — don't fake it with a placeholder unless asked.
+- **Detailed prompts win:** the more precise the requested logic/architecture, the better the result. If a request is vague, ask one clarifying question or state the assumption you're making, then build.
+- **Supervise the graph:** auto-generated Blueprint graphs are functional, not tidy — verify behavior (see "Success Claims Require Verification Evidence") rather than over-investing in auto-cleaning node layout.
+- **Living gotchas:** when you hit a real problem, work out a fix, and confirm it works, append a one-line gotcha + fix to this file (or the project's `CLAUDE.md`) so the next session doesn't relearn it.
 
 ## 🚀 Getting Started Workflow
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ https://www.vibeue.com/
 - **In-Editor AI Chat** - Chat with AI directly inside Unreal Editor
 - **Python API Services** - 32 specialized services with 1068 methods for Blueprints, Materials, Widgets, Landscape Terrain, Splines, Foliage, Animation Sequences, Animation Blueprints, Animation Montages, Niagara (systems + emitters + **scratch-pad graph authoring**), Skeletons, Sound Cues, MetaSounds, Gameplay Tags, Screenshots, Viewport Control, Runtime Virtual Textures, StateTree Behavior, UV Mapping, Editor Transactions, **Procedural FPS Map Blockout**, Project/Engine Settings, and more
 - **Full Unreal Python Access** - Execute any Unreal Engine Python API through MCP
-- **MCP Tools** - 10 tools for discovery, execution, asset workflows, debugging, terrain generation, and web research
+- **MCP Tools** - 11 tools for discovery, execution, asset workflows, debugging, terrain generation, web research, and editor/profiler control
+- **Eyes & hands in the viewport, built in** - spawn/move/edit level actors, control the editor camera, run the game (PIE), and **capture viewport screenshots for visual self-review** (`editor_control(action="screenshot")`) — the full build → look → fix loop without a second plugin
 - **Domain Skills** - 35 lazy-loaded skill packs covering Blueprints, graph editing, materials, terrain, animation, audio, AI, gameplay tags, widgets, viewport, data, PCG (procedural content generation), UV mapping, procedural map blockout, and more
 - **Custom Instructions** - Add project-specific context via markdown files
 - **External IDE Integration** - Connect VS Code, Claude Code, Cursor, and AntiGravity via MCP
@@ -30,7 +31,7 @@ https://www.vibeue.com/
 
 VibeUE uses a **Python-first architecture** that gives AI assistants access to:
 
-### 1. MCP Tools (10 tools, +1 optional)
+### 1. MCP Tools (11 tools, +1 optional)
 Lightweight MCP tools for AI interaction with Unreal:
 
 | Tool | Purpose |
@@ -45,6 +46,7 @@ Lightweight MCP tools for AI interaction with Unreal:
 | `read_logs` | Read and filter Unreal Engine log files with regex support |
 | `terrain_data` | Generate real-world heightmaps, map images, and water feature data from geographic coordinates |
 | `deep_research` | Web search, page fetching, and GPS geocoding — no API key required |
+| `editor_control` | Control PIE/standalone play, **capture viewport screenshots** for visual self-review, run Unreal Insights profiling, and report frame timing with a CPU-vs-GPU bound verdict |
 | `manage_editor_chat` _(optional)_ | Drive the in-editor AI chat for automated end-to-end testing. **Hidden unless Chat Editor Testing mode is enabled** — see [In-Editor AI Chat → Chat Editor Testing](#-chat-editor-testing-optional). |
 
 **Note:** The `read_logs` MCP tool provides access to Unreal Engine's log files for debugging, error analysis, and workflow understanding.
@@ -288,6 +290,58 @@ deep_research(action="reverse_geocode", lat=35.3606, lng=138.7274)
 **Typical workflows:**
 - Research: `search` → `fetch_page` on best URL → synthesize
 - Terrain: `geocode "Mount Fuji"` → pass lat/lng to `terrain_data`
+
+##### Editor & Profiler Control Tool
+
+**`editor_control`**
+```python
+# --- Play-in-Editor (PIE) ---
+editor_control(action="start_pie")
+editor_control(action="pie_status")
+editor_control(action="stop_pie")
+
+# --- Screenshot (synchronous) — SEE what you built, then self-review ---
+editor_control(action="screenshot")                       # whole editor window
+editor_control(action="screenshot", mode="active_window") # foreground window (e.g. a separate PIE game window)
+# Returns { file_path, width, height, ... } — open the PNG to review, then fix and re-capture.
+# External MCP clients only; the in-editor VibeUE chat captures via ScreenshotService + attach_image.
+
+# --- Standalone (separate game process with trace attached) ---
+editor_control(action="start_standalone")           # optional: name=, channels=
+editor_control(action="standalone_status")
+editor_control(action="stop_standalone")
+
+# --- Frame timing — RUN THIS FIRST ---
+# Reports Game/Render/GPU thread split + a CPU-vs-GPU bound verdict and hint
+editor_control(action="frame_timing")
+
+# --- Unreal Insights profiling ---
+editor_control(action="profiler_start", name="my_capture")  # begin trace to file
+editor_control(action="profiler_bookmark", name="boss_fight")
+editor_control(action="profiler_region_start", name="wave_1")
+editor_control(action="profiler_region_end", name="wave_1")
+editor_control(action="profiler_status")
+editor_control(action="profiler_stop")
+
+# --- Read back a trace/logs and summarize perf ---
+editor_control(action="analyse", source="both")      # source: trace | logs | both
+
+# --- Help ---
+editor_control(action="help")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | string | Yes | `start_pie`, `stop_pie`, `pie_status`, `start_standalone`, `stop_standalone`, `standalone_status`, `screenshot` (alias `capture`), `profiler_start`, `profiler_stop`, `profiler_status`, `profiler_bookmark`, `profiler_region_start`, `profiler_region_end`, `frame_timing`, `analyse`, `help` |
+| `name` | string | No | Trace file name (`profiler_start`/`start_standalone`), label (`profiler_bookmark`/`profiler_region_*`), or output PNG name (`screenshot`) |
+| `mode` | string | No | `screenshot` — `editor_window` (default) or `active_window` |
+| `channels` | string | No | Comma-separated trace channels (`profiler_start`/`start_standalone`). Default: `frame,cpu,gpu,log,loadtime,object,stats` |
+| `source` | string | No | `analyse` — what to read: `trace`, `logs`, or `both` (default: `both`) |
+| `file` | string | No | `analyse` — override the trace or log file path |
+
+**Typical workflow:** `frame_timing` to find whether you're CPU- or GPU-bound → `profiler_start` → play through a representative scene (drop `profiler_bookmark`/`region` markers) → `profiler_stop` → `analyse` to read the trace + logs back. Run inside PIE or a standalone session for a real game-bound reading; the editor viewport alone is not representative.
 
 ### 2. VibeUE Python API Services (32 services, 1068 methods)
 High-level services exposed to Python for common game development tasks:
@@ -1319,10 +1373,10 @@ See the [`niagara-emitters` skill](Content/Skills/niagara-emitters/SKILL.md) for
 
 ### ScreenshotService (5 methods)
 
-ScreenshotService enables AI vision by capturing editor content:
-- `capture_editor_window(path)` - Capture entire editor window (works for blueprints, materials, etc.)
-- `capture_viewport(path, width, height)` - Capture level viewport
-- `capture_active_window(path)` - Capture foreground window
+ScreenshotService enables AI vision by capturing editor content (the Python path; **external MCP clients should use `editor_control(action="screenshot")` instead**):
+- `capture_editor_window(path)` - **Use this for everything.** Synchronous capture of the entire editor window incl. the focused tab (level viewport, blueprints, materials, etc.)
+- `capture_active_window(path)` - Capture the foreground window (e.g. a separate PIE game window)
+- `capture_viewport(path, width, height)` - ⚠️ **Does NOT work from Python** (asynchronous — the file never lands during a Python call). Use `capture_editor_window` instead.
 - `get_open_editor_tabs()` - List open editor tabs with asset info
 - `get_active_window_title()` - Get focused window title
 - `is_editor_window_active()` - Check if editor is in focus

--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -10314,6 +10314,7 @@ namespace VibeUELayout
 		// edges form a DAG, so longest-path layering is well-defined and a cycle (a loop
 		// body wired back to its loop, recursion, etc.) can never inflate columns. The
 		// back-edge is still drawn as a wire; it just doesn't drive column assignment.
+		TMap<UEdGraphNode*, int32> VisitRank; // DFS pre-order rank (pin-ordered) for stable within-layer seeding
 		TMap<UEdGraphNode*, TArray<UEdGraphNode*>> LayerSucc;
 		TMap<UEdGraphNode*, TArray<UEdGraphNode*>> LayerPred;
 		{
@@ -10343,6 +10344,7 @@ namespace VibeUELayout
 				TArray<TPair<UEdGraphNode*, int32>> Stack;
 				Stack.Push(TPair<UEdGraphNode*, int32>(Seed, 0));
 				OnStack.Add(Seed);
+					VisitRank.Add(Seed, VisitRank.Num());
 				while (Stack.Num() > 0)
 				{
 					const int32 TopIdx = Stack.Num() - 1;
@@ -10362,6 +10364,7 @@ namespace VibeUELayout
 						if (!Visited.Contains(V))
 						{
 							OnStack.Add(V);
+								VisitRank.Add(V, VisitRank.Num());
 							Stack.Push(TPair<UEdGraphNode*, int32>(V, 0));
 						}
 					}
@@ -10484,10 +10487,14 @@ namespace VibeUELayout
 		{
 			for (TPair<int32, TArray<UEdGraphNode*>>& LayerPair : RankPair.Value)
 			{
-				LayerPair.Value.Sort([](const UEdGraphNode& A, const UEdGraphNode& B)
+				LayerPair.Value.Sort([&VisitRank](const UEdGraphNode& A, const UEdGraphNode& B)
 				{
-					if (A.NodePosY != B.NodePosY) return A.NodePosY < B.NodePosY;
-					return A.NodePosX < B.NodePosX;
+					const int32* RA = VisitRank.Find(const_cast<UEdGraphNode*>(&A));
+					const int32* RB = VisitRank.Find(const_cast<UEdGraphNode*>(&B));
+					const int32 VA = RA ? *RA : MAX_int32;
+					const int32 VB = RB ? *RB : MAX_int32;
+					if (VA != VB) return VA < VB;
+					return A.NodePosY < B.NodePosY;
 				});
 			}
 		}

--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -10302,7 +10302,73 @@ namespace VibeUELayout
 			}
 		}
 
-		// Layer = longest path over the combined DAG (Kahn topological order; cycle-safe).
+		// Break cycles for layering: classify edges with an iterative DFS and drop
+		// back-edges (edges pointing at a node still on the DFS stack). The remaining
+		// edges form a DAG, so longest-path layering is well-defined and a cycle (a loop
+		// body wired back to its loop, recursion, etc.) can never inflate columns. The
+		// back-edge is still drawn as a wire; it just doesn't drive column assignment.
+		TMap<UEdGraphNode*, TArray<UEdGraphNode*>> LayerSucc;
+		TMap<UEdGraphNode*, TArray<UEdGraphNode*>> LayerPred;
+		{
+			TSet<UEdGraphNode*> Visited;
+			TSet<UEdGraphNode*> OnStack;
+			// Seed DFS from exec entry points (events) first, then other roots (no
+			// predecessors), then everything else — so the dropped edge is the genuine
+			// loop-back rather than an arbitrary forward edge, and loop bodies still flow L->R.
+			TArray<UEdGraphNode*> SeedOrder;
+			for (UEdGraphNode* SN : Nodes)
+			{
+				if (SN->IsA<UK2Node_Event>() || SN->IsA<UK2Node_CustomEvent>()) { SeedOrder.AddUnique(SN); }
+			}
+			for (UEdGraphNode* SN : Nodes)
+			{
+				const TArray<UEdGraphNode*>* PP = Pred.Find(SN);
+				if (!PP || PP->Num() == 0) { SeedOrder.AddUnique(SN); }
+			}
+			for (UEdGraphNode* SN : Nodes) { SeedOrder.AddUnique(SN); }
+
+			for (UEdGraphNode* Seed : SeedOrder)
+			{
+				if (Visited.Contains(Seed))
+				{
+					continue;
+				}
+				TArray<TPair<UEdGraphNode*, int32>> Stack;
+				Stack.Push(TPair<UEdGraphNode*, int32>(Seed, 0));
+				OnStack.Add(Seed);
+				while (Stack.Num() > 0)
+				{
+					const int32 TopIdx = Stack.Num() - 1;
+					UEdGraphNode* U = Stack[TopIdx].Key;
+					const int32 ChildI = Stack[TopIdx].Value;
+					const TArray<UEdGraphNode*>* Children = Succ.Find(U);
+					if (Children && ChildI < Children->Num())
+					{
+						Stack[TopIdx].Value = ChildI + 1;
+						UEdGraphNode* V = (*Children)[ChildI];
+						if (OnStack.Contains(V))
+						{
+							continue; // back-edge: skip for layering
+						}
+						LayerSucc.FindOrAdd(U).AddUnique(V);
+						LayerPred.FindOrAdd(V).AddUnique(U);
+						if (!Visited.Contains(V))
+						{
+							OnStack.Add(V);
+							Stack.Push(TPair<UEdGraphNode*, int32>(V, 0));
+						}
+					}
+					else
+					{
+						OnStack.Remove(U);
+						Visited.Add(U);
+						Stack.Pop();
+					}
+				}
+			}
+		}
+
+		// Layer = longest path over the acyclic edge set (Kahn topological order).
 		TMap<UEdGraphNode*, int32> Layer;
 		TMap<UEdGraphNode*, int32> Deg;
 		for (UEdGraphNode* N : Nodes)
@@ -10310,7 +10376,7 @@ namespace VibeUELayout
 			Layer.Add(N, 0);
 			Deg.Add(N, 0);
 		}
-		for (const TPair<UEdGraphNode*, TArray<UEdGraphNode*>>& Pair : Pred)
+		for (const TPair<UEdGraphNode*, TArray<UEdGraphNode*>>& Pair : LayerPred)
 		{
 			Deg[Pair.Key] = Pair.Value.Num();
 		}
@@ -10323,13 +10389,11 @@ namespace VibeUELayout
 				Q.Enqueue(N);
 			}
 		}
-		int32 Processed = 0;
 		while (!Q.IsEmpty())
 		{
 			UEdGraphNode* C = nullptr;
 			Q.Dequeue(C);
-			++Processed;
-			if (const TArray<UEdGraphNode*>* S = Succ.Find(C))
+			if (const TArray<UEdGraphNode*>* S = LayerSucc.Find(C))
 			{
 				for (UEdGraphNode* T : *S)
 				{
@@ -10338,32 +10402,6 @@ namespace VibeUELayout
 					{
 						Q.Enqueue(T);
 					}
-				}
-			}
-		}
-		// Cycle fallback: bounded relaxation for any nodes trapped in a cycle.
-		if (Processed < Nodes.Num())
-		{
-			for (int32 Iter = 0; Iter < Nodes.Num(); ++Iter)
-			{
-				bool bChanged = false;
-				for (UEdGraphNode* N : Nodes)
-				{
-					if (const TArray<UEdGraphNode*>* S = Succ.Find(N))
-					{
-						for (UEdGraphNode* T : *S)
-						{
-							if (Layer[T] < Layer[N] + 1)
-							{
-								Layer[T] = Layer[N] + 1;
-								bChanged = true;
-							}
-						}
-					}
-				}
-				if (!bChanged)
-				{
-					break;
 				}
 			}
 		}

--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -10510,7 +10510,10 @@ namespace VibeUELayout
 			}
 		}
 
-		// Assign positions: X by layer, Y stacked by node size, components in stacked bands.
+		// Assign positions: X by layer; Y straightened by aligning each node to the
+		// median center of its connected neighbors (priority method) so chains and the
+		// exec backbone stay horizontal instead of sloping. Independent components are
+		// placed in stacked, non-overlapping bands.
 		const float ColumnWidth = 420.0f;
 		const float RowGap = 56.0f;
 		const float ComponentGap = 160.0f;
@@ -10524,32 +10527,85 @@ namespace VibeUELayout
 		{
 			TMap<int32, TArray<UEdGraphNode*>>& Layers = Grid[Rank];
 
-			float BandHeight = 0.0f;
-			for (TPair<int32, TArray<UEdGraphNode*>>& LayerPair : Layers)
-			{
-				float ColHeight = 0.0f;
-				for (UEdGraphNode* N : LayerPair.Value) { ColHeight += EstimateNodeHeight(N) + RowGap; }
-				BandHeight = FMath::Max(BandHeight, ColHeight);
-			}
+			TArray<int32> LayerKeys;
+			Layers.GetKeys(LayerKeys);
+			LayerKeys.Sort();
 
-			for (TPair<int32, TArray<UEdGraphNode*>>& LayerPair : Layers)
+			// Band-relative Y, seeded by a simple top-aligned stack per column.
+			TMap<UEdGraphNode*, float> Y;
+			for (int32 LK : LayerKeys)
 			{
-				float ColHeight = 0.0f;
-				for (UEdGraphNode* N : LayerPair.Value) { ColHeight += EstimateNodeHeight(N) + RowGap; }
-				ColHeight = FMath::Max(0.0f, ColHeight - RowGap);
-
-				// Center each column within the band so short columns don't drag long diagonal wires.
-				float Cursor = BandTop + FMath::Max(0.0f, (BandHeight - ColHeight) * 0.5f);
-				for (UEdGraphNode* N : LayerPair.Value)
+				float Cursor = 0.0f;
+				for (UEdGraphNode* N : Layers[LK])
 				{
-					N->Modify();
-					N->NodePosX = (int32)(OriginX + (float)LayerPair.Key * ColumnWidth);
-					N->NodePosY = (int32)Cursor;
+					Y.Add(N, Cursor);
 					Cursor += EstimateNodeHeight(N) + RowGap;
 				}
 			}
 
-			BandTop += BandHeight + ComponentGap;
+			// Alignment sweeps: pull each node toward the median center-Y of its neighbors
+			// on the already-placed side, then resolve overlaps in column order. Alternating
+			// L->R / R->L converges to straight chains without a systematic downward drift.
+			for (int32 Iter = 0; Iter < 6; ++Iter)
+			{
+				const bool bLeftToRight = (Iter % 2) == 0;
+				TArray<int32> Order = LayerKeys;
+				if (!bLeftToRight)
+				{
+					for (int32 a = 0, b = Order.Num() - 1; a < b; ++a, --b) { Order.Swap(a, b); }
+				}
+				for (int32 LK : Order)
+				{
+					TArray<UEdGraphNode*>& LayerNodes = Layers[LK];
+					float Cursor = -FLT_MAX;
+					for (UEdGraphNode* N : LayerNodes)
+					{
+						const float H = EstimateNodeHeight(N);
+						const TArray<UEdGraphNode*>* Adj = bLeftToRight ? Pred.Find(N) : Succ.Find(N);
+						float DesiredTop = Y[N];
+						if (Adj && Adj->Num() > 0)
+						{
+							TArray<float> Centers;
+							for (UEdGraphNode* M : *Adj)
+							{
+								if (const float* MY = Y.Find(M))
+								{
+									Centers.Add(*MY + EstimateNodeHeight(M) * 0.5f);
+								}
+							}
+							if (Centers.Num() > 0)
+							{
+								Centers.Sort();
+								DesiredTop = Centers[Centers.Num() / 2] - H * 0.5f;
+							}
+						}
+						const float Target = FMath::Max(DesiredTop, Cursor);
+						Y[N] = Target;
+						Cursor = Target + H + RowGap;
+					}
+				}
+			}
+
+			// Shift the band so its top sits at BandTop, commit positions, advance.
+			float MinY = FLT_MAX;
+			float MaxY = -FLT_MAX;
+			for (const TPair<UEdGraphNode*, float>& YPair : Y)
+			{
+				MinY = FMath::Min(MinY, YPair.Value);
+				MaxY = FMath::Max(MaxY, YPair.Value + EstimateNodeHeight(YPair.Key));
+			}
+			const float Shift = BandTop - MinY;
+			for (int32 LK : LayerKeys)
+			{
+				for (UEdGraphNode* N : Layers[LK])
+				{
+					N->Modify();
+					N->NodePosX = (int32)(OriginX + (float)LK * ColumnWidth);
+					N->NodePosY = (int32)(Y[N] + Shift);
+				}
+			}
+
+			BandTop += (MaxY - MinY) + ComponentGap;
 		}
 
 		return NumComp;

--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -10281,6 +10281,8 @@ namespace VibeUELayout
 		// Precedence edges (source -> target) for every link (exec AND data) within the set.
 		TMap<UEdGraphNode*, TArray<UEdGraphNode*>> Succ;
 		TMap<UEdGraphNode*, TArray<UEdGraphNode*>> Pred;
+		TMap<UEdGraphNode*, TArray<UEdGraphNode*>> ExecSucc;
+		TMap<UEdGraphNode*, TArray<UEdGraphNode*>> ExecPred;
 		for (UEdGraphNode* N : Nodes)
 		{
 			for (UEdGraphPin* P : N->Pins)
@@ -10298,6 +10300,11 @@ namespace VibeUELayout
 					}
 					Succ.FindOrAdd(N).AddUnique(T);
 					Pred.FindOrAdd(T).AddUnique(N);
+					if (P->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec)
+					{
+						ExecSucc.FindOrAdd(N).AddUnique(T);
+						ExecPred.FindOrAdd(T).AddUnique(N);
+					}
 				}
 			}
 		}
@@ -10599,25 +10606,31 @@ namespace VibeUELayout
 					for (UEdGraphNode* N : LayerNodes)
 					{
 						const float H = EstimateNodeHeight(N);
-						const TArray<UEdGraphNode*>* Adj = bLeftToRight ? Pred.Find(N) : Succ.Find(N);
-						float DesiredTop = Y[N];
-						if (Adj && Adj->Num() > 0)
-						{
+						// Align to the median center-Y of ALL neighbors (both sides) so leaf nodes
+							// (e.g. a loop's Completed output) snap next to their single neighbor.
 							TArray<float> Centers;
-							for (UEdGraphNode* M : *Adj)
+							// Prefer EXEC neighbors so the execution backbone stays straight; fall back
+							// to data neighbors only for pure (exec-less) nodes like math/getters.
+							auto Gather = [&](const TMap<UEdGraphNode*, TArray<UEdGraphNode*>>& AdjMap)
 							{
-								if (const float* MY = Y.Find(M))
+								if (const TArray<UEdGraphNode*>* A = AdjMap.Find(N))
 								{
-									Centers.Add(*MY + EstimateNodeHeight(M) * 0.5f);
+									for (UEdGraphNode* M : *A)
+									{
+										if (const float* MY = Y.Find(M)) { Centers.Add(*MY + EstimateNodeHeight(M) * 0.5f); }
+									}
 								}
-							}
+							};
+							Gather(ExecPred);
+							Gather(ExecSucc);
+							if (Centers.Num() == 0) { Gather(Pred); Gather(Succ); }
+							float DesiredTop = Y[N];
 							if (Centers.Num() > 0)
 							{
 								Centers.Sort();
 								DesiredTop = Centers[Centers.Num() / 2] - H * 0.5f;
 							}
-						}
-						const float Target = FMath::Max(DesiredTop, Cursor);
+							const float Target = FMath::Max(DesiredTop, Cursor);
 						Y[N] = Target;
 						Cursor = Target + H + RowGap;
 					}

--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -10247,6 +10247,315 @@ bool UBlueprintService::BuildGraph(
 // AutoLayoutGraph
 // ────────────────────────────────────────────────────────────────
 
+// ────────────────────────────────────────────────────────────────
+// Shared layered graph layout used by AutoLayoutGraph + AutoLayoutSelectedNodes.
+// Columns by dependency depth (longest path over BOTH exec and data edges, so
+// deep data chains step rightward instead of collapsing into one column),
+// independent components stacked into non-overlapping horizontal bands, wire
+// crossings reduced with median ordering sweeps, and rows spaced by node size.
+// ────────────────────────────────────────────────────────────────
+namespace VibeUELayout
+{
+	static float EstimateNodeHeight(const UEdGraphNode* Node)
+	{
+		int32 In = 0, Out = 0;
+		for (const UEdGraphPin* P : Node->Pins)
+		{
+			if (!P || P->bHidden) continue;
+			if (P->Direction == EGPD_Input) ++In; else ++Out;
+		}
+		const int32 Rows = FMath::Max3(In, Out, 1);
+		return 72.0f + (float)Rows * 26.0f;
+	}
+
+	// Lay out Nodes left-to-right anchored at (OriginX, OriginY). Returns component count.
+	static int32 LayeredLayout(const TArray<UEdGraphNode*>& Nodes, float OriginX, float OriginY)
+	{
+		if (Nodes.Num() == 0)
+		{
+			return 0;
+		}
+
+		TSet<UEdGraphNode*> InSet(Nodes);
+
+		// Precedence edges (source -> target) for every link (exec AND data) within the set.
+		TMap<UEdGraphNode*, TArray<UEdGraphNode*>> Succ;
+		TMap<UEdGraphNode*, TArray<UEdGraphNode*>> Pred;
+		for (UEdGraphNode* N : Nodes)
+		{
+			for (UEdGraphPin* P : N->Pins)
+			{
+				if (!P || P->Direction != EGPD_Output)
+				{
+					continue;
+				}
+				for (UEdGraphPin* L : P->LinkedTo)
+				{
+					UEdGraphNode* T = L ? L->GetOwningNode() : nullptr;
+					if (!T || T == N || !InSet.Contains(T))
+					{
+						continue;
+					}
+					Succ.FindOrAdd(N).AddUnique(T);
+					Pred.FindOrAdd(T).AddUnique(N);
+				}
+			}
+		}
+
+		// Layer = longest path over the combined DAG (Kahn topological order; cycle-safe).
+		TMap<UEdGraphNode*, int32> Layer;
+		TMap<UEdGraphNode*, int32> Deg;
+		for (UEdGraphNode* N : Nodes)
+		{
+			Layer.Add(N, 0);
+			Deg.Add(N, 0);
+		}
+		for (const TPair<UEdGraphNode*, TArray<UEdGraphNode*>>& Pair : Pred)
+		{
+			Deg[Pair.Key] = Pair.Value.Num();
+		}
+
+		TQueue<UEdGraphNode*> Q;
+		for (UEdGraphNode* N : Nodes)
+		{
+			if (Deg[N] == 0)
+			{
+				Q.Enqueue(N);
+			}
+		}
+		int32 Processed = 0;
+		while (!Q.IsEmpty())
+		{
+			UEdGraphNode* C = nullptr;
+			Q.Dequeue(C);
+			++Processed;
+			if (const TArray<UEdGraphNode*>* S = Succ.Find(C))
+			{
+				for (UEdGraphNode* T : *S)
+				{
+					Layer[T] = FMath::Max(Layer[T], Layer[C] + 1);
+					if (--Deg[T] <= 0)
+					{
+						Q.Enqueue(T);
+					}
+				}
+			}
+		}
+		// Cycle fallback: bounded relaxation for any nodes trapped in a cycle.
+		if (Processed < Nodes.Num())
+		{
+			for (int32 Iter = 0; Iter < Nodes.Num(); ++Iter)
+			{
+				bool bChanged = false;
+				for (UEdGraphNode* N : Nodes)
+				{
+					if (const TArray<UEdGraphNode*>* S = Succ.Find(N))
+					{
+						for (UEdGraphNode* T : *S)
+						{
+							if (Layer[T] < Layer[N] + 1)
+							{
+								Layer[T] = Layer[N] + 1;
+								bChanged = true;
+							}
+						}
+					}
+				}
+				if (!bChanged)
+				{
+					break;
+				}
+			}
+		}
+
+		// Components via undirected flood fill (for vertical band separation).
+		TMap<UEdGraphNode*, int32> Comp;
+		int32 NumComp = 0;
+		for (UEdGraphNode* Start : Nodes)
+		{
+			if (Comp.Contains(Start))
+			{
+				continue;
+			}
+			const int32 Id = NumComp++;
+			TQueue<UEdGraphNode*> BQ;
+			BQ.Enqueue(Start);
+			Comp.Add(Start, Id);
+			while (!BQ.IsEmpty())
+			{
+				UEdGraphNode* Cur = nullptr;
+				BQ.Dequeue(Cur);
+				auto Visit = [&](UEdGraphNode* M)
+				{
+					if (M && !Comp.Contains(M))
+					{
+						Comp.Add(M, Id);
+						BQ.Enqueue(M);
+					}
+				};
+				if (const TArray<UEdGraphNode*>* S = Succ.Find(Cur)) { for (UEdGraphNode* M : *S) Visit(M); }
+				if (const TArray<UEdGraphNode*>* Pp = Pred.Find(Cur)) { for (UEdGraphNode* M : *Pp) Visit(M); }
+			}
+		}
+
+		// Rank components: those containing events first, then larger ones (keeps the
+		// main event/function chain at the top).
+		TArray<int32> CompNodeCount;
+		TArray<int32> CompEventCount;
+		CompNodeCount.Init(0, NumComp);
+		CompEventCount.Init(0, NumComp);
+		for (const TPair<UEdGraphNode*, int32>& Pair : Comp)
+		{
+			CompNodeCount[Pair.Value]++;
+			if (Pair.Key->IsA<UK2Node_Event>() || Pair.Key->IsA<UK2Node_CustomEvent>())
+			{
+				CompEventCount[Pair.Value]++;
+			}
+		}
+		TArray<int32> CompOrder;
+		for (int32 i = 0; i < NumComp; ++i)
+		{
+			CompOrder.Add(i);
+		}
+		CompOrder.Sort([&](int32 A, int32 B)
+		{
+			if (CompEventCount[A] != CompEventCount[B]) return CompEventCount[A] > CompEventCount[B];
+			return CompNodeCount[A] > CompNodeCount[B];
+		});
+		TArray<int32> CompRank;
+		CompRank.Init(0, NumComp);
+		for (int32 i = 0; i < CompOrder.Num(); ++i)
+		{
+			CompRank[CompOrder[i]] = i;
+		}
+
+		// rank -> layer -> nodes, seeded in current visual order for determinism.
+		TMap<int32, TMap<int32, TArray<UEdGraphNode*>>> Grid;
+		for (UEdGraphNode* N : Nodes)
+		{
+			Grid.FindOrAdd(CompRank[Comp[N]]).FindOrAdd(Layer[N]).Add(N);
+		}
+		for (TPair<int32, TMap<int32, TArray<UEdGraphNode*>>>& RankPair : Grid)
+		{
+			for (TPair<int32, TArray<UEdGraphNode*>>& LayerPair : RankPair.Value)
+			{
+				LayerPair.Value.Sort([](const UEdGraphNode& A, const UEdGraphNode& B)
+				{
+					if (A.NodePosY != B.NodePosY) return A.NodePosY < B.NodePosY;
+					return A.NodePosX < B.NodePosX;
+				});
+			}
+		}
+
+		// Index of each node within its layer.
+		TMap<UEdGraphNode*, int32> Idx;
+		for (TPair<int32, TMap<int32, TArray<UEdGraphNode*>>>& RankPair : Grid)
+		{
+			for (TPair<int32, TArray<UEdGraphNode*>>& LayerPair : RankPair.Value)
+			{
+				for (int32 i = 0; i < LayerPair.Value.Num(); ++i)
+				{
+					Idx.Add(LayerPair.Value[i], i);
+				}
+			}
+		}
+
+		// Median ordering sweeps (down by predecessors, up by successors) to cut crossings.
+		for (int32 Sweep = 0; Sweep < 4; ++Sweep)
+		{
+			const bool bDown = (Sweep % 2) == 0;
+			for (TPair<int32, TMap<int32, TArray<UEdGraphNode*>>>& RankPair : Grid)
+			{
+				TArray<int32> LayerKeys;
+				RankPair.Value.GetKeys(LayerKeys);
+				LayerKeys.Sort();
+				if (!bDown)
+				{
+					for (int32 a = 0, b = LayerKeys.Num() - 1; a < b; ++a, --b) { LayerKeys.Swap(a, b); }
+				}
+				for (int32 LK : LayerKeys)
+				{
+					TArray<UEdGraphNode*>& LayerNodes = RankPair.Value[LK];
+					TArray<TPair<float, UEdGraphNode*>> Keyed;
+					Keyed.Reserve(LayerNodes.Num());
+					for (UEdGraphNode* N : LayerNodes)
+					{
+						const TArray<UEdGraphNode*>* Adj = bDown ? Pred.Find(N) : Succ.Find(N);
+						float Median = (float)Idx[N];
+						if (Adj && Adj->Num() > 0)
+						{
+							TArray<int32> Positions;
+							for (UEdGraphNode* M : *Adj)
+							{
+								if (const int32* PIdx = Idx.Find(M)) { Positions.Add(*PIdx); }
+							}
+							if (Positions.Num() > 0)
+							{
+								Positions.Sort();
+								Median = (float)Positions[Positions.Num() / 2];
+							}
+						}
+						Keyed.Add(TPair<float, UEdGraphNode*>(Median, N));
+					}
+					Keyed.StableSort([](const TPair<float, UEdGraphNode*>& A, const TPair<float, UEdGraphNode*>& B)
+					{
+						return A.Key < B.Key;
+					});
+					for (int32 i = 0; i < Keyed.Num(); ++i)
+					{
+						LayerNodes[i] = Keyed[i].Value;
+						Idx[LayerNodes[i]] = i;
+					}
+				}
+			}
+		}
+
+		// Assign positions: X by layer, Y stacked by node size, components in stacked bands.
+		const float ColumnWidth = 420.0f;
+		const float RowGap = 56.0f;
+		const float ComponentGap = 160.0f;
+
+		TArray<int32> Ranks;
+		Grid.GetKeys(Ranks);
+		Ranks.Sort();
+
+		float BandTop = OriginY;
+		for (int32 Rank : Ranks)
+		{
+			TMap<int32, TArray<UEdGraphNode*>>& Layers = Grid[Rank];
+
+			float BandHeight = 0.0f;
+			for (TPair<int32, TArray<UEdGraphNode*>>& LayerPair : Layers)
+			{
+				float ColHeight = 0.0f;
+				for (UEdGraphNode* N : LayerPair.Value) { ColHeight += EstimateNodeHeight(N) + RowGap; }
+				BandHeight = FMath::Max(BandHeight, ColHeight);
+			}
+
+			for (TPair<int32, TArray<UEdGraphNode*>>& LayerPair : Layers)
+			{
+				float ColHeight = 0.0f;
+				for (UEdGraphNode* N : LayerPair.Value) { ColHeight += EstimateNodeHeight(N) + RowGap; }
+				ColHeight = FMath::Max(0.0f, ColHeight - RowGap);
+
+				// Center each column within the band so short columns don't drag long diagonal wires.
+				float Cursor = BandTop + FMath::Max(0.0f, (BandHeight - ColHeight) * 0.5f);
+				for (UEdGraphNode* N : LayerPair.Value)
+				{
+					N->Modify();
+					N->NodePosX = (int32)(OriginX + (float)LayerPair.Key * ColumnWidth);
+					N->NodePosY = (int32)Cursor;
+					Cursor += EstimateNodeHeight(N) + RowGap;
+				}
+			}
+
+			BandTop += BandHeight + ComponentGap;
+		}
+
+		return NumComp;
+	}
+} // namespace VibeUELayout
+
 bool UBlueprintService::AutoLayoutGraph(
 	const FString& BlueprintPath,
 	const FString& GraphName,
@@ -10270,17 +10579,12 @@ bool UBlueprintService::AutoLayoutGraph(
 		return false;
 	}
 
-	// Collect all layoutable nodes (skip comments and knots for now)
+	// Lay out every node in the graph.
 	TArray<UEdGraphNode*> LayoutNodes;
 	for (UEdGraphNode* Node : Graph->Nodes)
 	{
-		if (Node && Node->CanUserDeleteNode())
+		if (Node)
 		{
-			LayoutNodes.Add(Node);
-		}
-		else if (Node)
-		{
-			// Entry/Result nodes — include them too
 			LayoutNodes.Add(Node);
 		}
 	}
@@ -10290,397 +10594,11 @@ bool UBlueprintService::AutoLayoutGraph(
 		return true; // Nothing to layout
 	}
 
-	// ── Pass 1: Layer Assignment (longest-path from roots) ──
-	// Build adjacency: exec output → target node
-	TMap<UEdGraphNode*, TArray<UEdGraphNode*>> ExecSuccessors;
-	TMap<UEdGraphNode*, TArray<UEdGraphNode*>> ExecPredecessors;
-	TMap<UEdGraphNode*, TArray<UEdGraphNode*>> DataConsumers; // pure node → nodes that use its output
-
-	for (UEdGraphNode* Node : LayoutNodes)
-	{
-		for (UEdGraphPin* Pin : Node->Pins)
-		{
-			if (!Pin) continue;
-
-			if (Pin->Direction == EGPD_Output && Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec)
-			{
-				for (UEdGraphPin* LinkedPin : Pin->LinkedTo)
-				{
-					if (LinkedPin && LinkedPin->GetOwningNode())
-					{
-						UEdGraphNode* Target = LinkedPin->GetOwningNode();
-						ExecSuccessors.FindOrAdd(Node).AddUnique(Target);
-						ExecPredecessors.FindOrAdd(Target).AddUnique(Node);
-					}
-				}
-			}
-			else if (Pin->Direction == EGPD_Output && Pin->PinType.PinCategory != UEdGraphSchema_K2::PC_Exec)
-			{
-				for (UEdGraphPin* LinkedPin : Pin->LinkedTo)
-				{
-					if (LinkedPin && LinkedPin->GetOwningNode())
-					{
-						DataConsumers.FindOrAdd(Node).AddUnique(LinkedPin->GetOwningNode());
-					}
-				}
-			}
-		}
-	}
-
-	// Identify roots: nodes with no incoming exec
-	TArray<UEdGraphNode*> Roots;
-	for (UEdGraphNode* Node : LayoutNodes)
-	{
-		bool bHasExecInput = false;
-		for (UEdGraphPin* Pin : Node->Pins)
-		{
-			if (Pin && Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec && Pin->Direction == EGPD_Input && Pin->LinkedTo.Num() > 0)
-			{
-				bHasExecInput = true;
-				break;
-			}
-		}
-
-		// Also check if node has exec pins at all
-		bool bHasAnyExecPin = false;
-		for (UEdGraphPin* Pin : Node->Pins)
-		{
-			if (Pin && Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec)
-			{
-				bHasAnyExecPin = true;
-				break;
-			}
-		}
-
-		if (!bHasExecInput && bHasAnyExecPin)
-		{
-			Roots.Add(Node);
-		}
-	}
-
-	// BFS to assign layers
-	TMap<UEdGraphNode*, int32> NodeLayer;
-	TQueue<UEdGraphNode*> Queue;
-
-	for (UEdGraphNode* Root : Roots)
-	{
-		NodeLayer.Add(Root, 0);
-		Queue.Enqueue(Root);
-	}
-
-	while (!Queue.IsEmpty())
-	{
-		UEdGraphNode* Current;
-		Queue.Dequeue(Current);
-
-		int32 CurrentLayer = NodeLayer[Current];
-		const TArray<UEdGraphNode*>* Succs = ExecSuccessors.Find(Current);
-		if (Succs)
-		{
-			for (UEdGraphNode* Succ : *Succs)
-			{
-				int32 NewLayer = CurrentLayer + 1;
-				int32* ExistingLayer = NodeLayer.Find(Succ);
-				if (!ExistingLayer || *ExistingLayer < NewLayer)
-				{
-					NodeLayer.Add(Succ, NewLayer);
-					Queue.Enqueue(Succ);
-				}
-			}
-		}
-	}
-
-	// Check if exec-based BFS produced any meaningful layering.
-	// If all layered nodes are at layer 0 (common for pure functions with no exec connections),
-	// fall back to data-flow-based layering instead.
-	bool bExecFlowIsFlat = true;
-	for (auto& Pair : NodeLayer)
-	{
-		if (Pair.Value > 0)
-		{
-			bExecFlowIsFlat = false;
-			break;
-		}
-	}
-
-	if (bExecFlowIsFlat && LayoutNodes.Num() > 1)
-	{
-		// ── Data-flow fallback: assign layers by longest data-flow path from sources ──
-		// Build data-flow adjacency: for each node, find nodes whose outputs feed into it
-		TMap<UEdGraphNode*, TArray<UEdGraphNode*>> DataPredecessors;
-		for (UEdGraphNode* Node : LayoutNodes)
-		{
-			for (UEdGraphPin* Pin : Node->Pins)
-			{
-				if (Pin && Pin->Direction == EGPD_Input && Pin->PinType.PinCategory != UEdGraphSchema_K2::PC_Exec)
-				{
-					for (UEdGraphPin* LinkedPin : Pin->LinkedTo)
-					{
-						if (LinkedPin && LinkedPin->GetOwningNode())
-						{
-							DataPredecessors.FindOrAdd(Node).AddUnique(LinkedPin->GetOwningNode());
-						}
-					}
-				}
-			}
-		}
-
-		// Topological sort via BFS (Kahn's algorithm) to assign layers by data-flow depth.
-		// Nodes with no data predecessors start at layer 0.
-		NodeLayer.Empty();
-
-		// Compute in-degree for each node in data flow
-		TMap<UEdGraphNode*, int32> InDegree;
-		for (UEdGraphNode* Node : LayoutNodes)
-		{
-			InDegree.FindOrAdd(Node); // ensure entry exists (default 0)
-		}
-		for (auto& Pair : DataPredecessors)
-		{
-			InDegree.FindOrAdd(Pair.Key) = Pair.Value.Num();
-		}
-
-		// Seed BFS with data sources (in-degree 0)
-		TQueue<UEdGraphNode*> DataQueue;
-		for (auto& Pair : InDegree)
-		{
-			if (Pair.Value == 0)
-			{
-				NodeLayer.Add(Pair.Key, 0);
-				DataQueue.Enqueue(Pair.Key);
-			}
-		}
-
-		while (!DataQueue.IsEmpty())
-		{
-			UEdGraphNode* Current;
-			DataQueue.Dequeue(Current);
-			int32 CurrentLayer = NodeLayer.FindRef(Current);
-
-			const TArray<UEdGraphNode*>* Consumers = DataConsumers.Find(Current);
-			if (Consumers)
-			{
-				for (UEdGraphNode* Consumer : *Consumers)
-				{
-					int32 NewLayer = CurrentLayer + 1;
-					int32* ExistingLayer = NodeLayer.Find(Consumer);
-					if (!ExistingLayer || *ExistingLayer < NewLayer)
-					{
-						NodeLayer.Add(Consumer, NewLayer);
-					}
-
-					// Decrement in-degree; enqueue when all predecessors processed
-					int32& Deg = InDegree.FindOrAdd(Consumer);
-					Deg--;
-					if (Deg <= 0)
-					{
-						DataQueue.Enqueue(Consumer);
-					}
-				}
-			}
-		}
-
-		// Assign any remaining unreached nodes to layer 0
-		for (UEdGraphNode* Node : LayoutNodes)
-		{
-			if (!NodeLayer.Contains(Node))
-			{
-				NodeLayer.Add(Node, 0);
-			}
-		}
-	}
-	else
-	{
-		// Original exec-based layering worked — place pure nodes relative to consumers.
-		for (UEdGraphNode* Node : LayoutNodes)
-		{
-			if (NodeLayer.Contains(Node)) continue;
-
-			bool bHasExecPin = false;
-			for (UEdGraphPin* Pin : Node->Pins)
-			{
-				if (Pin && Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec)
-				{
-					bHasExecPin = true;
-					break;
-				}
-			}
-
-			if (!bHasExecPin)
-			{
-				// Find the minimum layer of any consumer
-				int32 MinConsumerLayer = INT32_MAX;
-				const TArray<UEdGraphNode*>* Consumers = DataConsumers.Find(Node);
-				if (Consumers)
-				{
-					for (UEdGraphNode* Consumer : *Consumers)
-					{
-						const int32* ConsumerLayer = NodeLayer.Find(Consumer);
-						if (ConsumerLayer && *ConsumerLayer < MinConsumerLayer)
-						{
-							MinConsumerLayer = *ConsumerLayer;
-						}
-					}
-				}
-
-				if (MinConsumerLayer == INT32_MAX)
-				{
-					MinConsumerLayer = 0; // Disconnected pure node
-				}
-
-				// Place pure nodes one column LEFT of their consumer so they appear
-				// as data inputs flowing into the exec node, not stacked alongside it.
-				NodeLayer.Add(Node, FMath::Max(0, MinConsumerLayer - 1));
-			}
-			else
-			{
-				// Exec node never reached by BFS — disconnected island
-				NodeLayer.Add(Node, 0);
-			}
-		}
-	}
-
-	// ── Pass 2: Identify connected execution chains for vertical band separation ──
-	// Each independent event chain gets its own Y band so chains never overlap.
-	// Build reverse data lookup: consumer → pure nodes that feed it.
-	TMap<UEdGraphNode*, TArray<UEdGraphNode*>> DataProviders;
-	for (auto& Pair : DataConsumers)
-		for (UEdGraphNode* Consumer : Pair.Value)
-			DataProviders.FindOrAdd(Consumer).AddUnique(Pair.Key);
-
-	// BFS flood-fill treating exec + data edges as undirected to find components.
-	TMap<UEdGraphNode*, int32> NodeChainId;
-	int32 NumChains = 0;
-	for (UEdGraphNode* StartNode : LayoutNodes)
-	{
-		if (NodeChainId.Contains(StartNode)) continue;
-		int32 ChainId = NumChains++;
-		TQueue<UEdGraphNode*> BFSQ;
-		BFSQ.Enqueue(StartNode);
-		NodeChainId.Add(StartNode, ChainId);
-		while (!BFSQ.IsEmpty())
-		{
-			UEdGraphNode* Cur;
-			BFSQ.Dequeue(Cur);
-			auto Visit = [&](UEdGraphNode* N)
-			{
-				if (N && !NodeChainId.Contains(N))
-				{
-					NodeChainId.Add(N, ChainId);
-					BFSQ.Enqueue(N);
-				}
-			};
-			if (const TArray<UEdGraphNode*>* S = ExecSuccessors.Find(Cur))   for (UEdGraphNode* N : *S) Visit(N);
-			if (const TArray<UEdGraphNode*>* P = ExecPredecessors.Find(Cur)) for (UEdGraphNode* N : *P) Visit(N);
-			if (const TArray<UEdGraphNode*>* P = DataProviders.Find(Cur))    for (UEdGraphNode* N : *P) Visit(N);
-			if (const TArray<UEdGraphNode*>* C = DataConsumers.Find(Cur))    for (UEdGraphNode* N : *C) Visit(N);
-		}
-	}
-
-	// Sort chains: most event nodes first, then by total node count (largest chains on top).
-	TMap<int32, int32> ChainEventCount;
-	TMap<int32, int32> ChainNodeCount;
-	for (auto& Pair : NodeChainId)
-	{
-		ChainNodeCount.FindOrAdd(Pair.Value)++;
-		if (Pair.Key->IsA<UK2Node_Event>() || Pair.Key->IsA<UK2Node_CustomEvent>())
-			ChainEventCount.FindOrAdd(Pair.Value)++;
-	}
-
-	TArray<int32> ChainOrder;
-	for (int32 i = 0; i < NumChains; i++) ChainOrder.Add(i);
-	ChainOrder.Sort([&](int32 A, int32 B)
-	{
-		int32 AE = ChainEventCount.FindRef(A), BE = ChainEventCount.FindRef(B);
-		if (AE != BE) return AE > BE;
-		return ChainNodeCount.FindRef(A) > ChainNodeCount.FindRef(B);
-	});
-
-	TMap<int32, int32> ChainRank; // original chain ID → display rank
-	for (int32 i = 0; i < ChainOrder.Num(); i++)
-		ChainRank.Add(ChainOrder[i], i);
-
-	// ── Pass 3: Group by (chain rank, layer) and sort within each group ──
-	// Rank → Layer → nodes
-	TMap<int32, TMap<int32, TArray<UEdGraphNode*>>> ChainLayerMap;
-	for (auto& Pair : NodeLayer)
-	{
-		int32 Rank = ChainRank.FindRef(NodeChainId.FindRef(Pair.Key));
-		ChainLayerMap.FindOrAdd(Rank).FindOrAdd(Pair.Value).Add(Pair.Key);
-	}
-
-	// Within each (chain, layer): event nodes first, then exec nodes, then pure nodes.
-	// Within each group sort alphabetically.
-	for (auto& ChainPair : ChainLayerMap)
-	{
-		for (auto& LayerPair : ChainPair.Value)
-		{
-			LayerPair.Value.Sort([](const UEdGraphNode& A, const UEdGraphNode& B)
-			{
-				bool aIsEvent = A.IsA<UK2Node_Event>() || A.IsA<UK2Node_CustomEvent>();
-				bool bIsEvent = B.IsA<UK2Node_Event>() || B.IsA<UK2Node_CustomEvent>();
-				if (aIsEvent != bIsEvent) return aIsEvent;
-
-				bool aHasExec = false, bHasExec = false;
-				for (const UEdGraphPin* P : A.Pins)
-					if (P && P->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec) { aHasExec = true; break; }
-				for (const UEdGraphPin* P : B.Pins)
-					if (P && P->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec) { bHasExec = true; break; }
-				if (aHasExec != bHasExec) return aHasExec;
-
-				return A.GetNodeTitle(ENodeTitleType::FullTitle).ToString()
-					 < B.GetNodeTitle(ENodeTitleType::FullTitle).ToString();
-			});
-		}
-	}
-
-	// ── Pass 4: Assign positions with per-chain Y bands ──
-	// X uses the global layer key (so all chains share aligned columns).
-	// Y uses a per-chain base offset so chains never overlap vertically.
-	const float ColumnWidth  = 450.0f;
-	const float RowHeight    = 180.0f;
-	const float ChainGap     = 120.0f; // extra vertical gap between independent chains
-	const float MarginLeft   = 100.0f;
-	const float MarginTop    = 100.0f;
-
-	// Compute Y base for each chain rank.
-	TArray<int32> SortedRanks;
-	ChainLayerMap.GetKeys(SortedRanks);
-	SortedRanks.Sort();
-
-	TMap<int32, float> ChainBaseY;
-	float CurY = MarginTop;
-	for (int32 Rank : SortedRanks)
-	{
-		ChainBaseY.Add(Rank, CurY);
-		int32 MaxNodesInLayer = 0;
-		for (auto& LayerPair : ChainLayerMap[Rank])
-			MaxNodesInLayer = FMath::Max(MaxNodesInLayer, LayerPair.Value.Num());
-		CurY += (MaxNodesInLayer * RowHeight) + ChainGap;
-	}
-
 	FScopedTransaction Transaction(NSLOCTEXT("BlueprintService", "AutoLayout", "Auto-Layout Graph"));
-
-	for (auto& ChainPair : ChainLayerMap)
-	{
-		float BaseY = ChainBaseY.FindRef(ChainPair.Key);
-		for (auto& LayerPair : ChainPair.Value)
-		{
-			int32 LayerKey = LayerPair.Key;
-			const TArray<UEdGraphNode*>& Nodes = LayerPair.Value;
-			for (int32 NodeIdx = 0; NodeIdx < Nodes.Num(); NodeIdx++)
-			{
-				UEdGraphNode* Node = Nodes[NodeIdx];
-				Node->Modify();
-				Node->NodePosX = MarginLeft + (LayerKey * ColumnWidth);
-				Node->NodePosY = BaseY + (NodeIdx * RowHeight);
-			}
-		}
-	}
-
+	const int32 NumChains = VibeUELayout::LayeredLayout(LayoutNodes, 100.0f, 100.0f);
 	FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
 
-	UE_LOG(LogTemp, Log, TEXT("AutoLayoutGraph: Laid out %d nodes in %d chains in %s::%s"),
+	UE_LOG(LogTemp, Log, TEXT("AutoLayoutGraph: Laid out %d nodes in %d components in %s::%s"),
 		LayoutNodes.Num(), NumChains, *BlueprintPath, *GraphName);
 
 	return true;
@@ -10739,352 +10657,20 @@ bool UBlueprintService::AutoLayoutSelectedNodes(
 		return false;
 	}
 
-	// Build a fast lookup set of selected node pointers so adjacency stays within the selection
-	TSet<UEdGraphNode*> SelectedSet(LayoutNodes);
-
-	// ── Pass 1: Layer Assignment (longest-path from roots within the selection) ──
-	TMap<UEdGraphNode*, TArray<UEdGraphNode*>> ExecSuccessors;
-	TMap<UEdGraphNode*, TArray<UEdGraphNode*>> ExecPredecessors;
-	TMap<UEdGraphNode*, TArray<UEdGraphNode*>> DataConsumers;
-
-	for (UEdGraphNode* Node : LayoutNodes)
-	{
-		for (UEdGraphPin* Pin : Node->Pins)
-		{
-			if (!Pin) continue;
-
-			if (Pin->Direction == EGPD_Output && Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec)
-			{
-				for (UEdGraphPin* LinkedPin : Pin->LinkedTo)
-				{
-					if (LinkedPin && LinkedPin->GetOwningNode() && SelectedSet.Contains(LinkedPin->GetOwningNode()))
-					{
-						UEdGraphNode* Target = LinkedPin->GetOwningNode();
-						ExecSuccessors.FindOrAdd(Node).AddUnique(Target);
-						ExecPredecessors.FindOrAdd(Target).AddUnique(Node);
-					}
-				}
-			}
-			else if (Pin->Direction == EGPD_Output && Pin->PinType.PinCategory != UEdGraphSchema_K2::PC_Exec)
-			{
-				for (UEdGraphPin* LinkedPin : Pin->LinkedTo)
-				{
-					if (LinkedPin && LinkedPin->GetOwningNode() && SelectedSet.Contains(LinkedPin->GetOwningNode()))
-					{
-						DataConsumers.FindOrAdd(Node).AddUnique(LinkedPin->GetOwningNode());
-					}
-				}
-			}
-		}
-	}
-
-	// Identify roots: selected nodes with no incoming exec from another selected node
-	TArray<UEdGraphNode*> Roots;
-	for (UEdGraphNode* Node : LayoutNodes)
-	{
-		bool bHasExecInput = false;
-		for (UEdGraphPin* Pin : Node->Pins)
-		{
-			if (Pin && Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec && Pin->Direction == EGPD_Input && Pin->LinkedTo.Num() > 0)
-			{
-				for (UEdGraphPin* LinkedPin : Pin->LinkedTo)
-				{
-					if (LinkedPin && SelectedSet.Contains(LinkedPin->GetOwningNode()))
-					{
-						bHasExecInput = true;
-						break;
-					}
-				}
-			}
-			if (bHasExecInput) break;
-		}
-
-		bool bHasAnyExecPin = false;
-		for (UEdGraphPin* Pin : Node->Pins)
-		{
-			if (Pin && Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec)
-			{
-				bHasAnyExecPin = true;
-				break;
-			}
-		}
-
-		if (!bHasExecInput && bHasAnyExecPin)
-		{
-			Roots.Add(Node);
-		}
-	}
-
-	// BFS to assign exec layers
-	TMap<UEdGraphNode*, int32> NodeLayer;
-	TQueue<UEdGraphNode*> Queue;
-
-	for (UEdGraphNode* Root : Roots)
-	{
-		NodeLayer.Add(Root, 0);
-		Queue.Enqueue(Root);
-	}
-
-	while (!Queue.IsEmpty())
-	{
-		UEdGraphNode* Current;
-		Queue.Dequeue(Current);
-		int32 CurrentLayer = NodeLayer[Current];
-		const TArray<UEdGraphNode*>* Succs = ExecSuccessors.Find(Current);
-		if (Succs)
-		{
-			for (UEdGraphNode* Succ : *Succs)
-			{
-				int32 NewLayer = CurrentLayer + 1;
-				int32* ExistingLayer = NodeLayer.Find(Succ);
-				if (!ExistingLayer || *ExistingLayer < NewLayer)
-				{
-					NodeLayer.Add(Succ, NewLayer);
-					Queue.Enqueue(Succ);
-				}
-			}
-		}
-	}
-
-	// Check if exec-based BFS produced meaningful layering; fall back to data-flow if not
-	bool bExecFlowIsFlat = true;
-	for (auto& Pair : NodeLayer)
-	{
-		if (Pair.Value > 0) { bExecFlowIsFlat = false; break; }
-	}
-
-	if (bExecFlowIsFlat && LayoutNodes.Num() > 1)
-	{
-		TMap<UEdGraphNode*, TArray<UEdGraphNode*>> DataPredecessors;
-		for (UEdGraphNode* Node : LayoutNodes)
-		{
-			for (UEdGraphPin* Pin : Node->Pins)
-			{
-				if (Pin && Pin->Direction == EGPD_Input && Pin->PinType.PinCategory != UEdGraphSchema_K2::PC_Exec)
-				{
-					for (UEdGraphPin* LinkedPin : Pin->LinkedTo)
-					{
-						if (LinkedPin && LinkedPin->GetOwningNode() && SelectedSet.Contains(LinkedPin->GetOwningNode()))
-						{
-							DataPredecessors.FindOrAdd(Node).AddUnique(LinkedPin->GetOwningNode());
-						}
-					}
-				}
-			}
-		}
-
-		NodeLayer.Empty();
-		TMap<UEdGraphNode*, int32> InDegree;
-		for (UEdGraphNode* Node : LayoutNodes) InDegree.FindOrAdd(Node);
-		for (auto& Pair : DataPredecessors) InDegree.FindOrAdd(Pair.Key) = Pair.Value.Num();
-
-		TQueue<UEdGraphNode*> DataQueue;
-		for (auto& Pair : InDegree)
-		{
-			if (Pair.Value == 0) { NodeLayer.Add(Pair.Key, 0); DataQueue.Enqueue(Pair.Key); }
-		}
-
-		while (!DataQueue.IsEmpty())
-		{
-			UEdGraphNode* Current;
-			DataQueue.Dequeue(Current);
-			int32 CurrentLayer = NodeLayer.FindRef(Current);
-			const TArray<UEdGraphNode*>* Consumers = DataConsumers.Find(Current);
-			if (Consumers)
-			{
-				for (UEdGraphNode* Consumer : *Consumers)
-				{
-					int32 NewLayer = CurrentLayer + 1;
-					int32* ExistingLayer = NodeLayer.Find(Consumer);
-					if (!ExistingLayer || *ExistingLayer < NewLayer)
-						NodeLayer.Add(Consumer, NewLayer);
-					int32& Deg = InDegree.FindOrAdd(Consumer);
-					Deg--;
-					if (Deg <= 0) DataQueue.Enqueue(Consumer);
-				}
-			}
-		}
-
-		for (UEdGraphNode* Node : LayoutNodes)
-		{
-			if (!NodeLayer.Contains(Node)) NodeLayer.Add(Node, 0);
-		}
-	}
-	else
-	{
-		for (UEdGraphNode* Node : LayoutNodes)
-		{
-			if (NodeLayer.Contains(Node)) continue;
-
-			bool bHasExecPin = false;
-			for (UEdGraphPin* Pin : Node->Pins)
-			{
-				if (Pin && Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec) { bHasExecPin = true; break; }
-			}
-
-			if (!bHasExecPin)
-			{
-				int32 MinConsumerLayer = INT32_MAX;
-				const TArray<UEdGraphNode*>* Consumers = DataConsumers.Find(Node);
-				if (Consumers)
-				{
-					for (UEdGraphNode* Consumer : *Consumers)
-					{
-						const int32* ConsumerLayer = NodeLayer.Find(Consumer);
-						if (ConsumerLayer && *ConsumerLayer < MinConsumerLayer)
-							MinConsumerLayer = *ConsumerLayer;
-					}
-				}
-				if (MinConsumerLayer == INT32_MAX) MinConsumerLayer = 0;
-				NodeLayer.Add(Node, FMath::Max(0, MinConsumerLayer - 1));
-			}
-			else
-			{
-				NodeLayer.Add(Node, 0);
-			}
-		}
-	}
-
-	// ── Pass 2: Chain identification (flood-fill within selection) ──
-	TMap<UEdGraphNode*, TArray<UEdGraphNode*>> DataProviders;
-	for (auto& Pair : DataConsumers)
-		for (UEdGraphNode* Consumer : Pair.Value)
-			DataProviders.FindOrAdd(Consumer).AddUnique(Pair.Key);
-
-	TMap<UEdGraphNode*, int32> NodeChainId;
-	int32 NumChains = 0;
-	for (UEdGraphNode* StartNode : LayoutNodes)
-	{
-		if (NodeChainId.Contains(StartNode)) continue;
-		int32 ChainId = NumChains++;
-		TQueue<UEdGraphNode*> BFSQ;
-		BFSQ.Enqueue(StartNode);
-		NodeChainId.Add(StartNode, ChainId);
-		while (!BFSQ.IsEmpty())
-		{
-			UEdGraphNode* Cur;
-			BFSQ.Dequeue(Cur);
-			auto Visit = [&](UEdGraphNode* N)
-			{
-				if (N && SelectedSet.Contains(N) && !NodeChainId.Contains(N))
-				{
-					NodeChainId.Add(N, ChainId);
-					BFSQ.Enqueue(N);
-				}
-			};
-			if (const TArray<UEdGraphNode*>* S = ExecSuccessors.Find(Cur))   for (UEdGraphNode* N : *S) Visit(N);
-			if (const TArray<UEdGraphNode*>* P = ExecPredecessors.Find(Cur)) for (UEdGraphNode* N : *P) Visit(N);
-			if (const TArray<UEdGraphNode*>* P = DataProviders.Find(Cur))    for (UEdGraphNode* N : *P) Visit(N);
-			if (const TArray<UEdGraphNode*>* C = DataConsumers.Find(Cur))    for (UEdGraphNode* N : *C) Visit(N);
-		}
-	}
-
-	TMap<int32, int32> ChainEventCount;
-	TMap<int32, int32> ChainNodeCount;
-	for (auto& Pair : NodeChainId)
-	{
-		ChainNodeCount.FindOrAdd(Pair.Value)++;
-		if (Pair.Key->IsA<UK2Node_Event>() || Pair.Key->IsA<UK2Node_CustomEvent>())
-			ChainEventCount.FindOrAdd(Pair.Value)++;
-	}
-
-	TArray<int32> ChainOrder;
-	for (int32 i = 0; i < NumChains; i++) ChainOrder.Add(i);
-	ChainOrder.Sort([&](int32 A, int32 B)
-	{
-		int32 AE = ChainEventCount.FindRef(A), BE = ChainEventCount.FindRef(B);
-		if (AE != BE) return AE > BE;
-		return ChainNodeCount.FindRef(A) > ChainNodeCount.FindRef(B);
-	});
-
-	TMap<int32, int32> ChainRank;
-	for (int32 i = 0; i < ChainOrder.Num(); i++)
-		ChainRank.Add(ChainOrder[i], i);
-
-	// ── Pass 3: Group by (chain rank, layer) ──
-	TMap<int32, TMap<int32, TArray<UEdGraphNode*>>> ChainLayerMap;
-	for (auto& Pair : NodeLayer)
-	{
-		int32 Rank = ChainRank.FindRef(NodeChainId.FindRef(Pair.Key));
-		ChainLayerMap.FindOrAdd(Rank).FindOrAdd(Pair.Value).Add(Pair.Key);
-	}
-
-	for (auto& ChainPair : ChainLayerMap)
-	{
-		for (auto& LayerPair : ChainPair.Value)
-		{
-			LayerPair.Value.Sort([](const UEdGraphNode& A, const UEdGraphNode& B)
-			{
-				bool aIsEvent = A.IsA<UK2Node_Event>() || A.IsA<UK2Node_CustomEvent>();
-				bool bIsEvent = B.IsA<UK2Node_Event>() || B.IsA<UK2Node_CustomEvent>();
-				if (aIsEvent != bIsEvent) return aIsEvent;
-
-				bool aHasExec = false, bHasExec = false;
-				for (const UEdGraphPin* P : A.Pins)
-					if (P && P->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec) { aHasExec = true; break; }
-				for (const UEdGraphPin* P : B.Pins)
-					if (P && P->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec) { bHasExec = true; break; }
-				if (aHasExec != bHasExec) return aHasExec;
-
-				return A.GetNodeTitle(ENodeTitleType::FullTitle).ToString()
-					 < B.GetNodeTitle(ENodeTitleType::FullTitle).ToString();
-			});
-		}
-	}
-
-	// ── Pass 4: Assign positions ──
-	// Use the top-left corner of the current bounding box of the selected nodes as origin,
-	// so the layout stays near where the selection was.
-	float OriginX = FLT_MAX, OriginY = FLT_MAX;
+	// Anchor the layout at the top-left of the current selection so it stays put.
+	float OriginX = (float)LayoutNodes[0]->NodePosX;
+	float OriginY = (float)LayoutNodes[0]->NodePosY;
 	for (UEdGraphNode* Node : LayoutNodes)
 	{
 		OriginX = FMath::Min(OriginX, (float)Node->NodePosX);
 		OriginY = FMath::Min(OriginY, (float)Node->NodePosY);
 	}
-	if (OriginX == FLT_MAX) OriginX = 0.0f;
-	if (OriginY == FLT_MAX) OriginY = 0.0f;
-
-	const float ColumnWidth = 450.0f;
-	const float RowHeight   = 180.0f;
-	const float ChainGap    = 120.0f;
-
-	TArray<int32> SortedRanks;
-	ChainLayerMap.GetKeys(SortedRanks);
-	SortedRanks.Sort();
-
-	TMap<int32, float> ChainBaseY;
-	float CurY = OriginY;
-	for (int32 Rank : SortedRanks)
-	{
-		ChainBaseY.Add(Rank, CurY);
-		int32 MaxNodesInLayer = 0;
-		for (auto& LayerPair : ChainLayerMap[Rank])
-			MaxNodesInLayer = FMath::Max(MaxNodesInLayer, LayerPair.Value.Num());
-		CurY += (MaxNodesInLayer * RowHeight) + ChainGap;
-	}
 
 	FScopedTransaction Transaction(NSLOCTEXT("BlueprintService", "AutoLayoutSelected", "Auto-Layout Selected Nodes"));
-
-	for (auto& ChainPair : ChainLayerMap)
-	{
-		float BaseY = ChainBaseY.FindRef(ChainPair.Key);
-		for (auto& LayerPair : ChainPair.Value)
-		{
-			int32 LayerKey = LayerPair.Key;
-			const TArray<UEdGraphNode*>& Nodes = LayerPair.Value;
-			for (int32 NodeIdx = 0; NodeIdx < Nodes.Num(); NodeIdx++)
-			{
-				UEdGraphNode* Node = Nodes[NodeIdx];
-				Node->Modify();
-				Node->NodePosX = OriginX + (LayerKey * ColumnWidth);
-				Node->NodePosY = BaseY + (NodeIdx * RowHeight);
-			}
-		}
-	}
-
+	const int32 NumChains = VibeUELayout::LayeredLayout(LayoutNodes, OriginX, OriginY);
 	FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
 
-	UE_LOG(LogTemp, Log, TEXT("AutoLayoutSelectedNodes: Laid out %d/%d requested nodes in %d chains in %s::%s"),
+	UE_LOG(LogTemp, Log, TEXT("AutoLayoutSelectedNodes: Laid out %d/%d requested nodes in %d components in %s::%s"),
 		LayoutNodes.Num(), NodeIds.Num(), NumChains, *BlueprintPath, *GraphName);
 
 	return true;

--- a/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
+++ b/Source/VibeUE/Private/Tools/EditorControlToolsRegistration.cpp
@@ -18,6 +18,7 @@
 #include "RenderTimer.h"       // GGameThreadTime / GRenderThreadTime / GRHIThreadTime (RenderCore)
 #include "RHIGlobals.h"        // GGPUFrameTime (RHI)
 #include "HAL/PlatformTime.h"  // FPlatformTime::ToMilliseconds
+#include "PythonAPI/UScreenshotService.h" // synchronous editor/active-window capture for the screenshot action
 
 DEFINE_LOG_CATEGORY_STATIC(LogEditorControl, Log, All);
 
@@ -467,7 +468,8 @@ static FString FrameTimingReport()
 // ---------------------------------------------------------------------------
 
 REGISTER_VIBEUE_TOOL(editor_control,
-	"Control the Unreal Editor and profiler. Actions: start_pie, stop_pie, pie_status, "
+	"Control the Unreal Editor, capture viewport screenshots, and profile. Actions: start_pie, stop_pie, pie_status, "
+	"screenshot (synchronous PNG of the editor/active window so you can SEE what was built and self-review — params: mode=editor_window|active_window, name), "
 	"start_standalone (launches game as separate process with trace attached), stop_standalone, standalone_status, "
 	"profiler_start (begin Unreal Insights trace to file), profiler_stop, profiler_status, "
 	"profiler_bookmark (drop named point in trace), profiler_region_start, profiler_region_end, "
@@ -476,10 +478,11 @@ REGISTER_VIBEUE_TOOL(editor_control,
 	"Editor",
 	TOOL_PARAMS(
 		TOOL_PARAM("action",   "Action to perform — see tool description for full list", "string", true),
-		TOOL_PARAM("name",     "[profiler_start|bookmark|region_*] Trace file name (profiler_start) or label (bookmark/region)", "string", false),
+		TOOL_PARAM("name",     "[profiler_start|bookmark|region_*|screenshot] Trace file name (profiler_start), label (bookmark/region), or output PNG name (screenshot)", "string", false),
 		TOOL_PARAM("channels", "[profiler_start|start_standalone] Comma-separated trace channels. Default: frame,cpu,gpu,log,loadtime,object,stats", "string", false),
 		TOOL_PARAM("source",   "[analyse] What to read: trace, logs, or both (default: both)", "string", false),
-		TOOL_PARAM("file",     "[analyse] Override trace or log file path", "string", false)
+		TOOL_PARAM("file",     "[analyse] Override trace or log file path", "string", false),
+		TOOL_PARAM("mode",     "[screenshot] editor_window (default, whole editor incl. focused tab) or active_window (foreground window, e.g. a separate PIE window)", "string", false)
 	),
 	{
 		FString Action = GetParam(Params, TEXT("action")).ToLower();
@@ -796,7 +799,48 @@ REGISTER_VIBEUE_TOOL(editor_control,
 		// -----------------------------------------------------------------------
 		// Help
 		// -----------------------------------------------------------------------
-		if (Action == TEXT("help"))
+		if (Action == TEXT("screenshot") || Action == TEXT("capture"))
+			{
+				// Synchronous capture for the "build -> look -> fix" self-review loop.
+				// This action is for EXTERNAL MCP clients (Claude Code, Cursor, ...), which
+				// cannot call the internal-only attach_image tool. The VibeUE in-editor chat
+				// must instead capture via execute_python_code -> ScreenshotService +
+				// attach_image, so a returned file path actually enters its vision. Redirect
+				// internal-chat callers (CurrentSession is non-null only for the in-editor chat).
+				if (FToolRegistry::Get().GetCurrentSession() != nullptr)
+				{
+					return ErrJson(TEXT("USE_PYTHON_API"),
+						TEXT("The editor_control 'screenshot' action is for external MCP clients only. From the VibeUE chat, capture with execute_python_code -> unreal.ScreenshotService.capture_editor_window(\"name\"), then call the attach_image tool with the returned file_path so the image enters your vision. Load the 'screenshots' skill for the full workflow."));
+				}
+
+				const FString Mode = GetParam(Params, TEXT("mode"), TEXT("editor_window")).ToLower();
+				const FString Name = GetParam(Params, TEXT("name"), TEXT("editor_control_capture"));
+
+				const FScreenshotResult Shot = (Mode == TEXT("active_window"))
+					? UScreenshotService::CaptureActiveWindow(Name)
+					: UScreenshotService::CaptureEditorWindow(Name);
+
+				if (!Shot.bSuccess)
+				{
+					return ErrJson(TEXT("CAPTURE_FAILED"), Shot.Message);
+				}
+
+				TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+				R->SetStringField(TEXT("file_path"),       Shot.FilePath);
+				R->SetNumberField(TEXT("width"),           Shot.Width);
+				R->SetNumberField(TEXT("height"),          Shot.Height);
+				R->SetStringField(TEXT("captured_window"), Shot.CapturedWindowTitle);
+				R->SetStringField(TEXT("mode"),            Mode);
+				R->SetStringField(TEXT("hint"),
+					TEXT("Synchronous capture saved to disk - read/open the PNG at file_path to review what was built, then fix and re-capture. ")
+					TEXT("To see the running game, start_pie first; if PIE opens its own window use mode=active_window."));
+				return OkJson(R);
+			}
+
+			// -----------------------------------------------------------------------
+			// Help
+			// -----------------------------------------------------------------------
+			if (Action == TEXT("help"))
 		{
 			TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
 			R->SetStringField(TEXT("tool"), TEXT("editor_control"));
@@ -824,6 +868,7 @@ REGISTER_VIBEUE_TOOL(editor_control,
 			A(TEXT("profiler_region_end"),   TEXT("End a named region in the active trace. Params: name (required)"));
 			A(TEXT("analyse"),             TEXT("Read and summarise trace + logs. Params: source (trace|logs|both, default both), file (override path)"));
 			A(TEXT("frame_timing"),        TEXT("Report Game/Render/GPU/RHI thread ms + CPU-vs-GPU bound verdict for the last rendered frame (same data as 'stat unit'). RUN THIS FIRST in any frame-rate investigation. Alias: bound."));
+				A(TEXT("screenshot"),          TEXT("Synchronous PNG capture of the editor (or active window) for visual self-review — build, then SEE it. Params: mode (editor_window|active_window), name. Alias: capture. External MCP clients only; the in-editor VibeUE chat captures via ScreenshotService + attach_image instead."));
 
 			R->SetArrayField(TEXT("actions"), Actions);
 
@@ -832,7 +877,8 @@ REGISTER_VIBEUE_TOOL(editor_control,
 			Workflow->SetStringField(TEXT("in_editor"),  TEXT("profiler_start → [hit PIE] → profiler_stop → analyse"));
 			Workflow->SetStringField(TEXT("standalone"), TEXT("start_standalone → [game loads] → stop_standalone → analyse"));
 			Workflow->SetStringField(TEXT("pie_only"),   TEXT("start_pie → profiler_start → [play] → profiler_stop → stop_pie → analyse"));
-			R->SetObjectField(TEXT("common_workflows"), Workflow);
+			Workflow->SetStringField(TEXT("self_review"), TEXT("start_pie -> screenshot (mode=active_window) -> read the PNG -> fix -> screenshot again. For editor/asset views use screenshot (mode=editor_window)."));
+				R->SetObjectField(TEXT("common_workflows"), Workflow);
 
 			return OkJson(R);
 		}


### PR DESCRIPTION
Merges the `5-7` working branch into `master`. Highlights:

## Blueprint auto-layout rewrite (fixes spaghetti graphs)
`auto_layout_graph` / `auto_layout_selected_nodes` rebuilt as one shared layered (Sugiyama-style) layouter:
- **Columns by dependency depth** — longest path over combined exec + data edges, so data chains flow left→right instead of collapsing into one column.
- **Cycle-safe** — DFS back-edge removal (seeded from event entry points) so loops/back-edges never inflate graph width.
- **Crossing reduction** — median ordering sweeps; fan-out siblings (branch then/else, sequence, loop body/completed) keep pin order.
- **Straight backbones** — exec-weighted neighbor-median Y alignment; data feeds in from the side.
- Size-aware row spacing, non-overlapping component bands, idempotent (re-running moves nothing). Verified on a 31-node stress graph; median wire ≈ 65px vertical.

## editor_control: screenshot + viewport self-review (#430)
- New `screenshot`/`capture` action — synchronous editor/active-window PNG so external MCP clients get the "build → look → fix" loop in one call (redirects the in-editor chat to the ScreenshotService Python path).
- AGENTS.md.sample / instructions / screenshots skill / README updated to surface viewport + scene + PIE coverage and the self-review loop.

## editor_control: PIE / standalone / profiling
- PIE + standalone play control, Unreal Insights profiler (`profiler_*`), `frame_timing` CPU-vs-GPU bound verdict, `analyse` (trace+logs), with cross-platform process handling and UTS trace auto-detection.
- New `profiling` and `frame-rate` skills.

## Build hardening
- Strict warnings-as-errors for the VibeUE module; UE 5.7 build fixes (UDataTableService, ULandscapeService).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
