### PR TITLE
docs(agents): execute_tool for Epic toolsets + trim intro

### DIFF
--- a/Content/samples/AGENTS.md.sample
+++ b/Content/samples/AGENTS.md.sample
@@ -1,9 +1,7 @@
 # VibeUE — AI agent guide (Unreal Engine 5.8)
 
-VibeUE is a plugin that **extends Unreal 5.8's native AI toolset system**. Its services, tools, and
-skills register into the engine's own `ToolsetRegistry` + `ModelContextProtocol` and are served from
-Unreal's MCP endpoint (default `http://localhost:8000/mcp`). There is **no separate VibeUE server,
-no API key, and no in-editor chat** — you talk to the engine's endpoint.
+VibeUE **extends Unreal 5.8's native AI toolset system** — its services, tools, and skills register
+into the engine's `ToolsetRegistry` and are reachable through the MCP tools you already have.
 
 **ALWAYS use the MCP tools / Python API for Unreal operations — NEVER read `.uasset` files from disk.**
 
@@ -25,12 +23,9 @@ There are two ways to act on the editor. Pick the cheap one:
   (see §2), so batch engine-toolset calls with your Python instead of spending a round-trip. Don't
   use `call_tool` for work `execute_python_code` can batch.
 
-**Rules of thumb (speed + tokens):**
-1. Default to `execute_python_code`; one call should accomplish a logical step, not one operation.
-2. `call_tool` only for skills and Epic-only toolsets (below).
-3. **Avoid `describe_toolset` as a habit** — it dumps the full JSON schema of every tool in a toolset
-   (the most token-heavy thing here). Reach for a **skill** + `discover_python_class` instead.
-4. Discover signatures narrowly: `discover_python_class('unreal.BlueprintService', method_filter='variable')`.
+**Speed + tokens:** **avoid `describe_toolset` as a habit** — it dumps the full JSON schema of every
+tool in a toolset (the most token-heavy thing here); reach for a **skill** plus a narrow
+`discover_python_class('unreal.BlueprintService', method_filter='variable')` instead.
 
 ---
 

--- a/Content/samples/AGENTS.md.sample
+++ b/Content/samples/AGENTS.md.sample
@@ -18,9 +18,12 @@ There are two ways to act on the editor. Pick the cheap one:
   and sits next to the whole native `unreal.*` API in the same script. **Batch aggressively** — do a
   whole multi-step task (create + edit + compile + verify) in a single call, and `print()` only what
   you need back.
-- **`call_tool` — one tool per round-trip.** Use it only for things that are **not** Python-callable:
-  loading **skills** (`AgentSkillToolset`), and the few Epic toolsets with no good Python path
-  (screenshots, etc.). Don't use it to do work `execute_python_code` can batch.
+- **`call_tool` — one tool per round-trip.** Genuinely needed only for **skills**
+  (`AgentSkillToolset`) and for the few Epic tools whose **result the MCP layer must surface for
+  you** (image returns like `CaptureViewport`). **Everything else from Epic's engine toolsets is
+  also reachable from inside `execute_python_code`** via `unreal.ToolsetRegistry.execute_tool(...)`
+  (see §2), so batch engine-toolset calls with your Python instead of spending a round-trip. Don't
+  use `call_tool` for work `execute_python_code` can batch.
 
 **Rules of thumb (speed + tokens):**
 1. Default to `execute_python_code`; one call should accomplish a logical step, not one operation.
@@ -50,16 +53,40 @@ GameplayTag, Viewport, Actor, Engine/ProjectSettings, **Performance** (`unreal.P
 These overlap-trimmed services keep only what the engine lacks — for plain asset/actor/blueprint
 basics the engine's own tools may be simpler (below).
 
+**Calling Epic's engine toolsets from Python (`execute_tool`).** Epic's engine toolset *classes*
+exist as `unreal.*` (e.g. `unreal.EditorAppToolset`) but their AICallable functions are **not**
+exposed as Python methods — `unreal.EditorAppToolset.get_selected_assets()` fails. Invoke them
+through the registry instead (same dispatch `call_tool` uses, but in-process and batchable):
+```python
+import unreal, json
+res = unreal.ToolsetRegistry.execute_tool(
+    "EditorToolset.EditorAppToolset",   # registered (namespaced) toolset name
+    "GetSelectedAssets",                # tool name
+    "{}")                               # args as a JSON string
+assert res.is_complete and not res.error, res.error
+out = json.loads(res.get_value_as_json_string())     # -> {"returnValue": ...}
+```
+Discover exact names/schemas from Python: `unreal.ToolsetRegistry.get_all_toolset_json_schemas()`
+(all of them) or `get_toolset_json_schema("EditorToolset.EditorAppToolset")` (one). Names are
+namespaced — `EditorToolset.EditorAppToolset`, `NiagaraToolsets.NiagaraToolset_System`, etc. (a bare
+`"EditorAppToolset"` returns "Toolset not found"). Note `execute_tool` returns an **async** result:
+the editor tools above complete synchronously (`is_complete=True`), but for a long-running tool check
+`is_complete` / bind `on_completed` rather than assuming `value` is ready.
+
 **Use the engine's native tools for these (VibeUE intentionally doesn't duplicate them):**
 - **Assets** (find / save / move / delete / duplicate / metadata): native Python
   `unreal.EditorAssetLibrary` / `EditorAssetSubsystem` inside `execute_python_code` (batchable), or
-  Epic's `AssetTools` toolset via `call_tool`.
-- **Screenshots / vision**: Epic's `EditorAppToolset` via `call_tool` — `CaptureViewport` (returns a
-  PNG, and can overlay a world grid + actor labels), `CaptureEditorImage`, `CaptureAssetImage`.
-- **PIE**: Epic's `EditorAppToolset.StartPIE` / `StopPIE` / `IsPIERunning` via `call_tool`.
-- **Logs**: Epic's `LogsToolset.GetLogEntries` via `call_tool` (or read the `.log` file).
+  Epic's `AssetTools` toolset (via `execute_tool` in-Python, or `call_tool`).
+- **Screenshots / vision**: Epic's `EditorAppToolset` — `CaptureViewport` (returns a PNG, and can
+  overlay a world grid + actor labels), `CaptureEditorImage`, `CaptureAssetImage`. **Use `call_tool`
+  for these** so the MCP layer surfaces the image for you to view (`execute_tool` would only hand
+  back a base64 string).
+- **PIE**: `EditorAppToolset.StartPIE` / `StopPIE` / `IsPIERunning` — batchable via `execute_tool`
+  (`"EditorToolset.EditorAppToolset"`), or `call_tool`.
+- **Logs**: `LogsToolset.GetLogEntries` — via `execute_tool` or `call_tool` (or read the `.log` file).
 - **DataTables / DataAssets / enum-struct basics**: Epic's `DataTableTools` / `DataAssetTools` /
-  `ObjectTools`. (VibeUE keeps only `EnumStructService` for create/edit of user enums & structs.)
+  `ObjectTools` (via `execute_tool` or `call_tool`). (VibeUE keeps only `EnumStructService` for
+  create/edit of user enums & structs.)
 
 ---
 


### PR DESCRIPTION
Follow-up to #473 (already merged) — two AGENTS.md.sample doc commits pushed after that merge.

- **Epic engine toolsets are callable from Python** via `unreal.ToolsetRegistry.execute_tool(toolset, tool, json_input)` (the same dispatch `call_tool` uses, but in-process and batchable). Documents the pattern, schema discovery (`get_all_toolset_json_schemas` / `get_toolset_json_schema`), the namespaced tool names, and the async-result caveat. `call_tool` is now scoped to skills + image-returning tools (`CaptureViewport`). Verified live.
- **Efficiency trim:** dropped the non-actionable intro (MCP endpoint URL/port, "no separate server / API key / chat") and the redundant rules-of-thumb items that restated the `execute_python_code` / `call_tool` bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)