### PR TITLE
Remove deprecated StructUtils dependency

### DIFF
--- a/Source/VibeUE/VibeUE.Build.cs
+++ b/Source/VibeUE/VibeUE.Build.cs
@@ -101,7 +101,6 @@ public class VibeUE : ModuleRules
 				"MetasoundEngine",        // For UMetaSoundSource, UMetaSoundBuilderSubsystem, UMetaSoundSourceBuilder
 				"MetasoundFrontend",      // For FMetaSoundFrontendDocumentBuilder, FMetasoundFrontendClassName, ISearchEngine
 				"MetasoundGraphCore",     // For core MetaSound graph types
-				"StructUtils",            // For FInstancedStruct / MakeInstancedStruct support
 				"MeshDescription",        // For FMeshDescription / TVertexInstanceAttributesRef (UV editing)
 				"StaticMeshDescription",  // For FStaticMeshAttributes / FStaticMeshOperations / FUVMapParameters
 				"ToolsetRegistry",        // UE 5.8 native AI toolset registry — exposes services as AICallable tools on Epic's MCP endpoint

--- a/VibeUE.uplugin
+++ b/VibeUE.uplugin
@@ -62,10 +62,6 @@
 			"Enabled": true
 		},
 		{
-			"Name": "StructUtils",
-			"Enabled": true
-		},
-		{
 			"Name": "GameplayTagsEditor",
 			"Enabled": true
 		},


### PR DESCRIPTION
## Summary
- remove the deprecated StructUtils plugin dependency from VibeUE.uplugin
- remove the deprecated StructUtils module dependency from VibeUE.Build.cs

## Notes
In UE 5.8, the StructUtils plugin is deprecated. The StructUtils headers used by VibeUE are available through CoreUObject, and Engine is already listed as a module dependency for the Blueprint library lookup path.

## Testing
- Parsed VibeUE.uplugin as JSON
- Verified the plugin/build files no longer reference StructUtils
- Verified in a UE 5.8 project that the VibeUE StructUtils deprecation warnings disappear before the build stops due to -NoEngineChanges protecting engine binaries