### PR TITLE
Merge 5-8 into master: Fab submission prep, MapBlockout verification, foliage fix

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/UFoliageService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UFoliageService.cpp
@@ -40,8 +40,8 @@ AInstancedFoliageActor* UFoliageService::GetOrCreateFoliageActor(UWorld* World)
 		return nullptr;
 	}
 
-	// Find existing IFA
-	for (TActorIterator<AInstancedFoliageActor> It(World); It; ++It)
+	// Find existing IFA (return the first one if any exist)
+	if (TActorIterator<AInstancedFoliageActor> It(World); It)
 	{
 		return *It;
 	}


### PR DESCRIPTION
## Summary

Brings the `5-8` branch (UE 5.8 / native-MCP) into `master`. 4 commits, +291/-2380 lines.

- **Fab submission prep + MapBlockout verification** (#481) — descriptor/version updates, MapBlockout service refactors, and removal of the large `Tests/MapBlockout/reference` scratch data (~2.3k lines of Python references and example JSON).
- **Foliage fix** (#485) — avoid an unreachable loop increment in `GetOrCreateFoliageActor` ([UFoliageService.cpp](Source/VibeUE/Private/PythonAPI/UFoliageService.cpp)).
- Plugin descriptor bump: `VibeUE.uplugin` Version 4 → 5 (metadata only).

## Notable changed files

- `Source/VibeUE/Private/PythonAPI/UFoliageService.cpp`
- `Source/VibeUE/Private/PythonAPI/UMapBlockoutService*.cpp/.h`
- `Source/VibeUE/Private/MapBlockout/MapBlockoutMath.cpp`
- `VibeUE.uplugin`, `MakePlugin.ps1`
- Removal of `Source/VibeUE/Tests/MapBlockout/reference/**` scratch references

## Test plan

- [ ] Strict rebuild compiles cleanly under warnings-as-errors (`BuildAndLaunchGame.ps1 -StrictRebuild`)
- [ ] Editor launches and VibeUE MCP tools register

🤖 Generated with [Claude Code](https://claude.com/claude-code)