### PR TITLE
Fix UE 5.8 strict-build failures (missing FMargin include + deprecated-override warnings-as-errors)

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/UActorService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UActorService.cpp
@@ -7,7 +7,19 @@
 #include "Editor.h"
 #include "LevelEditor.h"
 #include "SLevelViewport.h"
+// LevelEditorViewport.h declares an override of the deprecated
+// FEditorViewportClient::DropObjectsAtCoordinates, which trips C4996
+// (promoted to C2220 by this module's bWarningsAsErrors) purely from
+// including the header — VibeUE never calls the deprecated overload
+// itself. See GitHub #491.
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
 #include "LevelEditorViewport.h"
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 #include "EditorSupportDelegates.h"
 #include "ScopedTransaction.h"
 #include "UObject/PropertyIterator.h"

--- a/Source/VibeUE/Private/PythonAPI/USoundCueService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/USoundCueService.cpp
@@ -2,7 +2,18 @@
 
 #include "PythonAPI/USoundCueService.h"
 
+// SoundCue.h declares an override of the deprecated
+// Audio::ILegacyParameterTransmitter::GetReferencedObjects, which trips C4996
+// (promoted to C2220 by this module's bWarningsAsErrors) purely from including
+// the header — VibeUE never calls the deprecated API itself. See GitHub #491.
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
 #include "Sound/SoundCue.h"
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 #include "Sound/SoundWave.h"
 #include "Sound/SoundNode.h"
 #include "Sound/SoundNodeWavePlayer.h"

--- a/Source/VibeUE/Private/PythonAPI/UViewportService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UViewportService.cpp
@@ -5,7 +5,19 @@
 #include "LevelEditor.h"
 #include "SLevelViewport.h"
 #include "SEditorViewport.h"
+// LevelEditorViewport.h declares an override of the deprecated
+// FEditorViewportClient::DropObjectsAtCoordinates, which trips C4996
+// (promoted to C2220 by this module's bWarningsAsErrors) purely from
+// including the header — VibeUE never calls the deprecated overload
+// itself. See GitHub #491.
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
 #include "LevelEditorViewport.h"
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 #include "LevelViewportActions.h"
 #include "EditorViewportClient.h"
 

--- a/Source/VibeUE/Public/Core/JsonValueHelper.h
+++ b/Source/VibeUE/Public/Core/JsonValueHelper.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "Dom/JsonValue.h"
 #include "Dom/JsonObject.h"
+#include "Layout/Margin.h"
 
 /**
  * Smart JSON value parsing utilities.


### PR DESCRIPTION
## Summary
- `JsonValueHelper.h` used `FMargin` in two method signatures without including `Layout/Margin.h`. With `bUseUnity=false` / `IWYUSupport=None` (module-wide strict settings), nothing pulls this in transitively anymore, so every TU compiling this header fails with `C2061`/`C2065`/`C3861`. Fixes #493.
- `SoundCue.h` and `LevelEditorViewport.h` each declare an **engine-internal** override of a deprecated virtual (`Audio::ILegacyParameterTransmitter::GetReferencedObjects`, `FEditorViewportClient::DropObjectsAtCoordinates`). VibeUE never calls either deprecated API directly — the `C4996` fires purely from including the header, and `bWarningsAsErrors=true` promotes it to a hard `C2220`. Added scoped `#pragma warning(push)/disable(4996)/pop` around just those three include sites (`USoundCueService.cpp`, `UViewportService.cpp`, `UActorService.cpp`) rather than relaxing the module-wide warnings-as-errors setting that PR #438 deliberately added. Fixes #491.

## Test plan
- [x] Ran `BuildAndLaunchGame.ps1 -StrictRebuild` (wipes VibeUE plugin Binaries/Intermediate, forces full recompile under the module's strict settings against UE 5.8) — build succeeded, all 60 plugin files compiled clean, editor launched.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>