### PR TITLE
Fix BuildPlugin.bat to detect UE 5.8 installations

### DIFF
--- a/BuildPlugin.bat
+++ b/BuildPlugin.bat
@@ -61,28 +61,33 @@ echo Found plugin: %PLUGIN_NAME%
 REM Search for Unreal Engine installation using registry (standard method)
 echo Searching for Unreal Engine installation...
 
-REM First, check common UE 5.7 paths (prioritize before registry to find latest version)
-echo Checking for Unreal Engine 5.7 installations...
-for %%P in (
-    "%ProgramFiles%\Epic Games\UE_5.7"
-    "%ProgramFiles(x86)%\Epic Games\UE_5.7"
-    "E:\Program Files\Epic Games\UE_5.7"
-    "C:\Program Files\Epic Games\UE_5.7"
-    "D:\Program Files\Epic Games\UE_5.7"
-    "F:\Program Files\Epic Games\UE_5.7"
-    "G:\Program Files\Epic Games\UE_5.7"
-    "H:\Program Files\Epic Games\UE_5.7"
-) do (
-    if exist "%%~P\Engine\Build\BatchFiles\RunUAT.bat" (
-        set "UE_PATH=%%~P"
-        echo Found UE 5.7 at: !UE_PATH!
-        goto :ue_found
+REM Supported engine versions, newest first (VibeUE currently targets 5.8;
+REM older versions are kept as fallback for branches/forks still on them).
+set "UE_VERSIONS=5.8 5.7 5.6 5.5 5.4 5.3"
+
+echo Checking common Unreal Engine installation paths...
+for %%V in (%UE_VERSIONS%) do (
+    for %%P in (
+        "%ProgramFiles%\Epic Games\UE_%%V"
+        "%ProgramFiles(x86)%\Epic Games\UE_%%V"
+        "E:\Program Files\Epic Games\UE_%%V"
+        "C:\Program Files\Epic Games\UE_%%V"
+        "D:\Program Files\Epic Games\UE_%%V"
+        "F:\Program Files\Epic Games\UE_%%V"
+        "G:\Program Files\Epic Games\UE_%%V"
+        "H:\Program Files\Epic Games\UE_%%V"
+    ) do (
+        if exist "%%~P\Engine\Build\BatchFiles\RunUAT.bat" (
+            set "UE_PATH=%%~P"
+            echo Found UE %%V at: !UE_PATH!
+            goto :ue_found
+        )
     )
 )
 
 REM Try to find UE versions from registry
 echo Checking Windows Registry for Epic Games Unreal Engine installations...
-for %%V in (5.7 5.6 5.5 5.4 5.3) do (
+for %%V in (%UE_VERSIONS%) do (
     reg query "HKLM\SOFTWARE\EpicGames\Unreal Engine\%%V" /v InstalledDirectory >nul 2>&1
     if !ERRORLEVEL! EQU 0 (
         for /f "skip=2 tokens=3*" %%a in ('reg query "HKLM\SOFTWARE\EpicGames\Unreal Engine\%%V" /v InstalledDirectory') do (
@@ -96,37 +101,12 @@ for %%V in (5.7 5.6 5.5 5.4 5.3) do (
     )
 )
 
-REM Fallback: Try common installation paths (if registry method fails)
-echo Registry search completed, trying common installation paths...
-REM Note: If UE 5.7 is not found, ensure it's properly installed via Epic Games Launcher
-REM or check that the installation is registered in the Windows Registry
-for %%P in (
-    "%ProgramFiles%\Epic Games\UE_5.7"
-    "%ProgramFiles(x86)%\Epic Games\UE_5.7"
-    "E:\Program Files\Epic Games\UE_5.7"
-    "C:\Program Files\Epic Games\UE_5.7"
-    "D:\Program Files\Epic Games\UE_5.7"
-    "F:\Program Files\Epic Games\UE_5.7"
-    "G:\Program Files\Epic Games\UE_5.7"
-    "H:\Program Files\Epic Games\UE_5.7"
-    "E:\Program Files\Epic Games\UE_5.6"
-    "%ProgramFiles%\Epic Games\UE_5.6"
-    "%ProgramFiles%\Epic Games\UE_5.5"
-    "%ProgramFiles%\Epic Games\UE_5.4"
-) do (
-    if exist "%%~P\Engine\Build\BatchFiles\RunUAT.bat" (
-        set "UE_PATH=%%~P"
-        echo Found at fallback path: !UE_PATH!
-        goto :ue_found
-    )
-)
-
 echo ERROR: Could not find Unreal Engine installation.
-echo Please ensure Unreal Engine 5.4+ is installed via Epic Games Launcher.
+echo Please ensure Unreal Engine 5.3+ is installed via Epic Games Launcher.
 echo.
 echo Checked:
+echo   - Common installation paths for versions: %UE_VERSIONS%
 echo   - Windows Registry (HKLM\SOFTWARE\EpicGames\Unreal Engine)
-echo   - Common installation paths
 echo.
 pause
 exit /b 1


### PR DESCRIPTION
## Summary
- `BuildPlugin.bat`'s engine search only checked for UE 5.7 (with 5.6/5.5/5.4/5.3 as fallback), so on a machine with only 5.8 installed it silently failed to find an engine and exited without building anything — reported on Discord (suddlemercury/TheOne, maxfield_31836) as the script "opening and closing immediately."
- Replaced the three separate 5.7-hardcoded path/registry search blocks with a single version-list-driven loop (`5.8 5.7 5.6 5.5 5.4 5.3`, newest first) shared by both the path scan and the registry scan.

## Test plan
- [x] Verified engine/project detection logic against this repo (UE 5.8, `ThirdPerson58.uproject`) in a dry-run copy of the script with the actual build invocation stubbed out — correctly detects UE 5.8 and the project.
- [ ] Full end-to-end build via `BuildPlugin.bat` on a clean UE 5.8-only machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)