### PR TITLE
Fix 10 open issues: bound events, SCS root persistence, graph summary/layout, Niagara diagnostics, WP landscapes, Python crash recovery, silent-failure sweep

### DIFF
--- a/Content/Skills/blueprint-graphs/SKILL.md
+++ b/Content/Skills/blueprint-graphs/SKILL.md
@@ -110,6 +110,46 @@ To remove a specific edge, disconnect the output pin on the source node (e.g. `"
 | `pin.current_value` | `pin.default_value` |
 | `pin.sub_pins` | *(does not exist)* |
 
+### ⚠️ Read graphs cheaply: `get_graph_summary()` first, filtered `get_nodes_in_graph()` second
+
+A full `get_nodes_in_graph()` dump of a big graph is the most token-expensive read in this toolset
+(every node ships its full pin list twice). Default reading order:
+
+```python
+# 1. Fixed-size overview — payload independent of graph size
+s = unreal.BlueprintService.get_graph_summary(bp_path, "EventGraph")  # None if bp/graph not found
+print(s.node_count, s.connection_count, s.compile_status)
+print(s.entry_points)      # ["Event BeginPlay|<node_id>", ...]
+print(s.node_type_counts)  # ["K2Node_CallFunction x12", ...]
+
+# 2. Drill in with filters: max nodes, name/type/id substring, and pins off
+nodes = unreal.BlueprintService.get_nodes_in_graph(bp_path, "EventGraph", 25, "SpawnActor", False)
+# args 3-5 are optional: max_nodes=0 (all), name_filter="" (all), include_pins=True
+```
+
+Only fall back to the unfiltered full dump when you genuinely need every pin of every node.
+
+### ⚠️ Component/widget bound events: use `create_component_bound_event()`, never `create_node_by_key`
+
+A `K2Node_ComponentBoundEvent` (e.g. *On Clicked (MyButton)*) built via `create_node_by_key` +
+`configure_node` **compiles clean but never fires at runtime** — the delegate binding params
+(including the generated handler function name) can only be initialized atomically:
+
+```python
+node_id = unreal.BlueprintService.create_component_bound_event(
+    bp_path, "EventGraph", "MyButton", "OnClicked", 100, 100)
+```
+
+Idempotent: if the bound event already exists, the existing node's id is returned. Works for any
+component delegate (`OnComponentBeginOverlap`, widget `OnClicked`/`OnValueChanged`, ...).
+
+### ⚠️ Override events are idempotent
+
+`create_node_by_key("EVENT Actor::ReceiveBeginPlay")` (and `EVENT CUSTOM::Name`) returns the
+**existing** node's id when the blueprint already has that event — a blueprint can hold each
+override event only once, and a duplicate would break compilation. Don't treat "node id I didn't
+just place" as an error; wire into it.
+
 ### ⚠️ `discover_nodes()` vs `get_nodes_in_graph()` — Different Object Types
 
 `get_nodes_in_graph()` returns **`FBlueprintNodeInfo`** objects — these have `node_title`, `node_id`, `pos_x`, `pos_y`, `node_type`.

--- a/Content/Skills/landscape/SKILL.md
+++ b/Content/Skills/landscape/SKILL.md
@@ -114,7 +114,7 @@ Four Python utility functions help match heightmaps to landscapes:
 | Function | Purpose |
 |----------|---------|
 | `get_heightmap_dimensions(file_path)` | Read width/height/bitdepth of a PNG or RAW heightmap file |
-| `resize_heightmap(source, width, height, output)` | Bilinear resample a 16-bit heightmap to new dimensions |
+| `resize_heightmap(source, width, height, output, interpolation)` | Resample a 16-bit heightmap to new dimensions. Default `interpolation="bicubic"` (Catmull-Rom, smooth normals); pass `"bilinear"` only if you need the legacy behavior — bilinear upsampling of a low-res DEM produces blocky planar facets on flat plains |
 | `calculate_landscape_resolution(cx, cy, quads, sections)` | Compute resolution from landscape config parameters |
 | `find_landscape_config_for_resolution(width, height)` | Find the best landscape config that matches a given resolution |
 
@@ -140,6 +140,38 @@ If you already have a heightmap at a non-matching resolution:
    - Find a landscape config that matches: `find_landscape_config_for_resolution(width, height)`
    - Or resize the heightmap to match your landscape: `resize_heightmap(source, target_w, target_h)`
 3. Create landscape / import resized heightmap
+
+### World Partition landscapes (streaming proxies)
+
+In a **World Partition** level, pass `world_partition_grid_size` (components per proxy grid cell,
+e.g. `2`) to `create_landscape` to split the landscape into `ALandscapeStreamingProxy` actors —
+the same thing the editor's New Landscape tool does in a WP world:
+
+```python
+result = unreal.LandscapeService.create_landscape(
+    unreal.Vector(0, 0, 0), unreal.Rotator(0, 0, 0), unreal.Vector(100, 100, 100),
+    sections_per_component=1, quads_per_section=63,
+    component_count_x=8, component_count_y=8,
+    landscape_label="WPLandscape", world_partition_grid_size=2)
+```
+
+- The default `world_partition_grid_size=0` keeps the single monolithic `ALandscape` (old behavior).
+- The call **fails with an error if the level is not World Partition** — the engine's grid split is
+  a silent no-op there, so VibeUE refuses instead of pretending.
+- `import_heightmap`, sculpting, painting, and region edits are proxy-transparent: they resolve the
+  parent `ALandscape` and fan updates out to every proxy sharing its landscape GUID. Nothing else
+  in your workflow changes.
+
+### Blocky / faceted flat areas (plains)
+
+Low-res source DEMs upsampled to landscape resolution show planar facets on flat terrain. Fixes,
+in order of preference:
+
+1. `resize_heightmap(..., interpolation="bicubic")` — now the default; re-run the resize+import if
+   the landscape was built with an older (bilinear) resize.
+2. Increase `blur_passes` (20–40) on `terrain_data generate_heightmap` for plains-heavy regions.
+3. Material-level smoothing without touching heights: derive a world-space smoothed normal in the
+   landscape material (see `landscape-materials` skill) when height data must stay pixel-exact.
 
 ### Landscape Scale
 

--- a/Content/Skills/niagara-emitters/scratch-pad.md
+++ b/Content/Skills/niagara-emitters/scratch-pad.md
@@ -118,8 +118,23 @@ unreal.NiagaraScratchPadService.add_module_output(S, E, MOD, "Particles.Splatted
 unreal.NiagaraScratchPadService.connect_pins(S, E, MOD, HLSL, "Splatted", mapset, "Particles.Splatted")
 
 # 6. Apply + recompile + save (one call)
-unreal.NiagaraScratchPadService.apply_changes(S)
+ok = unreal.NiagaraScratchPadService.apply_changes(S)
+if not ok:
+    # Real per-script compiler diagnostics — no more guessing from "System is invalid"
+    for line in unreal.NiagaraScratchPadService.get_compile_messages(S):
+        print(line)
 ```
+
+### Compile failures are debuggable now
+
+- `apply_changes` **validates the scratch graphs before compiling** (duplicate same-named Map
+  Get/Set pins used to fire a fatal engine assert and crash the editor — now it refuses with an
+  error naming the node/pin) and returns `False` when the compile produced errors.
+- `get_compile_messages(system_path, errors_only=True)` returns the actual Niagara translator
+  messages per script (`"Error: [Emitter/Script] message (node <guid>)"`). Call it after any failed
+  compile instead of bisecting the graph.
+- GPU-only data interfaces on a CPU emitter (below) are the most common cause — fix with
+  `unreal.NiagaraEmitterService.set_sim_target(S, "Emitter", "GPU")`, which recompiles the system.
 
 ### `add_module_input` / `add_module_output` are idempotent — call once per name
 
@@ -167,9 +182,11 @@ If a bare name doesn't resolve, pass the full `Namespace::Op` string.
 > only.** If their inputs/writes appear in an emitter whose Sim Target is **CPU** (the default for a
 > `minimal` emitter), `compile_with_results` returns `success=False` with the generic message
 > `"System is invalid after compilation"` — this is a Niagara constraint, not a service failure. Set
-> the emitter to **GPUComputeSim** before wiring grid/render-target logic. A Custom HLSL bool output
-> wired to a plain `Particles.*` attribute compiles fine on CPU; it's the grid/RT data interfaces that
-> force GPU. When you hit "System is invalid", first check the emitter's Sim Target.
+> the emitter to **GPUComputeSim** before wiring grid/render-target logic:
+> `unreal.NiagaraEmitterService.set_sim_target(S, "Emitter", "GPU")` (accepts "CPU"/"GPU", recompiles).
+> A Custom HLSL bool output wired to a plain `Particles.*` attribute compiles fine on CPU; it's the
+> grid/RT data interfaces that force GPU. When you hit "System is invalid", check
+> `get_compile_messages(S)` and the emitter's Sim Target first.
 
 ### One pattern that fixes most "input not found" errors
 

--- a/Source/VibeUE/Private/PythonAPI/UAnimMontageService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UAnimMontageService.cpp
@@ -1596,7 +1596,11 @@ FString UAnimMontageService::CreateMontageFromAnimation(
 	NewMontage->BlendOutTriggerTime = -1.0f;
 
 	NewMontage->MarkPackageDirty();
-	UEditorAssetLibrary::SaveAsset(FullPath);
+	if (!UEditorAssetLibrary::SaveAsset(FullPath))
+	{
+		UE_LOG(LogTemp, Error, TEXT("UAnimMontageService::CreateMontageFromAnimation: Failed to save asset: %s"), *FullPath);
+		return FString();
+	}
 
 	UE_LOG(LogTemp, Log, TEXT("UAnimMontageService::CreateMontageFromAnimation: Created montage: %s"), *FullPath);
 	return FullPath;
@@ -1664,7 +1668,11 @@ FString UAnimMontageService::CreateEmptyMontage(
 	NewMontage->BlendOut.SetBlendTime(0.25f);
 
 	NewMontage->MarkPackageDirty();
-	UEditorAssetLibrary::SaveAsset(FullPath);
+	if (!UEditorAssetLibrary::SaveAsset(FullPath))
+	{
+		UE_LOG(LogTemp, Error, TEXT("UAnimMontageService::CreateEmptyMontage: Failed to save asset: %s"), *FullPath);
+		return FString();
+	}
 
 	UE_LOG(LogTemp, Log, TEXT("UAnimMontageService::CreateEmptyMontage: Created montage: %s"), *FullPath);
 	return FullPath;

--- a/Source/VibeUE/Private/PythonAPI/UAnimSequenceService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UAnimSequenceService.cpp
@@ -600,7 +600,11 @@ FString UAnimSequenceService::CreateFromPose(
 
 	// Mark as modified and save
 	NewAnimSeq->MarkPackageDirty();
-	UEditorAssetLibrary::SaveAsset(FullPath);
+	if (!UEditorAssetLibrary::SaveAsset(FullPath))
+	{
+		UE_LOG(LogTemp, Error, TEXT("UAnimSequenceService::CreateFromPose: Failed to save asset: %s"), *FullPath);
+		return FString();
+	}
 
 	UE_LOG(LogTemp, Log, TEXT("UAnimSequenceService::CreateFromPose: Created animation: %s"), *FullPath);
 	return FullPath;
@@ -826,7 +830,11 @@ FString UAnimSequenceService::CreateAnimSequence(
 
 	// Mark as modified and save
 	NewAnimSeq->MarkPackageDirty();
-	UEditorAssetLibrary::SaveAsset(FullPath);
+	if (!UEditorAssetLibrary::SaveAsset(FullPath))
+	{
+		UE_LOG(LogTemp, Error, TEXT("UAnimSequenceService::CreateAnimSequence: Failed to save asset: %s"), *FullPath);
+		return FString();
+	}
 
 	UE_LOG(LogTemp, Log, TEXT("UAnimSequenceService::CreateAnimSequence: Created animation: %s with %d bone tracks"), *FullPath, TracksAdded);
 	return FullPath;

--- a/Source/VibeUE/Private/PythonAPI/UAssetDiscoveryService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UAssetDiscoveryService.cpp
@@ -147,7 +147,11 @@ FString UAssetDiscoveryService::ImportAsset(
 
 	FAssetRegistryModule::AssetCreated(NewObj);
 	Package->MarkPackageDirty();
-	UEditorAssetLibrary::SaveLoadedAsset(NewObj, false);
+	if (!UEditorAssetLibrary::SaveLoadedAsset(NewObj, false))
+	{
+		OutError = FString::Printf(TEXT("Failed to save imported asset '%s'"), *NewObj->GetPathName());
+		return FString();
+	}
 
 	UE_LOG(LogTemp, Log, TEXT("UAssetDiscoveryService::ImportAsset: imported '%s' -> '%s'"), *SourceFilePath, *NewObj->GetPathName());
 	return NewObj->GetPathName();

--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -22,7 +22,9 @@
 #include "K2Node_CallArrayFunction.h"   // For array library functions with wildcard pins
 #include "K2Node_GetArrayItem.h"        // For Array Get (replaces deprecated Array_Get)
 #include "K2Node_CreateDelegate.h"
+#include "K2Node_ComponentBoundEvent.h"
 #include "K2Node_CustomEvent.h"
+#include "EdGraphSchema_K2_Actions.h"
 #include "K2Node_DynamicCast.h"
 #include "K2Node_Event.h"
 #include "K2Node_EnhancedInputAction.h"  // For Enhanced Input Action event nodes
@@ -1534,6 +1536,27 @@ bool UBlueprintService::SetRootComponent(
 	// the auto-generated DefaultSceneRoot while the old root is being detached below.
 	SCS->AddNode(NewRootNode);
 
+	// RemoveChildNode/RemoveNode do NOT clear the serialized parent linkage. A root
+	// node that still names a parent deserializes as attached — after save+reload the
+	// SCS has no root and the cooker fires the cyclic-SCS ensure (issue #371).
+	NewRootNode->ParentComponentOrVariableName = NAME_None;
+	NewRootNode->ParentComponentOwnerClassName = NAME_None;
+	NewRootNode->bIsParentComponentNative = false;
+
+	// Attach a node as a same-SCS child of the new root. ParentComponentOrVariableName
+	// is reserved for attachment to INHERITED (parent-class/native) components — the
+	// engine's hierarchy fixup fires the "possible cyclic linkage" ensure on load/cook
+	// when it names the node's own SCS parent (issue #371). Same-SCS attachment is the
+	// ChildNodes array alone, with the inherited-parent linkage cleared.
+	auto AttachUnderNewRoot = [NewRootNode](USCS_Node* Child)
+	{
+		NewRootNode->AddChildNode(Child);
+		Child->Modify();
+		Child->ParentComponentOrVariableName = NAME_None;
+		Child->ParentComponentOwnerClassName = NAME_None;
+		Child->bIsParentComponentNative = false;
+	};
+
 	// If there was a current root, we need to handle it
 	if (CurrentRootNode && CurrentRootNode != NewRootNode)
 	{
@@ -1550,9 +1573,7 @@ bool UBlueprintService::SetRootComponent(
 		if (CurrentRootNode != SCS->GetDefaultSceneRootNode())
 		{
 			// Make the old user-created root a child of the new root
-			NewRootNode->AddChildNode(CurrentRootNode);
-			// CRITICAL: Call SetParent to properly set ParentComponentOrVariableName
-			CurrentRootNode->SetParent(NewRootNode);
+			AttachUnderNewRoot(CurrentRootNode);
 		}
 		// The auto-generated DefaultSceneRoot is dropped outright (matching the Blueprint
 		// editor); the SCS recreates it automatically if the blueprint ever needs one again.
@@ -1563,9 +1584,7 @@ bool UBlueprintService::SetRootComponent(
 	{
 		if (Child && Child != NewRootNode && Child != CurrentRootNode)
 		{
-			NewRootNode->AddChildNode(Child);
-			// CRITICAL: Call SetParent to properly set ParentComponentOrVariableName
-			Child->SetParent(NewRootNode);
+			AttachUnderNewRoot(Child);
 		}
 	}
 
@@ -1584,13 +1603,24 @@ bool UBlueprintService::SetRootComponent(
 	for (USCS_Node* Node : OtherSceneRoots)
 	{
 		SCS->RemoveNode(Node);
-		NewRootNode->AddChildNode(Node);
-		Node->SetParent(NewRootNode);
+		AttachUnderNewRoot(Node);
 	}
+
+	// Let the SCS reconcile its RootNodes/default-root state before the compile —
+	// this is what persists the root designation through save+reload (issue #371).
+	SCS->ValidateSceneRootNodes();
 
 	// Mark blueprint as structurally modified
 	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-	
+
+	// Verify the promoted node actually reads back as the scene root; report the
+	// failure instead of claiming success (issue #352: no silent failures).
+	if (FindActualSceneRootNode(SCS) != NewRootNode)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetRootComponent: '%s' did not persist as scene root of %s after validation"), *ComponentName, *BlueprintPath);
+		return false;
+	}
+
 	UE_LOG(LogTemp, Log, TEXT("SetRootComponent: Set '%s' as root component in %s"), *ComponentName, *BlueprintPath);
 	return true;
 }
@@ -3121,6 +3151,87 @@ FString UBlueprintService::AddCustomEventNode(
 	return SpawnedNode->NodeGuid.ToString();
 }
 
+FString UBlueprintService::CreateComponentBoundEvent(
+	const FString& BlueprintPath,
+	const FString& GraphName,
+	const FString& ComponentName,
+	const FString& DelegateName,
+	float PosX,
+	float PosY)
+{
+	UBlueprint* Blueprint = LoadBlueprint(BlueprintPath);
+	if (!Blueprint)
+	{
+		UE_LOG(LogTemp, Error, TEXT("CreateComponentBoundEvent: Failed to load blueprint: %s"), *BlueprintPath);
+		return FString();
+	}
+
+	UEdGraph* Graph = ResolveBlueprintGraph(Blueprint, GraphName);
+	if (!Graph)
+	{
+		UE_LOG(LogTemp, Error, TEXT("CreateComponentBoundEvent: Graph '%s' not found in %s"), *GraphName, *BlueprintPath);
+		return FString();
+	}
+	if (!Blueprint->UbergraphPages.Contains(Graph))
+	{
+		UE_LOG(LogTemp, Error, TEXT("CreateComponentBoundEvent: Graph '%s' is not an event graph — bound events only live in ubergraphs"), *GraphName);
+		return FString();
+	}
+
+	// The component variable is a property on the (skeleton) generated class.
+	UClass* OwnerClass = Blueprint->SkeletonGeneratedClass ? Blueprint->SkeletonGeneratedClass : Blueprint->GeneratedClass;
+	if (!OwnerClass)
+	{
+		UE_LOG(LogTemp, Error, TEXT("CreateComponentBoundEvent: %s has no generated class — compile the blueprint first"), *BlueprintPath);
+		return FString();
+	}
+
+	FObjectProperty* ComponentProperty = FindFProperty<FObjectProperty>(OwnerClass, *ComponentName);
+	if (!ComponentProperty)
+	{
+		UE_LOG(LogTemp, Error, TEXT("CreateComponentBoundEvent: Component variable '%s' not found on %s (is it marked as a variable?)"), *ComponentName, *OwnerClass->GetName());
+		return FString();
+	}
+
+	const FMulticastDelegateProperty* DelegateProperty = FindFProperty<FMulticastDelegateProperty>(ComponentProperty->PropertyClass, *DelegateName);
+	if (!DelegateProperty)
+	{
+		UE_LOG(LogTemp, Error, TEXT("CreateComponentBoundEvent: Delegate '%s' not found on component class %s"), *DelegateName, *ComponentProperty->PropertyClass->GetName());
+		return FString();
+	}
+
+	// Idempotent: a component+delegate pair can only have one bound event in a
+	// blueprint — reuse it rather than creating a dead duplicate.
+	if (const UK2Node_ComponentBoundEvent* Existing = FKismetEditorUtilities::FindBoundEventForComponent(Blueprint, DelegateProperty->GetFName(), ComponentProperty->GetFName()))
+	{
+		UE_LOG(LogTemp, Log, TEXT("CreateComponentBoundEvent: Bound event for %s.%s already exists — returning existing node"), *ComponentName, *DelegateName);
+		return Existing->NodeGuid.ToString();
+	}
+
+	// Same path as the Designer's green "+": spawn the node and atomically
+	// initialize the binding params (ComponentPropertyName, DelegatePropertyName,
+	// EventReference, and the generated CustomFunctionName the compiler registers
+	// the runtime handler under). See FKismetEditorUtilities::CreateNewBoundEventForClass.
+	UK2Node_ComponentBoundEvent* NewNode = FEdGraphSchemaAction_K2NewNode::SpawnNode<UK2Node_ComponentBoundEvent>(
+		Graph,
+		FVector2D(PosX, PosY),
+		EK2NewNodeFlags::None,
+		[ComponentProperty, DelegateProperty](UK2Node_ComponentBoundEvent* NewInstance)
+		{
+			NewInstance->InitializeComponentBoundEventParams(ComponentProperty, DelegateProperty);
+		});
+	if (!NewNode)
+	{
+		UE_LOG(LogTemp, Error, TEXT("CreateComponentBoundEvent: Failed to spawn bound event node for %s.%s"), *ComponentName, *DelegateName);
+		return FString();
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
+	UE_LOG(LogTemp, Log, TEXT("CreateComponentBoundEvent: Created bound event %s.%s in %s"), *ComponentName, *DelegateName, *GraphName);
+
+	return NewNode->NodeGuid.ToString();
+}
+
 // Returns true if the editable-pin node already has a user-defined pin with this name.
 // (Avoids UK2Node_EditablePinBase::UserDefinedPinExists, which isn't exported from BlueprintGraph.)
 static bool VibeUE_HasUserDefinedPin(const UK2Node_EditablePinBase* Node, const FName PinName)
@@ -4473,7 +4584,10 @@ bool UBlueprintService::ConnectNodes(
 
 TArray<FBlueprintNodeInfo> UBlueprintService::GetNodesInGraph(
 	const FString& BlueprintPath,
-	const FString& GraphName)
+	const FString& GraphName,
+	int32 MaxNodes,
+	const FString& NameFilter,
+	bool bIncludePins)
 {
 	TArray<FBlueprintNodeInfo> NodeInfos;
 
@@ -4503,28 +4617,117 @@ TArray<FBlueprintNodeInfo> UBlueprintService::GetNodesInGraph(
 		NodeInfo.PosX = Node->NodePosX;
 		NodeInfo.PosY = Node->NodePosY;
 
-		// Get pin names (for quick reference)
-		for (UEdGraphPin* Pin : Node->Pins)
+		if (!NameFilter.IsEmpty()
+			&& !NodeInfo.NodeTitle.Contains(NameFilter)
+			&& !NodeInfo.NodeType.Contains(NameFilter)
+			&& !NodeInfo.NodeId.Contains(NameFilter))
 		{
-			if (Pin)
-			{
-				NodeInfo.PinNames.Add(Pin->PinName.ToString());
+			continue;
+		}
 
-				// Also add detailed pin info
-				FBlueprintPinInfo PinInfo;
-				PinInfo.PinName = Pin->PinName.ToString();
-				PinInfo.PinType = Pin->PinType.PinCategory.ToString();
-				PinInfo.bIsInput = (Pin->Direction == EGPD_Input);
-				PinInfo.bIsConnected = Pin->LinkedTo.Num() > 0;
-				PinInfo.DefaultValue = Pin->DefaultValue;
-				NodeInfo.Pins.Add(PinInfo);
+		if (bIncludePins)
+		{
+			// Get pin names (for quick reference)
+			for (UEdGraphPin* Pin : Node->Pins)
+			{
+				if (Pin)
+				{
+					NodeInfo.PinNames.Add(Pin->PinName.ToString());
+
+					// Also add detailed pin info
+					FBlueprintPinInfo PinInfo;
+					PinInfo.PinName = Pin->PinName.ToString();
+					PinInfo.PinType = Pin->PinType.PinCategory.ToString();
+					PinInfo.bIsInput = (Pin->Direction == EGPD_Input);
+					PinInfo.bIsConnected = Pin->LinkedTo.Num() > 0;
+					PinInfo.DefaultValue = Pin->DefaultValue;
+					NodeInfo.Pins.Add(PinInfo);
+				}
 			}
 		}
 
 		NodeInfos.Add(NodeInfo);
+
+		if (MaxNodes > 0 && NodeInfos.Num() >= MaxNodes)
+		{
+			break;
+		}
 	}
 
 	return NodeInfos;
+}
+
+bool UBlueprintService::GetGraphSummary(
+	const FString& BlueprintPath,
+	const FString& GraphName,
+	FBlueprintGraphSummary& OutSummary)
+{
+	UBlueprint* Blueprint = LoadBlueprint(BlueprintPath);
+	if (!Blueprint)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("GetGraphSummary: Failed to load blueprint: %s"), *BlueprintPath);
+		return false;
+	}
+
+	UEdGraph* Graph = FindGraph(Blueprint, GraphName);
+	if (!Graph)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("GetGraphSummary: Graph '%s' not found in %s"), *GraphName, *BlueprintPath);
+		return false;
+	}
+
+	OutSummary.GraphName = Graph->GetName();
+
+	OutSummary.GraphKind = TEXT("Ubergraph");
+	if (Blueprint->FunctionGraphs.Contains(Graph)) { OutSummary.GraphKind = TEXT("Function"); }
+	else if (Blueprint->MacroGraphs.Contains(Graph)) { OutSummary.GraphKind = TEXT("Macro"); }
+	else if (Blueprint->DelegateSignatureGraphs.Contains(Graph)) { OutSummary.GraphKind = TEXT("DelegateSignature"); }
+
+	switch (Blueprint->Status)
+	{
+	case BS_UpToDate:             OutSummary.CompileStatus = TEXT("UpToDate"); break;
+	case BS_UpToDateWithWarnings: OutSummary.CompileStatus = TEXT("UpToDateWithWarnings"); break;
+	case BS_Dirty:                OutSummary.CompileStatus = TEXT("Dirty"); break;
+	case BS_Error:                OutSummary.CompileStatus = TEXT("Error"); break;
+	default:                      OutSummary.CompileStatus = TEXT("Unknown"); break;
+	}
+
+	OutSummary.NodeCount = 0;
+	OutSummary.ConnectionCount = 0;
+	TMap<FString, int32> TypeCounts;
+	for (UEdGraphNode* Node : Graph->Nodes)
+	{
+		if (!Node)
+		{
+			continue;
+		}
+		OutSummary.NodeCount++;
+		TypeCounts.FindOrAdd(Node->GetClass()->GetName())++;
+
+		for (UEdGraphPin* Pin : Node->Pins)
+		{
+			// Count each link once, from its output side.
+			if (Pin && Pin->Direction == EGPD_Output)
+			{
+				OutSummary.ConnectionCount += Pin->LinkedTo.Num();
+			}
+		}
+
+		if (Node->IsA<UK2Node_Event>() || Node->IsA<UK2Node_FunctionEntry>())
+		{
+			OutSummary.EntryPoints.Add(FString::Printf(TEXT("%s|%s"),
+				*Node->GetNodeTitle(ENodeTitleType::ListView).ToString(),
+				*Node->NodeGuid.ToString()));
+		}
+	}
+
+	TypeCounts.ValueSort([](int32 A, int32 B) { return A > B; });
+	for (const TPair<FString, int32>& Pair : TypeCounts)
+	{
+		OutSummary.NodeTypeCounts.Add(FString::Printf(TEXT("%s x%d"), *Pair.Key, Pair.Value));
+	}
+
+	return true;
 }
 
 namespace
@@ -5481,9 +5684,15 @@ bool UBlueprintService::SetProperty(
 		return false;
 	}
 
-	// Import property value from string
+	// Import property value from string. ImportText returns null on parse failure —
+	// report it instead of saving an unchanged asset and claiming success (issue #352).
 	void* PropertyAddr = Property->ContainerPtrToValuePtr<void>(CDO);
-	Property->ImportText_Direct(*PropertyValue, PropertyAddr, nullptr, PPF_None);
+	if (!Property->ImportText_Direct(*PropertyValue, PropertyAddr, CDO, PPF_None))
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetProperty: Failed to parse '%s' for property '%s' (%s) — value rejected by ImportText"),
+			*PropertyValue, *PropertyName, *Property->GetClass()->GetName());
+		return false;
+	}
 
 	FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
 	UEditorAssetLibrary::SaveAsset(BlueprintPath, false);
@@ -6672,15 +6881,18 @@ bool UBlueprintService::ConfigureNode(
 			return false;
 		}
 	}
-	else if (FSoftClassProperty* SoftClassProp = CastField<FSoftClassProperty>(Property))
-	{
-		// Use generic import for soft class references
-		Property->ImportText_Direct(*Value, PropertyAddr, nullptr, PPF_None);
-	}
 	else
 	{
-		// Use generic import
-		Property->ImportText_Direct(*Value, PropertyAddr, nullptr, PPF_None);
+		// Generic import (soft class refs included). ImportText returns null when the
+		// value fails to parse (e.g. a bare string handed to a struct property) — a
+		// silent no-op unless we surface it (issue #386).
+		const TCHAR* ImportResult = Property->ImportText_Direct(*Value, PropertyAddr, nullptr, PPF_None);
+		if (!ImportResult)
+		{
+			UE_LOG(LogTemp, Error, TEXT("ConfigureNode: Failed to parse '%s' for property '%s' (%s) on node '%s' — value rejected by ImportText"),
+				*Value, *PropertyName, *Property->GetClass()->GetName(), *NodeId);
+			return false;
+		}
 	}
 
 	// Reconstruct node to apply changes
@@ -6787,6 +6999,17 @@ FString UBlueprintService::CreateNodeByKey(
 				}
 			}
 
+			// Idempotent: a named custom event already in the blueprint is returned
+			// instead of duplicated — a second same-named event is a compile error.
+			if (!CustomEventName.IsNone())
+			{
+				if (UK2Node_Event* Existing = FBlueprintEditorUtils::FindCustomEventNode(Blueprint, CustomEventName))
+				{
+					UE_LOG(LogTemp, Log, TEXT("CreateNodeByKey: Custom event '%s' already exists — returning existing node"), *CustomEventName.ToString());
+					return Existing->NodeGuid.ToString();
+				}
+			}
+
 			EventSpawner = UBlueprintEventNodeSpawner::Create(UK2Node_CustomEvent::StaticClass(), CustomEventName);
 		}
 		else
@@ -6811,6 +7034,17 @@ FString UBlueprintService::CreateNodeByKey(
 			{
 				UE_LOG(LogTemp, Error, TEXT("CreateNodeByKey: Event function '%s' not found in class '%s'"), *FunctionName, *ClassName);
 				return FString();
+			}
+
+			// Idempotent: an override event (BeginPlay/Tick/overlap/...) can exist only
+			// once per blueprint. Creating a second one yields two same-named event nodes
+			// that both error out ("found more than one function with the same name") and
+			// the graph looks "not connected" (issue #349). Do what the editor does on
+			// double-click: return the existing node.
+			if (UK2Node_Event* Existing = FBlueprintEditorUtils::FindOverrideForFunction(Blueprint, EventFunction->GetOwnerClass(), EventFunction->GetFName()))
+			{
+				UE_LOG(LogTemp, Log, TEXT("CreateNodeByKey: Override event '%s' already exists in %s — returning existing node"), *FunctionName, *BlueprintPath);
+				return Existing->NodeGuid.ToString();
 			}
 
 			EventSpawner = UBlueprintEventNodeSpawner::Create(EventFunction);
@@ -9152,9 +9386,15 @@ namespace VibeUELayout
 			// predecessors), then everything else — so the dropped edge is the genuine
 			// loop-back rather than an arbitrary forward edge, and loop bodies still flow L->R.
 			TArray<UEdGraphNode*> SeedOrder;
+			// Primary events (BeginPlay/Tick/input/overrides) seed before custom events so
+			// the main event chain gets the earliest visit ranks (issue #354).
 			for (UEdGraphNode* SN : Nodes)
 			{
-				if (SN->IsA<UK2Node_Event>() || SN->IsA<UK2Node_CustomEvent>()) { SeedOrder.AddUnique(SN); }
+				if (SN->IsA<UK2Node_Event>() && !SN->IsA<UK2Node_CustomEvent>()) { SeedOrder.AddUnique(SN); }
+			}
+			for (UEdGraphNode* SN : Nodes)
+			{
+				if (SN->IsA<UK2Node_CustomEvent>()) { SeedOrder.AddUnique(SN); }
 			}
 			for (UEdGraphNode* SN : Nodes)
 			{
@@ -9274,18 +9514,27 @@ namespace VibeUELayout
 			}
 		}
 
-		// Rank components: those containing events first, then larger ones (keeps the
-		// main event/function chain at the top).
+		// Rank components: those containing primary events (BeginPlay/Tick/input — real
+		// entry points) first, then any-event components, then larger ones. A timer
+		// callback Custom Event lives in its own component (the timer links by function
+		// name, not a wire), and without the primary-event key a large callback body
+		// out-ranked the small BeginPlay chain and was drawn above it (issue #354).
 		TArray<int32> CompNodeCount;
 		TArray<int32> CompEventCount;
+		TArray<int32> CompPrimaryEventCount;
 		CompNodeCount.Init(0, NumComp);
 		CompEventCount.Init(0, NumComp);
+		CompPrimaryEventCount.Init(0, NumComp);
 		for (const TPair<UEdGraphNode*, int32>& Pair : Comp)
 		{
 			CompNodeCount[Pair.Value]++;
 			if (Pair.Key->IsA<UK2Node_Event>() || Pair.Key->IsA<UK2Node_CustomEvent>())
 			{
 				CompEventCount[Pair.Value]++;
+				if (!Pair.Key->IsA<UK2Node_CustomEvent>())
+				{
+					CompPrimaryEventCount[Pair.Value]++;
+				}
 			}
 		}
 		TArray<int32> CompOrder;
@@ -9295,6 +9544,7 @@ namespace VibeUELayout
 		}
 		CompOrder.Sort([&](int32 A, int32 B)
 		{
+			if (CompPrimaryEventCount[A] != CompPrimaryEventCount[B]) return CompPrimaryEventCount[A] > CompPrimaryEventCount[B];
 			if (CompEventCount[A] != CompEventCount[B]) return CompEventCount[A] > CompEventCount[B];
 			return CompNodeCount[A] > CompNodeCount[B];
 		});

--- a/Source/VibeUE/Private/PythonAPI/UFoliageService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UFoliageService.cpp
@@ -632,7 +632,12 @@ FFoliageTypeCreateResult UFoliageService::CreateFoliageType(
 	FString PackageFileName = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
 	FSavePackageArgs SaveArgs;
 	SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
-	UPackage::SavePackage(Package, FoliageType, *PackageFileName, SaveArgs);
+	if (!UPackage::SavePackage(Package, FoliageType, *PackageFileName, SaveArgs))
+	{
+		Result.ErrorMessage = FString::Printf(TEXT("Failed to save package '%s'"), *PackageName);
+		UE_LOG(LogTemp, Error, TEXT("UFoliageService::CreateFoliageType: %s"), *Result.ErrorMessage);
+		return Result;
+	}
 
 	Result.bSuccess = true;
 	Result.AssetPath = FoliageType->GetPathName();

--- a/Source/VibeUE/Private/PythonAPI/UInputService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UInputService.cpp
@@ -164,9 +164,13 @@ FInputCreateResult UInputService::CreateAction(
 	}
 	
 	// Save the asset
-	UEditorAssetLibrary::SaveAsset(FullPath, false);
-	
-	Result.bSuccess = true;
+	Result.bSuccess = UEditorAssetLibrary::SaveAsset(FullPath, false);
+	if (!Result.bSuccess)
+	{
+		Result.ErrorMessage = FString::Printf(TEXT("Failed to save asset '%s'"), *FullPath);
+		return Result;
+	}
+
 	Result.AssetPath = FullPath + TEXT(".") + ActionName;
 	
 	return Result;
@@ -302,9 +306,13 @@ FInputCreateResult UInputService::CreateMappingContext(
 	}
 	
 	// Save the asset
-	UEditorAssetLibrary::SaveAsset(FullPath, false);
-	
-	Result.bSuccess = true;
+	Result.bSuccess = UEditorAssetLibrary::SaveAsset(FullPath, false);
+	if (!Result.bSuccess)
+	{
+		Result.ErrorMessage = FString::Printf(TEXT("Failed to save asset '%s'"), *FullPath);
+		return Result;
+	}
+
 	Result.AssetPath = FullPath + TEXT(".") + ContextName;
 	
 	return Result;

--- a/Source/VibeUE/Private/PythonAPI/ULandscapeMaterialService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/ULandscapeMaterialService.cpp
@@ -771,9 +771,14 @@ FLandscapeLayerInfoCreateResult ULandscapeMaterialService::CreateLayerInfoObject
 	LayerInfoObj->MarkPackageDirty();
 
 	// Save the asset
-	UEditorAssetLibrary::SaveAsset(FullAssetPath, false);
+	Result.bSuccess = UEditorAssetLibrary::SaveAsset(FullAssetPath, false);
+	if (!Result.bSuccess)
+	{
+		Result.ErrorMessage = FString::Printf(TEXT("Failed to save layer info asset '%s'"), *FullAssetPath);
+		UE_LOG(LogTemp, Error, TEXT("ULandscapeMaterialService::CreateLayerInfoObject: %s"), *Result.ErrorMessage);
+		return Result;
+	}
 
-	Result.bSuccess = true;
 	Result.AssetPath = FullAssetPath;
 	Result.LayerName = LayerName;
 
@@ -1719,9 +1724,13 @@ FLandscapeAutoMaterialResult ULandscapeMaterialService::CreateAutoMaterial(
 	}
 
 	// Save the material
-	UEditorAssetLibrary::SaveAsset(Result.MaterialAssetPath, false);
-
-	Result.bSuccess = true;
+	Result.bSuccess = UEditorAssetLibrary::SaveAsset(Result.MaterialAssetPath, false);
+	if (!Result.bSuccess)
+	{
+		Result.ErrorMessage = FString::Printf(TEXT("Failed to save material asset '%s'"), *Result.MaterialAssetPath);
+		UE_LOG(LogTemp, Error, TEXT("ULandscapeMaterialService::CreateAutoMaterial: %s"), *Result.ErrorMessage);
+		return Result;
+	}
 	UE_LOG(LogTemp, Log, TEXT("ULandscapeMaterialService::CreateAutoMaterial: Created auto-material '%s' with %d layers"),
 		*Result.MaterialAssetPath, LayerConfigs.Num());
 

--- a/Source/VibeUE/Private/PythonAPI/ULandscapeService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/ULandscapeService.cpp
@@ -12,6 +12,7 @@
 #include "LandscapeDataAccess.h"
 #include "LandscapeEditLayer.h"
 #include "LandscapeEditorModule.h"
+#include "LandscapeSubsystem.h"
 #include "LandscapeFileFormatInterface.h"
 #include "EditorAssetLibrary.h"
 #include "Editor.h"
@@ -278,7 +279,8 @@ FLandscapeCreateResult ULandscapeService::CreateLandscape(
 	int32 QuadsPerSection,
 	int32 ComponentCountX,
 	int32 ComponentCountY,
-	const FString& LandscapeLabel)
+	const FString& LandscapeLabel,
+	int32 WorldPartitionGridSize)
 {
 	FLandscapeCreateResult Result;
 
@@ -286,6 +288,17 @@ FLandscapeCreateResult ULandscapeService::CreateLandscape(
 	if (!World)
 	{
 		Result.ErrorMessage = TEXT("No editor world available");
+		UE_LOG(LogTemp, Error, TEXT("ULandscapeService::CreateLandscape: %s"), *Result.ErrorMessage);
+		return Result;
+	}
+
+	// Validate the WP request up front — ChangeGridSize is a silent no-op in a
+	// non-partitioned world, so failing late would leave a monolithic landscape
+	// while claiming success (issue #394).
+	ULandscapeSubsystem* LandscapeSubsystem = World->GetSubsystem<ULandscapeSubsystem>();
+	if (WorldPartitionGridSize > 0 && (!LandscapeSubsystem || !LandscapeSubsystem->IsGridBased()))
+	{
+		Result.ErrorMessage = TEXT("WorldPartitionGridSize requires a World Partition level — the current level is not partitioned. Create in a WP level, or omit the parameter for a monolithic landscape.");
 		UE_LOG(LogTemp, Error, TEXT("ULandscapeService::CreateLandscape: %s"), *Result.ErrorMessage);
 		return Result;
 	}
@@ -384,6 +397,22 @@ FLandscapeCreateResult ULandscapeService::CreateLandscape(
 	if (LandscapeInfo)
 	{
 		LandscapeInfo->UpdateComponentLayerAllowList();
+	}
+
+	// World Partition: split the freshly imported landscape into a grid of
+	// ALandscapeStreamingProxy actors — the same call the editor's New Landscape
+	// tool makes in a WP world (issue #394). Edit ops already fan out across
+	// proxies by landscape GUID, so everything downstream keeps working.
+	if (WorldPartitionGridSize > 0 && LandscapeSubsystem)
+	{
+		if (!LandscapeInfo)
+		{
+			Result.ErrorMessage = TEXT("Landscape imported but has no LandscapeInfo — cannot apply World Partition grid size");
+			UE_LOG(LogTemp, Error, TEXT("ULandscapeService::CreateLandscape: %s"), *Result.ErrorMessage);
+			return Result;
+		}
+		LandscapeSubsystem->ChangeGridSize(LandscapeInfo, static_cast<uint32>(WorldPartitionGridSize));
+		UE_LOG(LogTemp, Log, TEXT("ULandscapeService::CreateLandscape: Applied World Partition grid size %d (landscape split into streaming proxies)"), WorldPartitionGridSize);
 	}
 
 	Result.bSuccess = true;
@@ -789,13 +818,21 @@ FHeightmapResizeResult ULandscapeService::ResizeHeightmap(
 	const FString& SourcePath,
 	int32 TargetWidth,
 	int32 TargetHeight,
-	const FString& OutputPath)
+	const FString& OutputPath,
+	const FString& Interpolation)
 {
 	FHeightmapResizeResult Result;
 
 	if (TargetWidth <= 0 || TargetHeight <= 0)
 	{
 		Result.ErrorMessage = FString::Printf(TEXT("Invalid target dimensions: %dx%d"), TargetWidth, TargetHeight);
+		return Result;
+	}
+
+	const bool bBicubic = !Interpolation.Equals(TEXT("bilinear"), ESearchCase::IgnoreCase);
+	if (bBicubic && !Interpolation.Equals(TEXT("bicubic"), ESearchCase::IgnoreCase))
+	{
+		Result.ErrorMessage = FString::Printf(TEXT("Unknown interpolation '%s' — use \"bicubic\" or \"bilinear\""), *Interpolation);
 		return Result;
 	}
 
@@ -870,33 +907,69 @@ FHeightmapResizeResult ULandscapeService::ResizeHeightmap(
 		return Result;
 	}
 
-	// Bilinear resample uint16 data
+	// Resample uint16 data. Bicubic (Catmull-Rom) by default: bilinear upsampling of
+	// a low-res DEM is only C0-continuous, so flat plains come out as visible planar
+	// facets ("blocky" terraces, issue #393); Catmull-Rom is C1 so normals stay smooth.
 	TArray<uint16> ResizedData;
 	ResizedData.SetNumUninitialized(TargetWidth * TargetHeight);
 
 	const float ScaleX = static_cast<float>(SrcDims.Width - 1) / static_cast<float>(TargetWidth - 1);
 	const float ScaleY = static_cast<float>(SrcDims.Height - 1) / static_cast<float>(TargetHeight - 1);
 
+	auto SampleClamped = [&SourceData, &SrcDims](int32 X, int32 Y) -> float
+	{
+		X = FMath::Clamp(X, 0, SrcDims.Width - 1);
+		Y = FMath::Clamp(Y, 0, SrcDims.Height - 1);
+		return static_cast<float>(SourceData[Y * SrcDims.Width + X]);
+	};
+
+	// Catmull-Rom weight for 4 taps at offsets -1..2 around the sample point.
+	auto CatmullRom = [](float P0, float P1, float P2, float P3, float T) -> float
+	{
+		const float T2 = T * T;
+		const float T3 = T2 * T;
+		return 0.5f * ((2.0f * P1)
+			+ (-P0 + P2) * T
+			+ (2.0f * P0 - 5.0f * P1 + 4.0f * P2 - P3) * T2
+			+ (-P0 + 3.0f * P1 - 3.0f * P2 + P3) * T3);
+	};
+
 	for (int32 Y = 0; Y < TargetHeight; Y++)
 	{
 		const float SrcY = Y * ScaleY;
 		const int32 Y0 = FMath::FloorToInt(SrcY);
-		const int32 Y1 = FMath::Min(Y0 + 1, SrcDims.Height - 1);
 		const float Fy = SrcY - static_cast<float>(Y0);
 
 		for (int32 X = 0; X < TargetWidth; X++)
 		{
 			const float SrcX = X * ScaleX;
 			const int32 X0 = FMath::FloorToInt(SrcX);
-			const int32 X1 = FMath::Min(X0 + 1, SrcDims.Width - 1);
 			const float Fx = SrcX - static_cast<float>(X0);
 
-			const float TL = static_cast<float>(SourceData[Y0 * SrcDims.Width + X0]);
-			const float TR = static_cast<float>(SourceData[Y0 * SrcDims.Width + X1]);
-			const float BL = static_cast<float>(SourceData[Y1 * SrcDims.Width + X0]);
-			const float BR = static_cast<float>(SourceData[Y1 * SrcDims.Width + X1]);
-
-			const float Interpolated = FMath::Lerp(FMath::Lerp(TL, TR, Fx), FMath::Lerp(BL, BR, Fx), Fy);
+			float Interpolated;
+			if (bBicubic)
+			{
+				float Rows[4];
+				for (int32 Row = 0; Row < 4; Row++)
+				{
+					const int32 SampleY = Y0 - 1 + Row;
+					Rows[Row] = CatmullRom(
+						SampleClamped(X0 - 1, SampleY),
+						SampleClamped(X0,     SampleY),
+						SampleClamped(X0 + 1, SampleY),
+						SampleClamped(X0 + 2, SampleY),
+						Fx);
+				}
+				Interpolated = CatmullRom(Rows[0], Rows[1], Rows[2], Rows[3], Fy);
+			}
+			else
+			{
+				const float TL = SampleClamped(X0,     Y0);
+				const float TR = SampleClamped(X0 + 1, Y0);
+				const float BL = SampleClamped(X0,     Y0 + 1);
+				const float BR = SampleClamped(X0 + 1, Y0 + 1);
+				Interpolated = FMath::Lerp(FMath::Lerp(TL, TR, Fx), FMath::Lerp(BL, BR, Fx), Fy);
+			}
 			ResizedData[Y * TargetWidth + X] = static_cast<uint16>(FMath::Clamp(FMath::RoundToInt(Interpolated), 0, 65535));
 		}
 	}
@@ -2488,7 +2561,11 @@ bool ULandscapeService::SetLandscapeProperty(
 	Landscape->Modify();
 
 	const TCHAR* ValuePtr = *Value;
-	Property->ImportText_Direct(ValuePtr, Property->ContainerPtrToValuePtr<void>(Landscape), Landscape, PPF_None);
+	if (!Property->ImportText_Direct(ValuePtr, Property->ContainerPtrToValuePtr<void>(Landscape), Landscape, PPF_None))
+	{
+		UE_LOG(LogTemp, Error, TEXT("ULandscapeService::SetLandscapeProperty: Failed to parse value '%s' for property '%s'"), *Value, *PropertyName);
+		return false;
+	}
 	Landscape->PostEditChange();
 
 	return true;

--- a/Source/VibeUE/Private/PythonAPI/UMaterialNodeService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UMaterialNodeService.cpp
@@ -1635,8 +1635,14 @@ int32 UMaterialNodeService::BatchSetProperties(
 			}
 		}
 
-		Property->ImportText_Direct(*PropertyValues[i], PropertyPtr, Expression, PPF_None);
-		SuccessCount++;
+		if (Property->ImportText_Direct(*PropertyValues[i], PropertyPtr, Expression, PPF_None))
+		{
+			SuccessCount++;
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("UMaterialNodeService::BatchSetProperties: Failed to parse value '%s' for property '%s'"), *PropertyValues[i], *PropertyNames[i]);
+		}
 	}
 
 	// Single refresh at end
@@ -3079,11 +3085,16 @@ FMaterialCreateResult UMaterialNodeService::CreateMaterialFunction(
 		Function->bExposeToLibrary = bExposeToLibrary;
 	}
 
-	Result.bSuccess = true;
 	Result.AssetPath = NewAsset->GetPathName();
 
 	// Save immediately
-	UEditorAssetLibrary::SaveAsset(Result.AssetPath, false);
+	Result.bSuccess = UEditorAssetLibrary::SaveAsset(Result.AssetPath, false);
+	if (!Result.bSuccess)
+	{
+		Result.ErrorMessage = FString::Printf(TEXT("Failed to save material function asset '%s'"), *Result.AssetPath);
+		UE_LOG(LogTemp, Error, TEXT("UMaterialNodeService::CreateMaterialFunction: %s"), *Result.ErrorMessage);
+		return Result;
+	}
 
 	UE_LOG(LogTemp, Log, TEXT("UMaterialNodeService::CreateMaterialFunction: Created '%s' at '%s'"),
 		*FunctionName, *Result.AssetPath);
@@ -3134,7 +3145,11 @@ FString UMaterialNodeService::AddFunctionInput(
 	Function->PostEditChange();
 
 	// Save
-	UEditorAssetLibrary::SaveAsset(FunctionPath, false);
+	if (!UEditorAssetLibrary::SaveAsset(FunctionPath, false))
+	{
+		UE_LOG(LogTemp, Error, TEXT("UMaterialNodeService::AddFunctionInput: Failed to save '%s'"), *FunctionPath);
+		return FString();
+	}
 
 	FString Id = GetExpressionId(NewInput);
 	UE_LOG(LogTemp, Log, TEXT("UMaterialNodeService::AddFunctionInput: Added input '%s' (type=%s) to '%s', id=%s"),
@@ -3179,7 +3194,11 @@ FString UMaterialNodeService::AddFunctionOutput(
 
 	Function->PostEditChange();
 
-	UEditorAssetLibrary::SaveAsset(FunctionPath, false);
+	if (!UEditorAssetLibrary::SaveAsset(FunctionPath, false))
+	{
+		UE_LOG(LogTemp, Error, TEXT("UMaterialNodeService::AddFunctionOutput: Failed to save '%s'"), *FunctionPath);
+		return FString();
+	}
 
 	FString Id = GetExpressionId(NewOutput);
 	UE_LOG(LogTemp, Log, TEXT("UMaterialNodeService::AddFunctionOutput: Added output '%s' to '%s', id=%s"),
@@ -3451,7 +3470,10 @@ int32 UMaterialNodeService::CleanupUnusedExpressions(const FString& AssetPath)
 			Function->GetExpressionCollection().RemoveExpression(Expr);
 		}
 		Function->PostEditChange();
-		UEditorAssetLibrary::SaveAsset(AssetPath, false);
+		if (!UEditorAssetLibrary::SaveAsset(AssetPath, false))
+		{
+			UE_LOG(LogTemp, Warning, TEXT("UMaterialNodeService::CleanupUnusedExpressions: Failed to save '%s'"), *AssetPath);
+		}
 	}
 
 	UE_LOG(LogTemp, Log, TEXT("UMaterialNodeService::CleanupUnusedExpressions: Removed %d unused expression(s) from %s"),

--- a/Source/VibeUE/Private/PythonAPI/UMaterialService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UMaterialService.cpp
@@ -17,6 +17,7 @@
 #include "Subsystems/AssetEditorSubsystem.h"
 #include "Editor.h"
 #include "UObject/SavePackage.h"
+#include "Misc/DefaultValueHelper.h"
 #include "Misc/PackageName.h"
 #include "Engine/Texture.h"
 #include "StaticParameterSet.h"
@@ -273,19 +274,34 @@ bool UMaterialService::StringToPropertyValue(FProperty* Property, void* Containe
 	// Float
 	if (FFloatProperty* FloatProp = CastField<FFloatProperty>(Property))
 	{
-		FloatProp->SetPropertyValue(ValuePtr, FCString::Atof(*Value));
+		float FloatValue = 0.0f;
+		if (!FDefaultValueHelper::ParseFloat(Value, FloatValue))
+		{
+			return false;
+		}
+		FloatProp->SetPropertyValue(ValuePtr, FloatValue);
 		return true;
 	}
 	// Double
 	if (FDoubleProperty* DoubleProp = CastField<FDoubleProperty>(Property))
 	{
-		DoubleProp->SetPropertyValue(ValuePtr, FCString::Atod(*Value));
+		double DoubleValue = 0.0;
+		if (!FDefaultValueHelper::ParseDouble(Value, DoubleValue))
+		{
+			return false;
+		}
+		DoubleProp->SetPropertyValue(ValuePtr, DoubleValue);
 		return true;
 	}
 	// Int
 	if (FIntProperty* IntProp = CastField<FIntProperty>(Property))
 	{
-		IntProp->SetPropertyValue(ValuePtr, FCString::Atoi(*Value));
+		int32 IntValue = 0;
+		if (!FDefaultValueHelper::ParseInt(Value, IntValue))
+		{
+			return false;
+		}
+		IntProp->SetPropertyValue(ValuePtr, IntValue);
 		return true;
 	}
 	// Byte/Enum
@@ -294,13 +310,21 @@ bool UMaterialService::StringToPropertyValue(FProperty* Property, void* Containe
 		if (UEnum* Enum = ByteProp->Enum)
 		{
 			int64 EnumValue = ResolveEnumValue(Enum, Value);
-			if (EnumValue != INDEX_NONE)
+			if (EnumValue == INDEX_NONE)
 			{
-				ByteProp->SetPropertyValue(ValuePtr, static_cast<uint8>(EnumValue));
-				return true;
+				// Don't fall through to Atoi for enum-backed bytes — a bad name would silently become 0.
+				UE_LOG(LogTemp, Error, TEXT("UMaterialService::StringToPropertyValue: '%s' is not a valid value for enum %s"), *Value, *Enum->GetName());
+				return false;
 			}
+			ByteProp->SetPropertyValue(ValuePtr, static_cast<uint8>(EnumValue));
+			return true;
 		}
-		ByteProp->SetPropertyValue(ValuePtr, static_cast<uint8>(FCString::Atoi(*Value)));
+		int32 ByteValue = 0;
+		if (!FDefaultValueHelper::ParseInt(Value, ByteValue))
+		{
+			return false;
+		}
+		ByteProp->SetPropertyValue(ValuePtr, static_cast<uint8>(ByteValue));
 		return true;
 	}
 	if (FEnumProperty* EnumProp = CastField<FEnumProperty>(Property))

--- a/Source/VibeUE/Private/PythonAPI/UMetaSoundService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UMetaSoundService.cpp
@@ -283,13 +283,13 @@ UMetaSoundBuilderBase* UMetaSoundService::BeginEditing(const FString& AssetPath,
 	return Builder;
 }
 
-void UMetaSoundService::CommitEditing(const FString& AssetPath, UMetaSoundSource* Source)
+bool UMetaSoundService::CommitEditing(const FString& AssetPath, UMetaSoundSource* Source)
 {
 	UMetaSoundEditorSubsystem::GetChecked().RegisterGraphWithFrontend(*Source);
 	// Notify any open MetaSound editor window to resync its graph view.
 	// Without this, the editor displays stale state until the asset is closed/reopened.
 	Source->PostEditChange();
-	UEditorAssetLibrary::SaveAsset(AssetPath, false);
+	return UEditorAssetLibrary::SaveAsset(AssetPath, false);
 }
 
 // ============================================================================
@@ -396,7 +396,11 @@ FMetaSoundResult UMetaSoundService::CreateMetaSound(const FString& PackagePath,
 
 			if (bModified)
 			{
-				CommitEditing(FullPath, NewSource);
+				if (!CommitEditing(FullPath, NewSource))
+				{
+					UE_LOG(LogMetaSoundService, Warning,
+					       TEXT("CreateMetaSound: SaveAsset failed for '%s'"), *FullPath);
+				}
 				UEditorAssetLibrary::SaveAsset(FullPath, false);
 			}
 		}
@@ -476,7 +480,10 @@ FMetaSoundResult UMetaSoundService::SaveMetaSound(const FString& AssetPath)
 		return Fail(LoadError);
 	}
 
-	CommitEditing(AssetPath, Source);
+	if (!CommitEditing(AssetPath, Source))
+	{
+		return Fail(FString::Printf(TEXT("SaveMetaSound: SaveAsset failed for '%s'"), *AssetPath));
+	}
 	return Succeed(AssetPath, TEXT("Saved"));
 }
 
@@ -594,7 +601,10 @@ FMetaSoundResult UMetaSoundService::AddNode(const FString& AssetPath,
 	Builder->SetNodeLocation(NodeHandle, FVector2D(PosX, PosY), LocR);
 #endif
 
-	CommitEditing(AssetPath, Source);
+	if (!CommitEditing(AssetPath, Source))
+	{
+		return Fail(FString::Printf(TEXT("AddNode: SaveAsset failed for '%s'"), *AssetPath));
+	}
 
 	const FString NodeId = NodeHandle.NodeID.ToString(EGuidFormats::DigitsWithHyphens);
 	return Succeed(AssetPath,
@@ -626,7 +636,10 @@ FMetaSoundResult UMetaSoundService::RemoveNode(const FString& AssetPath, const F
 		return Fail(FString::Printf(TEXT("RemoveNode: node '%s' not found"), *NodeId));
 	}
 
-	CommitEditing(AssetPath, Source);
+	if (!CommitEditing(AssetPath, Source))
+	{
+		return Fail(FString::Printf(TEXT("RemoveNode: SaveAsset failed for '%s'"), *AssetPath));
+	}
 	return Succeed(AssetPath, TEXT("Node removed"), NodeId);
 }
 
@@ -914,7 +927,10 @@ FMetaSoundResult UMetaSoundService::ConnectNodes(const FString& AssetPath,
 		return Fail(FString::Printf(TEXT("ConnectNodes: connection failed (type mismatch or already connected)")));
 	}
 
-	CommitEditing(AssetPath, Source);
+	if (!CommitEditing(AssetPath, Source))
+	{
+		return Fail(FString::Printf(TEXT("ConnectNodes: SaveAsset failed for '%s'"), *AssetPath));
+	}
 	return Succeed(AssetPath, FString::Printf(TEXT("Connected %s.%s -> %s.%s"),
 	                                           *FromNodeId, *OutputName, *ToNodeId, *InputName));
 }
@@ -956,7 +972,10 @@ FMetaSoundResult UMetaSoundService::DisconnectPin(const FString& AssetPath,
 		return Fail(FString::Printf(TEXT("DisconnectPin: pin '%s' was not connected"), *InputName));
 	}
 
-	CommitEditing(AssetPath, Source);
+	if (!CommitEditing(AssetPath, Source))
+	{
+		return Fail(FString::Printf(TEXT("DisconnectPin: SaveAsset failed for '%s'"), *AssetPath));
+	}
 	return Succeed(AssetPath, FString::Printf(TEXT("Disconnected %s.%s"), *NodeId, *InputName));
 }
 
@@ -986,7 +1005,10 @@ FMetaSoundResult UMetaSoundService::AddGraphInput(const FString& AssetPath,
 		return Fail(FString::Printf(TEXT("AddGraphInput: failed to add '%s' (%s)"), *InputName, *DataType));
 	}
 
-	CommitEditing(AssetPath, Source);
+	if (!CommitEditing(AssetPath, Source))
+	{
+		return Fail(FString::Printf(TEXT("AddGraphInput: SaveAsset failed for '%s'"), *AssetPath));
+	}
 	return Succeed(AssetPath, FString::Printf(TEXT("Added graph input '%s:%s'"), *InputName, *DataType));
 }
 
@@ -1010,7 +1032,10 @@ FMetaSoundResult UMetaSoundService::AddGraphOutput(const FString& AssetPath,
 		return Fail(FString::Printf(TEXT("AddGraphOutput: failed to add '%s' (%s)"), *OutputName, *DataType));
 	}
 
-	CommitEditing(AssetPath, Source);
+	if (!CommitEditing(AssetPath, Source))
+	{
+		return Fail(FString::Printf(TEXT("AddGraphOutput: SaveAsset failed for '%s'"), *AssetPath));
+	}
 	return Succeed(AssetPath, FString::Printf(TEXT("Added graph output '%s:%s'"), *OutputName, *DataType));
 }
 
@@ -1031,7 +1056,10 @@ FMetaSoundResult UMetaSoundService::RemoveGraphInput(const FString& AssetPath, c
 		return Fail(FString::Printf(TEXT("RemoveGraphInput: input '%s' not found"), *InputName));
 	}
 
-	CommitEditing(AssetPath, Source);
+	if (!CommitEditing(AssetPath, Source))
+	{
+		return Fail(FString::Printf(TEXT("RemoveGraphInput: SaveAsset failed for '%s'"), *AssetPath));
+	}
 	return Succeed(AssetPath, FString::Printf(TEXT("Removed graph input '%s'"), *InputName));
 }
 
@@ -1052,7 +1080,10 @@ FMetaSoundResult UMetaSoundService::RemoveGraphOutput(const FString& AssetPath, 
 		return Fail(FString::Printf(TEXT("RemoveGraphOutput: output '%s' not found"), *OutputName));
 	}
 
-	CommitEditing(AssetPath, Source);
+	if (!CommitEditing(AssetPath, Source))
+	{
+		return Fail(FString::Printf(TEXT("RemoveGraphOutput: SaveAsset failed for '%s'"), *AssetPath));
+	}
 	return Succeed(AssetPath, FString::Printf(TEXT("Removed graph output '%s'"), *OutputName));
 }
 
@@ -1117,7 +1148,10 @@ FMetaSoundResult UMetaSoundService::SetNodeInputDefault(const FString& AssetPath
 		                            *InputName, *NodeId));
 	}
 
-	CommitEditing(AssetPath, Source);
+	if (!CommitEditing(AssetPath, Source))
+	{
+		return Fail(FString::Printf(TEXT("SetNodeInputDefault: SaveAsset failed for '%s'"), *AssetPath));
+	}
 	return Succeed(AssetPath, FString::Printf(TEXT("Set %s.%s = %s"), *NodeId, *InputName, *Value));
 }
 
@@ -1146,7 +1180,10 @@ FMetaSoundResult UMetaSoundService::SetNodeLocation(const FString& AssetPath,
 		return Fail(FString::Printf(TEXT("SetNodeLocation: node '%s' not found"), *NodeId));
 	}
 
-	CommitEditing(AssetPath, Source);
+	if (!CommitEditing(AssetPath, Source))
+	{
+		return Fail(FString::Printf(TEXT("SetNodeLocation: SaveAsset failed for '%s'"), *AssetPath));
+	}
 	return Succeed(AssetPath, FString::Printf(TEXT("Moved node to (%.0f, %.0f)"), PosX, PosY), NodeId);
 #else
 	return Fail(TEXT("SetNodeLocation: requires editor build"));

--- a/Source/VibeUE/Private/PythonAPI/UNiagaraEmitterService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UNiagaraEmitterService.cpp
@@ -477,6 +477,77 @@ bool UNiagaraEmitterService::SetColorTint(
 	return bRGBSet && bAlphaSet;
 }
 
+bool UNiagaraEmitterService::SetSimTarget(
+	const FString& SystemPath,
+	const FString& EmitterName,
+	const FString& SimTarget)
+{
+	UNiagaraSystem* System = LoadNiagaraSystem(SystemPath);
+	if (!System)
+	{
+		UE_LOG(LogTemp, Error, TEXT("UNiagaraEmitterService::SetSimTarget - Failed to load system: %s"), *SystemPath);
+		return false;
+	}
+
+	FNiagaraEmitterHandle* Handle = FindEmitterHandle(System, EmitterName);
+	if (!Handle)
+	{
+		UE_LOG(LogTemp, Error, TEXT("UNiagaraEmitterService::SetSimTarget - Emitter '%s' not found in %s"), *EmitterName, *SystemPath);
+		return false;
+	}
+
+	FVersionedNiagaraEmitterData* EmitterData = Handle->GetEmitterData();
+	if (!EmitterData)
+	{
+		UE_LOG(LogTemp, Error, TEXT("UNiagaraEmitterService::SetSimTarget - Emitter '%s' has no emitter data"), *EmitterName);
+		return false;
+	}
+
+	// Accept "CPU"/"GPU" shorthands as well as the enum names.
+	ENiagaraSimTarget NewTarget;
+	if (SimTarget.Equals(TEXT("CPU"), ESearchCase::IgnoreCase) || SimTarget.Equals(TEXT("CPUSim"), ESearchCase::IgnoreCase))
+	{
+		NewTarget = ENiagaraSimTarget::CPUSim;
+	}
+	else if (SimTarget.Equals(TEXT("GPU"), ESearchCase::IgnoreCase) || SimTarget.Equals(TEXT("GPUComputeSim"), ESearchCase::IgnoreCase))
+	{
+		NewTarget = ENiagaraSimTarget::GPUComputeSim;
+	}
+	else
+	{
+		UE_LOG(LogTemp, Error, TEXT("UNiagaraEmitterService::SetSimTarget - Unknown sim target '%s' — use \"CPU\" or \"GPU\""), *SimTarget);
+		return false;
+	}
+
+	if (EmitterData->SimTarget == NewTarget)
+	{
+		UE_LOG(LogTemp, Log, TEXT("UNiagaraEmitterService::SetSimTarget - Emitter '%s' already targets %s"), *EmitterName, *SimTarget);
+		return true;
+	}
+
+	// The emitter data lives on the versioned UNiagaraEmitter, not the system —
+	// Modify() it so the change transacts and persists.
+	UNiagaraEmitter* Emitter = Handle->GetInstance().Emitter;
+	if (Emitter)
+	{
+		Emitter->Modify();
+	}
+	EmitterData->SimTarget = NewTarget;
+	if (Emitter)
+	{
+		Emitter->MarkPackageDirty();
+	}
+
+	System->Modify();
+	System->MarkPackageDirty();
+	System->RequestCompile(false);
+	System->WaitForCompilationComplete();
+
+	UE_LOG(LogTemp, Log, TEXT("UNiagaraEmitterService::SetSimTarget - Set emitter '%s' sim target to %s and recompiled"), *EmitterName,
+		NewTarget == ENiagaraSimTarget::GPUComputeSim ? TEXT("GPUComputeSim") : TEXT("CPUSim"));
+	return true;
+}
+
 // =================================================================
 // Color Curve Manipulation (Hue Shifting)
 // =================================================================

--- a/Source/VibeUE/Private/PythonAPI/UNiagaraScratchPadService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UNiagaraScratchPadService.cpp
@@ -1160,10 +1160,115 @@ FNiagaraScratchResult UNiagaraScratchPadService::AddModuleOutput(
 // Apply
 // =====================================================================
 
+namespace
+{
+	// A scratch module left with duplicate same-named pins on a Map Get/Set node (the
+	// pre-7bca8ce non-idempotency, or manual edits) makes ANY later system compile fire
+	// a fatal "Array index out of bounds" assert inside ReallocatePins — taking down the
+	// editor. Detect it up front so ApplyChanges can refuse with a clear error instead
+	// (issue #432).
+	bool ValidateScratchGraphsForCompile(UNiagaraSystem* System, FString& OutError)
+	{
+		for (const FNiagaraEmitterHandle& Handle : System->GetEmitterHandles())
+		{
+			const FVersionedNiagaraEmitterData* EmitterData = Handle.GetEmitterData();
+			if (!EmitterData || !EmitterData->ScratchPads) continue;
+			for (UNiagaraScript* Scratch : EmitterData->ScratchPads->Scripts)
+			{
+				if (!Scratch) continue;
+				const auto* Src = Cast<UNiagaraScriptSource>(Scratch->GetLatestSource());
+				if (!Src || !Src->NodeGraph) continue;
+
+				for (UEdGraphNode* Node : Src->NodeGraph->Nodes)
+				{
+					if (!IsMapGet(Node) && !IsMapSet(Node)) continue;
+
+					TSet<FName> InputNames;
+					TSet<FName> OutputNames;
+					for (const UEdGraphPin* Pin : Node->Pins)
+					{
+						if (!Pin) continue;
+						TSet<FName>& Names = (Pin->Direction == EGPD_Input) ? InputNames : OutputNames;
+						bool bAlreadyThere = false;
+						Names.Add(Pin->PinName, &bAlreadyThere);
+						if (bAlreadyThere)
+						{
+							OutError = FString::Printf(
+								TEXT("Scratch module '%s' (emitter '%s') has duplicate %s pins named '%s' on a %s node (%s) — compiling this graph would crash the editor. Remove the duplicate pin (remove_node_pin) before apply_changes."),
+								*Scratch->GetName(), *Handle.GetName().ToString(),
+								Pin->Direction == EGPD_Input ? TEXT("input") : TEXT("output"),
+								*Pin->PinName.ToString(),
+								IsMapGet(Node) ? TEXT("MapGet") : TEXT("MapSet"),
+								*Node->NodeGuid.ToString());
+							return false;
+						}
+					}
+				}
+			}
+		}
+		return true;
+	}
+
+	// Collect the real Niagara compiler diagnostics from every script in the system.
+	void CollectCompileMessages(UNiagaraSystem* System, bool bErrorsOnly, TArray<FString>& OutMessages)
+	{
+		TArray<TPair<FString, UNiagaraScript*>> Scripts;
+		Scripts.Emplace(TEXT("SystemSpawn"), System->GetSystemSpawnScript());
+		Scripts.Emplace(TEXT("SystemUpdate"), System->GetSystemUpdateScript());
+		for (const FNiagaraEmitterHandle& Handle : System->GetEmitterHandles())
+		{
+			const FVersionedNiagaraEmitterData* EmitterData = Handle.GetEmitterData();
+			if (!EmitterData) continue;
+			TArray<UNiagaraScript*> EmitterScripts;
+			EmitterData->GetScripts(EmitterScripts, /*bCompilableOnly=*/true);
+			for (UNiagaraScript* Script : EmitterScripts)
+			{
+				Scripts.Emplace(Handle.GetName().ToString(), Script);
+			}
+		}
+
+		for (const TPair<FString, UNiagaraScript*>& Entry : Scripts)
+		{
+			UNiagaraScript* Script = Entry.Value;
+			if (!Script) continue;
+
+#if WITH_EDITORONLY_DATA
+			const FNiagaraVMExecutableData& VMData = Script->GetVMExecutableData();
+			if (VMData.LastCompileStatus == ENiagaraScriptCompileStatus::NCS_Error && !VMData.ErrorMsg.IsEmpty())
+			{
+				OutMessages.Add(FString::Printf(TEXT("Error: [%s/%s] %s"), *Entry.Key, *Script->GetName(), *VMData.ErrorMsg));
+			}
+			for (const FNiagaraCompileEvent& Event : VMData.LastCompileEvents)
+			{
+				const bool bIsError = Event.Severity == FNiagaraCompileEventSeverity::Error;
+				const bool bIsWarning = Event.Severity == FNiagaraCompileEventSeverity::Warning;
+				if (!bIsError && (bErrorsOnly || !bIsWarning))
+				{
+					continue;
+				}
+				OutMessages.Add(FString::Printf(TEXT("%s: [%s/%s] %s%s"),
+					bIsError ? TEXT("Error") : TEXT("Warning"),
+					*Entry.Key, *Script->GetName(),
+					*Event.Message,
+					Event.NodeGuid.IsValid() ? *FString::Printf(TEXT(" (node %s)"), *Event.NodeGuid.ToString()) : TEXT("")));
+			}
+#endif
+		}
+	}
+}
+
 bool UNiagaraScratchPadService::ApplyChanges(const FString& SystemPath)
 {
 	UNiagaraSystem* System = LoadSystem(SystemPath);
 	if (!System) return false;
+
+	// Refuse to compile a corrupt scratch graph — the engine assert it would fire is fatal.
+	FString ValidationError;
+	if (!ValidateScratchGraphsForCompile(System, ValidationError))
+	{
+		UE_LOG(LogTemp, Error, TEXT("ApplyChanges: %s"), *ValidationError);
+		return false;
+	}
 
 	// Notify each scratch script graph that it has changed so its ChangeID bumps. This is what
 	// triggers callers (the stack function-call nodes that reference it) to pick up the new
@@ -1198,7 +1303,33 @@ bool UNiagaraScratchPadService::ApplyChanges(const FString& SystemPath)
 	System->WaitForCompilationComplete();
 
 	UEditorAssetLibrary::SaveLoadedAsset(System);
+
+	// Surface the real compiler diagnostics instead of a bare true/false — a compile
+	// with errors is a failure the caller must see (issues #432, #352).
+	TArray<FString> CompileErrors;
+	CollectCompileMessages(System, /*bErrorsOnly=*/true, CompileErrors);
+	if (CompileErrors.Num() > 0)
+	{
+		for (const FString& Msg : CompileErrors)
+		{
+			UE_LOG(LogTemp, Error, TEXT("ApplyChanges: %s"), *Msg);
+		}
+		return false;
+	}
 	return true;
+}
+
+TArray<FString> UNiagaraScratchPadService::GetCompileMessages(const FString& SystemPath, bool bErrorsOnly)
+{
+	TArray<FString> Messages;
+	UNiagaraSystem* System = LoadSystem(SystemPath);
+	if (!System)
+	{
+		Messages.Add(FString::Printf(TEXT("Error: failed to load Niagara system '%s'"), *SystemPath));
+		return Messages;
+	}
+	CollectCompileMessages(System, bErrorsOnly, Messages);
+	return Messages;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/VibeUE/Private/PythonAPI/URuntimeVirtualTextureService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/URuntimeVirtualTextureService.cpp
@@ -185,9 +185,14 @@ FRVTCreateResult URuntimeVirtualTextureService::CreateRuntimeVirtualTexture(
 	NewRVT->MarkPackageDirty();
 
 	// Save the asset
-	UEditorAssetLibrary::SaveAsset(FullAssetPath, false);
+	Result.bSuccess = UEditorAssetLibrary::SaveAsset(FullAssetPath, false);
+	if (!Result.bSuccess)
+	{
+		Result.ErrorMessage = FString::Printf(TEXT("Failed to save RVT asset '%s'"), *FullAssetPath);
+		UE_LOG(LogTemp, Error, TEXT("URuntimeVirtualTextureService::CreateRuntimeVirtualTexture: %s"), *Result.ErrorMessage);
+		return Result;
+	}
 
-	Result.bSuccess = true;
 	Result.AssetPath = FullAssetPath;
 
 	UE_LOG(LogTemp, Log, TEXT("URuntimeVirtualTextureService::CreateRuntimeVirtualTexture: Created '%s' (type=%s)"),

--- a/Source/VibeUE/Private/PythonAPI/USoundCueService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/USoundCueService.cpp
@@ -319,9 +319,13 @@ FSoundCueResult USoundCueService::DuplicateSoundCue(const FString& SourcePath, c
 		return Result;
 	}
 
-	UEditorAssetLibrary::SaveAsset(DestPath, false);
+	Result.bSuccess = UEditorAssetLibrary::SaveAsset(DestPath, false);
+	if (!Result.bSuccess)
+	{
+		Result.Message = FString::Printf(TEXT("SaveAsset failed for '%s'"), *DestPath);
+		return Result;
+	}
 
-	Result.bSuccess  = true;
 	Result.AssetPath = Duplicate->GetPathName();
 	Result.Message   = FString::Printf(TEXT("Duplicated '%s' → '%s'"), *SourcePath, *DestPath);
 	return Result;

--- a/Source/VibeUE/Private/PythonAPI/UStateTreeService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UStateTreeService.cpp
@@ -809,6 +809,11 @@ static bool SetPropertyValueFromString(FProperty* Property, void* ValuePtr, cons
 
 	if (FNumericProperty* NumericProperty = CastField<FNumericProperty>(Property))
 	{
+		// SetNumericPropertyValueFromString returns void and silently coerces bad input to 0 — validate first.
+		if (!FCString::IsNumeric(*Value))
+		{
+			return false;
+		}
 		NumericProperty->SetNumericPropertyValueFromString(ValuePtr, *Value);
 		return true;
 	}

--- a/Source/VibeUE/Private/Tools/PythonExecutionService.cpp
+++ b/Source/VibeUE/Private/Tools/PythonExecutionService.cpp
@@ -225,18 +225,30 @@ TResult<FPythonExecutionResult> FPythonExecutionService::ExecuteCode(
 			CrashMessage = FString::Printf(TEXT("Python execution caused a crash (exception code: 0x%08X). The Python code may have accessed invalid memory."), SEHResult.ExceptionCode);
 		}
 
-		// A caught access violation / assertion leaves the CPython runtime in an undefined state;
-		// it cannot be reinitialized in-process. Give the caller actionable guidance instead of
-		// letting subsequent calls fail identically with no explanation.
-		if (GbPythonInterpreterCrashed)
+		// A caught fault often originates in engine C++ called from Python, not in
+		// CPython itself — in that case the interpreter (and GIL) are still healthy and
+		// the session can keep working. Probe with a no-op through the same SEH wrapper:
+		// clean probe → recovered; probe faults too → genuinely wedged (issue #399).
+		FPythonCommandEx ProbeCommand;
+		ProbeCommand.Command = TEXT("pass");
+		ProbeCommand.ExecutionMode = EPythonCommandExecutionMode::ExecuteStatement;
+		ProbeCommand.Flags = EPythonCommandFlags::None;
+		const FSEHExecutionResult ProbeResult = ExecutePythonWithSEH(PythonPlugin, &ProbeCommand);
+		if (!ProbeResult.bCrashed && ProbeResult.bSuccess)
 		{
-			CrashMessage += TEXT(" NOTE: the Python interpreter has now crashed more than once this session and is unrecoverable in-process — restart the editor (BuildAndLaunch) to restore Python execution.");
+			GbPythonInterpreterCrashed = false;
+			CrashMessage += TEXT(" NOTE: the interpreter responded to a post-crash probe — the session has been recovered and further Python calls will execute normally. Dirty assets touched by the crashed script may still be corrupt; verify before saving.");
+		}
+		else if (GbPythonInterpreterCrashed)
+		{
+			CrashMessage += TEXT(" NOTE: the post-crash probe failed and the interpreter has crashed repeatedly this session — it is unrecoverable in-process; restart the editor (BuildAndLaunch) to restore Python execution.");
+			GbPythonInterpreterCrashed = true;
 		}
 		else
 		{
-			CrashMessage += TEXT(" NOTE: the interpreter may now be unstable; if further commands keep failing identically, restart the editor (BuildAndLaunch).");
+			CrashMessage += TEXT(" NOTE: the post-crash probe failed — the interpreter is unstable; if further commands keep failing identically, restart the editor (BuildAndLaunch).");
+			GbPythonInterpreterCrashed = true;
 		}
-		GbPythonInterpreterCrashed = true;
 
 		UE_LOG(LogTemp, Error, TEXT("%s"), *CrashMessage);
 	}

--- a/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
+++ b/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
@@ -58,6 +58,45 @@ struct FBlueprintGraphInfo
 };
 
 /**
+ * Fixed-size overview of a single graph — the cheap first read before deciding
+ * whether a full get_nodes_in_graph dump is needed. Payload size is independent
+ * of graph size (the histogram/entry lists are one line per distinct type/event,
+ * not per node).
+ */
+USTRUCT(BlueprintType)
+struct FBlueprintGraphSummary
+{
+	GENERATED_BODY()
+
+	/** Tab name as shown in the My Blueprint panel */
+	UPROPERTY(BlueprintReadWrite, Category = "Blueprint")
+	FString GraphName;
+
+	/** "Ubergraph" | "Function" | "Macro" | "DelegateSignature" */
+	UPROPERTY(BlueprintReadWrite, Category = "Blueprint")
+	FString GraphKind;
+
+	UPROPERTY(BlueprintReadWrite, Category = "Blueprint")
+	int32 NodeCount = 0;
+
+	/** Number of pin-to-pin links in the graph */
+	UPROPERTY(BlueprintReadWrite, Category = "Blueprint")
+	int32 ConnectionCount = 0;
+
+	/** Blueprint-level compile status: UpToDate | UpToDateWithWarnings | Dirty | Error | Unknown */
+	UPROPERTY(BlueprintReadWrite, Category = "Blueprint")
+	FString CompileStatus;
+
+	/** Titles of entry-point nodes (events, custom events, function entry) with their node ids: "Title|NodeId" */
+	UPROPERTY(BlueprintReadWrite, Category = "Blueprint")
+	TArray<FString> EntryPoints;
+
+	/** Node class histogram, most frequent first: "K2Node_CallFunction x12" */
+	UPROPERTY(BlueprintReadWrite, Category = "Blueprint")
+	TArray<FString> NodeTypeCounts;
+};
+
+/**
  * Detailed information about a blueprint variable (for get_info action)
  */
 USTRUCT(BlueprintType)
@@ -1824,19 +1863,56 @@ public:
 	/**
 	 * Get all nodes in a graph.
 	 *
+	 * On large graphs the full dump is expensive — prefer get_graph_summary first,
+	 * then narrow this call with the optional filters.
+	 *
 	 * @param BlueprintPath - Full path to the blueprint
 	 * @param GraphName - Name of the graph
+	 * @param MaxNodes - Cap on returned nodes; 0 = unlimited (default)
+	 * @param NameFilter - Case-insensitive substring match against node title,
+	 *                     node type, or node id; empty = all nodes
+	 * @param bIncludePins - False drops the pins/pin_names arrays (the bulk of the
+	 *                       payload) leaving id/type/title/position per node
 	 * @return Array of node information
 	 *
 	 * Example:
 	 *   nodes = unreal.BlueprintService.get_nodes_in_graph("/Game/BP_Player", "ApplyDamage")
 	 *   for node in nodes:
 	 *       print(f"{node.node_title} at ({node.pos_x}, {node.pos_y})")
+	 *
+	 * Example - terse read of just the SpawnActor nodes, no pin data:
+	 *   nodes = unreal.BlueprintService.get_nodes_in_graph("/Game/BP_Player", "EventGraph", 25, "SpawnActor", False)
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Blueprints")
 	static TArray<FBlueprintNodeInfo> GetNodesInGraph(
 		const FString& BlueprintPath,
-		const FString& GraphName
+		const FString& GraphName,
+		int32 MaxNodes = 0,
+		const FString& NameFilter = TEXT(""),
+		bool bIncludePins = true
+	);
+
+	/**
+	 * Get a fixed-size overview of a graph: node/connection counts, blueprint
+	 * compile status, entry points, and a node-class histogram. Use this as the
+	 * default first read on any graph — its payload does not grow with graph
+	 * size, unlike get_nodes_in_graph.
+	 *
+	 * @param BlueprintPath - Full path to the blueprint
+	 * @param GraphName - Name of the graph
+	 * @param OutSummary - Filled with the summary on success
+	 * @return True if the blueprint and graph were found
+	 *
+	 * Example:
+	 *   s = unreal.BlueprintService.get_graph_summary("/Game/BP_Player", "EventGraph")
+	 *   if s[0]:
+	 *       print(s[1].node_count, s[1].compile_status, s[1].entry_points)
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Blueprints")
+	static bool GetGraphSummary(
+		const FString& BlueprintPath,
+		const FString& GraphName,
+		FBlueprintGraphSummary& OutSummary
 	);
 
 	/**
@@ -1917,6 +1993,38 @@ public:
 		const FString& BlueprintPath,
 		const FString& GraphName,
 		const FString& EventName,
+		float PosX = 0.0f,
+		float PosY = 0.0f
+	);
+
+	/**
+	 * Create a component-bound event node (e.g. "On Clicked (MyButton)") — the same
+	 * node the Designer's green "+" next to an event creates. This is the ONLY
+	 * path that produces a runtime-live bound event: it initializes the delegate
+	 * binding params (including the auto-generated handler function name) that the
+	 * compiler needs to register the handler. Building the node manually via
+	 * create_node_by_key + configure_node compiles clean but never fires.
+	 *
+	 * If a bound event for this component+delegate already exists in the blueprint,
+	 * its node ID is returned instead of creating a duplicate.
+	 *
+	 * @param BlueprintPath - Full path to the blueprint (widget or actor)
+	 * @param GraphName - Name of the event graph (typically "EventGraph"; must be an ubergraph)
+	 * @param ComponentName - Variable name of the component (e.g. "MyButton")
+	 * @param DelegateName - Delegate property name on the component class (e.g. "OnClicked", "OnComponentBeginOverlap")
+	 * @param PosX - X position in the graph
+	 * @param PosY - Y position in the graph
+	 * @return Node ID (GUID) if successful, empty string otherwise
+	 *
+	 * Example:
+	 *   node_id = unreal.BlueprintService.create_component_bound_event("/Game/UI/WBP_Menu", "EventGraph", "MyButton", "OnClicked", 100, 100)
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Blueprints")
+	static FString CreateComponentBoundEvent(
+		const FString& BlueprintPath,
+		const FString& GraphName,
+		const FString& ComponentName,
+		const FString& DelegateName,
 		float PosX = 0.0f,
 		float PosY = 0.0f
 	);

--- a/Source/VibeUE/Public/PythonAPI/ULandscapeService.h
+++ b/Source/VibeUE/Public/PythonAPI/ULandscapeService.h
@@ -725,6 +725,12 @@ public:
 	 * @param ComponentCountX - Number of components in X direction
 	 * @param ComponentCountY - Number of components in Y direction
 	 * @param LandscapeLabel - Optional display label
+	 * @param WorldPartitionGridSize - 0 (default) keeps the single monolithic
+	 *        ALandscape. In a World Partition level, pass a grid size in components
+	 *        (e.g. 2) to split the landscape into ALandscapeStreamingProxy actors —
+	 *        the same as the editor's New Landscape tool in a WP world. Fails with
+	 *        an error if the current level is not World Partition. Heightmap import
+	 *        and all edit operations work across the proxies transparently.
 	 * @return Create result with actor label
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category ="VibeUE|Landscape")
@@ -736,7 +742,8 @@ public:
 		int32 QuadsPerSection = 63,
 		int32 ComponentCountX = 8,
 		int32 ComponentCountY = 8,
-		const FString& LandscapeLabel = TEXT(""));
+		const FString& LandscapeLabel = TEXT(""),
+		int32 WorldPartitionGridSize = 0);
 
 	/**
 	 * Delete a landscape from the level.
@@ -798,10 +805,14 @@ public:
 	static FHeightmapDimensions GetHeightmapDimensions(const FString& FilePath);
 
 	/**
-	 * Resize a heightmap file to a target resolution using bilinear interpolation.
+	 * Resize a heightmap file to a target resolution.
 	 *
 	 * Reads a 16-bit grayscale PNG heightmap, resamples it to the target dimensions,
 	 * and saves the result. Use this to match a heightmap to a landscape's resolution.
+	 *
+	 * Default interpolation is bicubic (Catmull-Rom): upsampling a low-res DEM with
+	 * bilinear produces piecewise-planar facets that read as "blocky" terraces on
+	 * flat plains; bicubic is C1-continuous so normals stay smooth.
 	 *
 	 * Workflow: generate_heightmap → GetHeightmapDimensions → ResizeHeightmap → ImportHeightmap
 	 *
@@ -809,6 +820,7 @@ public:
 	 * @param TargetWidth - Desired output width in pixels (must match landscape resolution_x)
 	 * @param TargetHeight - Desired output height in pixels (must match landscape resolution_y)
 	 * @param OutputPath - Absolute path for the resized output file. If empty, appends "_resized" to source filename
+	 * @param Interpolation - "bicubic" (default, smooth) or "bilinear" (legacy, faster)
 	 * @return Result with success status, dimensions, output file path
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category ="VibeUE|Landscape")
@@ -816,7 +828,8 @@ public:
 		const FString& SourcePath,
 		int32 TargetWidth,
 		int32 TargetHeight,
-		const FString& OutputPath = TEXT(""));
+		const FString& OutputPath = TEXT(""),
+		const FString& Interpolation = TEXT("bicubic"));
 
 	/**
 	 * Calculate the vertex resolution a landscape will have for given configuration parameters.

--- a/Source/VibeUE/Public/PythonAPI/UMetaSoundService.h
+++ b/Source/VibeUE/Public/PythonAPI/UMetaSoundService.h
@@ -414,8 +414,8 @@ private:
 	/** Load asset and begin a builder session. Returns nullptr and sets OutError on failure. */
 	static UMetaSoundBuilderBase* BeginEditing(const FString& AssetPath, UMetaSoundSource** OutSource, FString& OutError);
 
-	/** Register the graph and save the asset to disk. */
-	static void CommitEditing(const FString& AssetPath, UMetaSoundSource* Source);
+	/** Register the graph and save the asset to disk. Returns false if the save failed. */
+	static bool CommitEditing(const FString& AssetPath, UMetaSoundSource* Source);
 
 	/** Parse a GUID string, populating OutResult.Message on failure. */
 	static bool ParseNodeGuid(const FString& NodeIdStr, FGuid& OutGuid, FMetaSoundResult& OutResult);

--- a/Source/VibeUE/Public/PythonAPI/UNiagaraEmitterService.h
+++ b/Source/VibeUE/Public/PythonAPI/UNiagaraEmitterService.h
@@ -159,6 +159,28 @@ public:
 		float Alpha = 1.0f);
 
 	/**
+	 * Set an emitter's simulation target (CPU vs GPU compute).
+	 *
+	 * GPU-only data interfaces (Grid2DCollection, Grid3DCollection, RenderTarget2D, ...)
+	 * make a CPU emitter's system invalid at compile time — switch the emitter to
+	 * "GPU" before wiring them. The system is recompiled after the change; on compile
+	 * errors check NiagaraScratchPadService.get_compile_messages.
+	 *
+	 * @param SystemPath - Full path to the Niagara system
+	 * @param EmitterName - Name of the emitter
+	 * @param SimTarget - "CPU"/"CPUSim" or "GPU"/"GPUComputeSim"
+	 * @return True if the target was set (or already matched) and the recompile ran
+	 *
+	 * Example:
+	 *   unreal.NiagaraEmitterService.set_sim_target("/Game/VFX/NS_TrackPainter", "Painter", "GPU")
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|NiagaraEmitter", meta = (AICallable, DisplayName = "Set Sim Target"))
+	static bool SetSimTarget(
+		const FString& SystemPath,
+		const FString& EmitterName,
+		const FString& SimTarget);
+
+	/**
 	 * Get the color curve keyframes from a ColorFromCurve module.
 	 *
 	 * Returns an array of keyframes, each containing time and RGBA values.

--- a/Source/VibeUE/Public/PythonAPI/UNiagaraScratchPadService.h
+++ b/Source/VibeUE/Public/PythonAPI/UNiagaraScratchPadService.h
@@ -467,13 +467,37 @@ public:
 	 * Finalize scratch-pad edits: refresh every stack module that references a scratch script, rebuild the
 	 * system's emitter compiled nodes, recompile, and save. Call this once after a batch of graph edits.
 	 *
-	 * @return True if recompilation succeeded with no errors
+	 * Before compiling, the scratch graphs are validated (e.g. duplicate same-named pins on Map Get/Set
+	 * nodes, which would fire a fatal engine assert inside RequestCompile) — a corrupt graph fails fast
+	 * with a clear error instead of crashing the editor. On compile errors, the real per-script Niagara
+	 * compiler messages are logged and False is returned; fetch them with get_compile_messages.
+	 *
+	 * @return True if validation and recompilation succeeded with no errors
 	 *
 	 * Example:
 	 *   ok = unreal.NiagaraScratchPadService.apply_changes("/Game/VFX/NS_Fx")
+	 *   if not ok:
+	 *       print(unreal.NiagaraScratchPadService.get_compile_messages("/Game/VFX/NS_Fx"))
 	 */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|NiagaraScratch", meta = (AICallable, DisplayName = "Apply Scratch Changes"))
 	static bool ApplyChanges(const FString& SystemPath);
+
+	/**
+	 * Get the real Niagara compiler diagnostics from the system's last compile — one line per issue,
+	 * formatted "Severity: [Script] Message". Replaces the useless catch-all "System is invalid after
+	 * compilation": walks every script in the system (system spawn/update + each emitter's scripts) and
+	 * reads its last compile status, error summary, and per-node compile events.
+	 *
+	 * @param SystemPath - Full path to the Niagara System asset
+	 * @param bErrorsOnly - True (default) returns only errors; False includes warnings
+	 * @return One formatted line per diagnostic; empty if the last compile was clean
+	 *
+	 * Example:
+	 *   for line in unreal.NiagaraScratchPadService.get_compile_messages("/Game/VFX/NS_Fx"):
+	 *       print(line)
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|NiagaraScratch", meta = (AICallable, DisplayName = "Get Compile Messages"))
+	static TArray<FString> GetCompileMessages(const FString& SystemPath, bool bErrorsOnly = true);
 
 	// (All internal helpers are file-static in UNiagaraScratchPadService.cpp.)
 };

--- a/test_prompts/blueprint/blueprint_tests.md
+++ b/test_prompts/blueprint/blueprint_tests.md
@@ -70,6 +70,14 @@ Try a shorter summary with just 50 nodes max.
 
 ---
 
+Give me a one-screen overview of TestActor's event graph — node count, connection count, compile status, entry points, and which node types dominate — without dumping every node. (Expected: a single get_graph_summary call, NOT a full get_nodes_in_graph dump.)
+
+---
+
+List only the SpawnActor-related nodes in the event graph, without pin details. (Expected: get_nodes_in_graph with name_filter="SpawnActor" and include_pins=False — the reply should not contain a full-graph dump.)
+
+---
+
 ## More Configuration
 
 Set the initial lifespan on TestActor.
@@ -87,6 +95,26 @@ Recompile TestActor.
 ---
 
 Check the state to make sure it compiled cleanly.
+
+---
+
+## Graph Layout (Set Timer regression — issue #354)
+
+In TestActor's event graph, build this: BeginPlay → Set Timer by Function Name (looping, 2s) calling a custom event named OnTimerTick, and give OnTimerTick a body of 6+ nodes (e.g. increment a counter, branch on it, two print strings). Then auto-align the whole graph.
+
+---
+
+Screenshot the graph and confirm: BeginPlay's chain is ABOVE the OnTimerTick chain (the custom event must not be laid out above the primary event), no overlapping nodes.
+
+---
+
+## Bound Events (issue #386)
+
+Create a widget blueprint WBP_BoundEventTest with a Button variable named TestButton. Add an On Clicked bound event for TestButton wired to a Print String saying "clicked". (Expected: create_component_bound_event, NOT create_node_by_key + configure_node.)
+
+---
+
+Compile, run PIE, click the button, and confirm the print fires. Then ask for the bound event again — it must reuse the existing node, not create a duplicate.
 
 ---
 


### PR DESCRIPTION
Overnight pass through the open issue backlog. Ten issues fixed across five commits; everything passed a -StrictRebuild (warnings-as-errors, zero warnings) on UE 5.8 and was verified live in the editor where noted.

## Fixed

- **#386** — `create_component_bound_event()`: spawns a runtime-live `K2Node_ComponentBoundEvent` via the Designer's `InitializeComponentBoundEventParams` path (generates `CustomFunctionName`); idempotent per component+delegate. `configure_node` now returns `False` when `ImportText` rejects the value. *Verified: bound On Clicked on a test widget, correct title, clean compile, idempotent; bad struct value returns False.*
- **#371** — `set_root_component` persists. Root cause: `SetParent()` on same-SCS children wrote `ParentComponentOrVariableName` = own parent's name — exactly the state the engine's load/cook hierarchy fixup flags as "possible cyclic linkage" (the field is only for inherited parents). Same-SCS attachment now uses `ChildNodes` only, linkage fields cleared, `ValidateSceneRootNodes()` before the structural mark, result read back. *Verified through compile + save + full package reload.*
- **#484** — `get_graph_summary()` (fixed-size overview: counts, compile status, entry points, node-type histogram) + optional `max_nodes`/`name_filter`/`include_pins` on `get_nodes_in_graph`. Skill doc + test prompts updated to make the summary the default first read. *Verified all modes.*
- **#354** — Set Timer layout: component band ranking gains a primary-event key (BeginPlay/Tick/input outrank custom-event-only components regardless of node count); DFS seeds primary events first. All other ranking keys untouched to avoid the regressions of the three prior attempts. *Verified on the exact failing shape: BeginPlay band above a larger timer-callback body.*
- **#394** — `create_landscape(..., world_partition_grid_size=N)` splits into `LandscapeStreamingProxy` actors via `ULandscapeSubsystem::ChangeGridSize`; clear error in non-WP levels instead of a silent no-op. Edit/import paths were already proxy-aware. *Verified: 68 proxies generated in a WP test level.*
- **#393** — `resize_heightmap` defaults to Catmull-Rom bicubic (bilinear DEM upsampling caused the planar facets on flat plains); `"bilinear"` still available. Landscape skill gains a "blocky flat areas" recovery section. *Verified functionally.*
- **#399** — Python crash recovery: after an SEH-caught fault, a no-op probe runs through the same wrapper; a clean probe proves the interpreter survived (fault was in engine C++, the common case) and the session recovers instead of latching dead until restart.
- **#432** — Niagara: `get_compile_messages()` surfaces real per-script translator diagnostics (status, `ErrorMsg`, `LastCompileEvents` with node guids) replacing the catch-all "System is invalid after compilation"; `apply_changes` pre-validates scratch graphs (duplicate same-named Map Get/Set pins now refuse with a named error instead of the fatal `ReallocatePins` assert) and returns `False` on compile errors; new `NiagaraEmitterService.set_sim_target(system, emitter, "CPU"|"GPU")`.
- **#349** — the screenshot shows duplicated override events (second Event Tick → compile errors → "nodes not connected"). `create_node_by_key` EVENT keys are now idempotent: existing override/custom events return the existing node id. *Verified both paths.*
- **#352** — silent-failure sweep: 24 sites across 14 services stopped reporting success on rejected parses (`Atoi("abc")`→0, unresolved enum names→index 0, discarded `ImportText`) or ignored `SaveAsset`/`SavePackage` results.

## Partially addressed

- **#427** — the event-anchoring piece landed with #354 and a layout regression test prompt was added; the larger asks (crossing-reduction upgrades, branch lanes, size-aware spacing, comment boxes, model-supplied layout hints) remain open.

Fixes #386, fixes #371, fixes #484, fixes #354, fixes #394, fixes #393, fixes #399, fixes #432, fixes #349, fixes #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)