### PR TITLE
LandscapeService: persist AddLayer into the proxy's TargetLayers (paint layers vanished on map reload)

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/ULandscapeService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/ULandscapeService.cpp
@@ -2172,6 +2172,9 @@ TArray<FLandscapeLayerInfo_Custom> ULandscapeService::ListLayers(const FString& 
 	return Result;
 }
 
+// Defined later in this file (near the paint functions).
+static ULandscapeLayerInfoObject* FindLayerInfoByName(ULandscapeInfo* Info, const FString& LayerName);
+
 bool ULandscapeService::AddLayer(
 	const FString& LandscapeNameOrLabel,
 	const FString& LayerInfoAssetPath)
@@ -2206,10 +2209,24 @@ bool ULandscapeService::AddLayer(
 
 	FScopedTransaction Transaction(NSLOCTEXT("LandscapeService", "AddLayer", "Add Landscape Layer"));
 
-	// Add layer info to landscape
-	int32 LayerIndex = Info->Layers.Num();
-	FLandscapeInfoLayerSettings NewLayerSettings(LayerInfoObj, Landscape);
-	Info->Layers.Add(NewLayerSettings);
+	// Register in the PERSISTENT per-proxy target-layer list FIRST. ULandscapeInfo is a
+	// transient object rebuilt from the proxies' TargetLayers on every map load — writing
+	// only Info->Layers (the old behaviour) meant the layer (and all painted weights for it)
+	// silently vanished on save/reload.
+	const FName LayerFName = LayerInfoObj->GetLayerName();
+	if (!Landscape->HasTargetLayer(LayerFName))
+	{
+		Landscape->Modify();
+		Landscape->AddTargetLayer(LayerFName, FLandscapeTargetLayerSettings(LayerInfoObj));
+	}
+
+	// Keep the transient LandscapeInfo in sync for this session (AddTargetLayer's
+	// PostEditChange may already have refreshed it — guard against a duplicate entry).
+	if (!FindLayerInfoByName(Info, LayerFName.ToString()))
+	{
+		FLandscapeInfoLayerSettings NewLayerSettings(LayerInfoObj, Landscape);
+		Info->Layers.Add(NewLayerSettings);
+	}
 
 	// Update the component layer allowlist
 	Info->UpdateComponentLayerAllowList();


### PR DESCRIPTION
## Problem

`LandscapeService.AddLayer` only writes the new layer into `ULandscapeInfo->Layers`. That object is **transient** — it's rebuilt from the proxies' `TargetLayers` on every map load — so the added layer, and **every weight painted into it**, silently vanishes on save/reload.

The loss is easy to miss: the editor viewport masks it via the material's `preview_weight` fallback, so everything looks fine until you PIE — where the landscape renders **black** (weight-blend all-zero everywhere).

Quick check for the broken state: `land.get_editor_property("target_layers")` is missing the layer immediately after `add_layer`, and painted weights are gone after save + reload.

## Fix

Register the layer in the persistent `ALandscapeProxy::TargetLayers` first (`AddTargetLayer`, guarded by `HasTargetLayer`), then keep the transient `LandscapeInfo` in sync for the current session — guarded against a duplicate entry, since `AddTargetLayer`'s `PostEditChange` may already have refreshed it.

## Verification

Running in production use since 2026-07-04: `add_layer` → paint → save → `load_level` → `get_layer_weights_at_location` round-trips correctly, and PIE renders the painted layers. Same theme as the recent silent-failure sweep (#352) — a success result for an operation that doesn't survive a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
