### PR TITLE
Add Hermes as a GenerateAgentConfig client target

### DIFF
--- a/FAB_Tech_Details.md
+++ b/FAB_Tech_Details.md
@@ -10,7 +10,7 @@ Prerequisites — enable Unreal's native MCP stack and start the MCP server, the
 Dependencies — VibeUE declares and auto-enables every engine plugin it needs: PythonScriptPlugin, EditorScriptingUtilities, EnhancedInput, Niagara, MeshModelingToolset, ModelViewViewModel, StateTree, MetaSound, GameplayTagsEditor, ToolsetRegistry, and ModelContextProtocol.
 
 
-Setup -  run console command VibeUE.GenerateAgentConfig [ClaudeCode|Gemini|Codex|Cursor|Copilot|All] to write the agent guide to the matching project file (CLAUDE.md, GEMINI.md, AGENTS.md, .github/copilot-instructions.md). 
+Setup -  run console command VibeUE.GenerateAgentConfig [ClaudeCode|Gemini|Codex|Hermes|Cursor|Copilot|All] to write the agent guide to the matching project file (CLAUDE.md, GEMINI.md, AGENTS.md, .github/copilot-instructions.md).
 
 
 A free API  key (vibeue.com/login), set in Editor Preferences → Plugins → VibeUE, unlocks the real-world terrain tools; every other feature works without it.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ ModelContextProtocol.GenerateClientConfig ClaudeCode
 VibeUE.GenerateAgentConfig ClaudeCode
 ```
 This writes the guide to the correct file for your agent — `CLAUDE.md` (Claude Code), `GEMINI.md`
-(Gemini), `AGENTS.md` (Codex / Cursor), or `.github/copilot-instructions.md` (Copilot) — or pass
+(Gemini), `AGENTS.md` (Codex / Hermes / Cursor), or `.github/copilot-instructions.md` (Copilot) — or pass
 `All` to write CLAUDE.md + GEMINI.md + AGENTS.md at once. It resolves the plugin location
 automatically, so it works whether VibeUE was installed from **FAB** or **Git**. The guide goes in a
 managed block, so re-run any time to refresh without disturbing your own notes. Pass `import` to link

--- a/Source/VibeUE/Private/Module.cpp
+++ b/Source/VibeUE/Private/Module.cpp
@@ -122,7 +122,7 @@ static FAutoConsoleCommandWithArgsAndOutputDevice TestToolCommand(
 // path is the whole reason this command exists.
 //
 // Each agent expects a different memory file, and only Claude Code (CLAUDE.md) and Gemini
-// CLI (GEMINI.md) resolve `@path` imports — Codex (AGENTS.md), Cursor (AGENTS.md) and
+// CLI (GEMINI.md) resolve `@path` imports — Codex/Hermes (AGENTS.md), Cursor (AGENTS.md) and
 // Copilot do not. So the default COPIES the guide in (universal); pass "import" to instead
 // write a one-line `@<resolved sample path>` for the two agents that support it (others
 // fall back to copy). Copilot also reads AGENTS.md/CLAUDE.md/GEMINI.md, so "All" covers it.
@@ -173,7 +173,7 @@ static void GenerateVibeUEAgentConfig(const TArray<FString>& Args, FOutputDevice
 	{
 		Targets.Add(TPair<FString, bool>(TEXT(".github/copilot-instructions.md"), false));
 	}
-	else if (Client == TEXT("codex") || Client == TEXT("cursor") || Client == TEXT("agents") || Client == TEXT("agent"))
+	else if (Client == TEXT("codex") || Client == TEXT("hermes") || Client == TEXT("cursor") || Client == TEXT("agents") || Client == TEXT("agent"))
 	{
 		Targets.Add(TPair<FString, bool>(TEXT("AGENTS.md"), false));
 	}
@@ -181,11 +181,11 @@ static void GenerateVibeUEAgentConfig(const TArray<FString>& Args, FOutputDevice
 	{
 		Targets.Add(TPair<FString, bool>(TEXT("CLAUDE.md"), true));   // Claude Code
 		Targets.Add(TPair<FString, bool>(TEXT("GEMINI.md"), true));   // Gemini CLI
-		Targets.Add(TPair<FString, bool>(TEXT("AGENTS.md"), false));  // Codex, Cursor (and Copilot reads it too)
+		Targets.Add(TPair<FString, bool>(TEXT("AGENTS.md"), false));  // Codex, Hermes, Cursor (and Copilot reads it too)
 	}
 	else
 	{
-		Ar.Logf(TEXT("VibeUE.GenerateAgentConfig: unknown client '%s'. Use: ClaudeCode | Gemini | Codex | Cursor | Copilot | All."), *Client);
+		Ar.Logf(TEXT("VibeUE.GenerateAgentConfig: unknown client '%s'. Use: ClaudeCode | Gemini | Codex | Hermes | Cursor | Copilot | All."), *Client);
 		return;
 	}
 
@@ -279,14 +279,15 @@ static void GenerateVibeUEAgentConfig(const TArray<FString>& Args, FOutputDevice
 		}
 	}
 
+	const FString McpConfigClient = (Client == TEXT("hermes")) ? TEXT("Codex") : ((Args.Num() > 0) ? Args[0] : TEXT("All"));
 	Ar.Logf(TEXT("VibeUE.GenerateAgentConfig: done (source: %s). Tip: also run 'ModelContextProtocol.GenerateClientConfig %s' to write .mcp.json."),
-		*SamplePath, (Args.Num() > 0) ? *Args[0] : TEXT("All"));
+		*SamplePath, *McpConfigClient);
 }
 
 static FAutoConsoleCommandWithArgsAndOutputDevice GenerateAgentConfigCommand(
 	TEXT("VibeUE.GenerateAgentConfig"),
 	TEXT("Write the VibeUE agent guide to the project root from the bundled sample. ")
-	TEXT("Usage: VibeUE.GenerateAgentConfig [ClaudeCode|Gemini|Codex|Cursor|Copilot|All] [import]. ")
+	TEXT("Usage: VibeUE.GenerateAgentConfig [ClaudeCode|Gemini|Codex|Hermes|Cursor|Copilot|All] [import]. ")
 	TEXT("Default All -> CLAUDE.md + GEMINI.md + AGENTS.md. 'import' writes a one-line @import for Claude/Gemini (others copy)."),
 	FConsoleCommandWithArgsAndOutputDeviceDelegate::CreateStatic(GenerateVibeUEAgentConfig)
 );


### PR DESCRIPTION
Adds `Hermes` to `VibeUE.GenerateAgentConfig` — Hermes reads `AGENTS.md` like Codex/Cursor, so it routes to the same target file. The follow-up `.mcp.json` tip maps `hermes → Codex` for `ModelContextProtocol.GenerateClientConfig`, which has no Hermes option. README + FAB_Tech_Details updated to list the new client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)