### PR TITLE
BlueprintService: restore typed member-variable creation (AddMemberVariable)

### DIFF
--- a/Content/Skills/asset-management/SKILL.md
+++ b/Content/Skills/asset-management/SKILL.md
@@ -218,9 +218,17 @@ unreal.EditorAssetLibrary.rename_asset(
 
 ### Creating Widget Blueprints
 
-`unreal.BlueprintService.create_blueprint(name, "UserWidget", path)` creates a proper
-`WidgetBlueprint` (it detects UserWidget-derived parents and uses the UMG factory). For designing
-the widget afterwards (hierarchy, slots, bindings), load the **umg-widgets** skill.
+Use the engine's `WidgetBlueprintFactory` — a plain `BlueprintFactory` with a UserWidget
+parent creates a regular Blueprint, not a `WidgetBlueprint` (the removed
+`BlueprintService.create_blueprint` used to pick the UMG factory automatically):
+
+```python
+factory = unreal.WidgetBlueprintFactory()
+factory.set_editor_property("ParentClass", unreal.UserWidget)
+wbp = unreal.AssetToolsHelpers.get_asset_tools().create_asset("WBP_Menu", "/Game/UI", None, factory)
+```
+
+For designing the widget afterwards (hierarchy, slots, bindings), load the **umg-widgets** skill.
 
 ---
 

--- a/Content/Skills/blueprint-graphs/build-graph.md
+++ b/Content/Skills/blueprint-graphs/build-graph.md
@@ -107,6 +107,21 @@ if result.errors:
         print(f"  ERROR: {e}")
 ```
 
+### ⚠️ Hard-won gotchas (live-verified 2026-07-03)
+
+- **`make_struct` needs the FULL struct path for engine structs** — `"FStateTreeEvent"` and
+  `"StateTreeEvent"` both fail with "Struct type not found"; `"/Script/StateTreeModule.StateTreeEvent"`
+  works. Short names only resolve for user-defined structs.
+- **`build_graph` returns `None` on ANY partial failure** (e.g. 2/3 nodes created) — it does NOT
+  return a result with per-item errors. Check the editor log (`LogTemp: BuildGraph: ...`) for which
+  node/connection/default failed, then repair incrementally with `get_nodes_in_graph` +
+  `connect_nodes` + `set_node_pin_value`.
+- **Pin defaults on existing nodes**: use `set_node_pin_value(bp, graph, node_id, pin, value)` —
+  struct pins accept serialized text, e.g. a GameplayTag pin takes `(TagName="My.Tag")`.
+- The engine `BlueprintTools.compile_blueprint` tool (via `call_tool`) requires the FULL object
+  path (`/Game/X/BP_Foo.BP_Foo`); from Python prefer
+  `unreal.BlueprintEditorLibrary.compile_blueprint(loaded_bp)`.
+
 ### Example: Branch with Math
 
 ```python

--- a/Content/Skills/state-trees/api-bindings.md
+++ b/Content/Skills/state-trees/api-bindings.md
@@ -204,12 +204,15 @@ st_path = "/Game/StateTree/ST_Cube"
 state_path = "Root/Rotating"
 transition_index = 0  # from get_state_tree_info
 
-# Step 1: Add a FStateTreeDelegateDispatcher variable to the Blueprint task
-if not unreal.BlueprintService.variable_exists(bp_path, "FinishRotatingDispatcher"):
-    result = unreal.BlueprintService.add_variable(bp_path, "FinishRotatingDispatcher", "FStateTreeDelegateDispatcher")
-    assert result, "Failed to add FinishRotatingDispatcher variable"
-    unreal.BlueprintService.compile_blueprint(bp_path)
-    unreal.EditorAssetLibrary.save_asset(bp_path)
+# Step 1: The task Blueprint needs a FStateTreeDelegateDispatcher member variable.
+# ⚠️ KNOWN GAP: there is currently no scripted way to CREATE one — BlueprintService.add_variable
+# was removed in the Epic-overlap consolidation, the engine BlueprintTools.add_variable only
+# supports basic types (bool/int/float/.../Vector/Rotator/Transform), and the Python safety
+# layer blocks constructing the EdGraphPinType that BlueprintEditorLibrary.add_member_variable
+# needs for struct types. Until member-variable creation is restored, the dispatcher variable
+# must already exist on the task (added by a human in the editor, or baked into the task class).
+assert unreal.BlueprintService.variable_exists(bp_path, "FinishRotatingDispatcher"), \
+    "Task has no FinishRotatingDispatcher variable — see the known gap above"
 
 # Step 2: Set the transition trigger to OnDelegate
 result = unreal.StateTreeService.update_transition(st_path, state_path, transition_index, trigger="OnDelegate")
@@ -240,7 +243,7 @@ In `STT_Rotate`'s Blueprint graph, call the dispatcher to trigger the transition
 
 #### Notes
 
-- `FStateTreeDelegateDispatcher` is a USTRUCT — use type string `"FStateTreeDelegateDispatcher"` with `add_variable`.
+- `FStateTreeDelegateDispatcher` is a USTRUCT member variable on the task — see the known gap in Step 1: no scripted door currently creates struct-typed member variables.
 - The dispatcher variable must be on the task that is **in the same state** as the `OnDelegate` transition.
 - After `bind_transition_to_delegate`, the compile error about the missing binding will resolve.
 
@@ -379,7 +382,7 @@ unreal.BlueprintService.set_component_property(bp_path, "StateTree", "StateTree"
 
 # CORRECT — sets the FStateTreeReference struct that the editor reads
 unreal.BlueprintService.set_component_property(bp_path, "StateTree", "StateTreeRef", st_path)
-unreal.BlueprintService.compile_blueprint(bp_path)
+unreal.BlueprintEditorLibrary.compile_blueprint(unreal.EditorAssetLibrary.load_asset(bp_path))
 unreal.EditorAssetLibrary.save_asset(bp_path)
 ```
 

--- a/Content/Skills/state-trees/api-bindings.md
+++ b/Content/Skills/state-trees/api-bindings.md
@@ -204,15 +204,14 @@ st_path = "/Game/StateTree/ST_Cube"
 state_path = "Root/Rotating"
 transition_index = 0  # from get_state_tree_info
 
-# Step 1: The task Blueprint needs a FStateTreeDelegateDispatcher member variable.
-# ⚠️ KNOWN GAP: there is currently no scripted way to CREATE one — BlueprintService.add_variable
-# was removed in the Epic-overlap consolidation, the engine BlueprintTools.add_variable only
-# supports basic types (bool/int/float/.../Vector/Rotator/Transform), and the Python safety
-# layer blocks constructing the EdGraphPinType that BlueprintEditorLibrary.add_member_variable
-# needs for struct types. Until member-variable creation is restored, the dispatcher variable
-# must already exist on the task (added by a human in the editor, or baked into the task class).
-assert unreal.BlueprintService.variable_exists(bp_path, "FinishRotatingDispatcher"), \
-    "Task has no FinishRotatingDispatcher variable — see the known gap above"
+# Step 1: Add the FStateTreeDelegateDispatcher member variable the binding needs.
+# add_member_variable is the struct/object/enum-capable door (the engine's
+# BlueprintTools.add_variable covers basic types only).
+if not unreal.BlueprintService.variable_exists(bp_path, "FinishRotatingDispatcher"):
+    result = unreal.BlueprintService.add_member_variable(bp_path, "FinishRotatingDispatcher", "FStateTreeDelegateDispatcher")
+    assert result, "add_member_variable failed — check the type string"
+    unreal.BlueprintEditorLibrary.compile_blueprint(unreal.EditorAssetLibrary.load_asset(bp_path))
+    unreal.EditorAssetLibrary.save_asset(bp_path)
 
 # Step 2: Set the transition trigger to OnDelegate
 result = unreal.StateTreeService.update_transition(st_path, state_path, transition_index, trigger="OnDelegate")
@@ -243,7 +242,8 @@ In `STT_Rotate`'s Blueprint graph, call the dispatcher to trigger the transition
 
 #### Notes
 
-- `FStateTreeDelegateDispatcher` is a USTRUCT member variable on the task — see the known gap in Step 1: no scripted door currently creates struct-typed member variables.
+- `FStateTreeDelegateDispatcher` is a USTRUCT — use type string `"FStateTreeDelegateDispatcher"` with `add_member_variable`.
+- `bind_transition_to_delegate` matches the task by its **registered class name** (`STT_Rotate_C`) — the Blueprint asset path that `add_task` accepts is NOT accepted here (live-verified).
 - The dispatcher variable must be on the task that is **in the same state** as the `OnDelegate` transition.
 - After `bind_transition_to_delegate`, the compile error about the missing binding will resolve.
 

--- a/Content/Skills/state-trees/blueprint-tasks.md
+++ b/Content/Skills/state-trees/blueprint-tasks.md
@@ -1,6 +1,6 @@
 ---
 name: blueprint-tasks
-description: Create and edit STT_* StateTree Blueprint Tasks - discover parent class, create_blueprint, ReceiveLatentTick / ReceiveLatentEnterState event functions, registered task type names, and extended FStateTree* info fields
+description: Create and edit STT_* StateTree Blueprint Tasks - discover parent class, create via the engine BlueprintFactory, ReceiveLatentTick / ReceiveLatentEnterState event functions, registered task type names, and extended FStateTree* info fields
 ---
 
 This sub-doc continues from skill.md → "Creating & Editing StateTree Blueprint Tasks".
@@ -16,8 +16,9 @@ edit Blueprint internals:
 - Overriding functions (`GetDescription`, `ReceiveLatentTick`, `ReceiveLatentEnterState`, etc.)
 - Adding nodes or wiring pins in a function graph
 
-**Always discover the exact class name first** — the same discovery pattern works for both
-`create_blueprint` and `reparent_blueprint`.
+**Always discover the exact class name first**, then create with the engine's
+`BlueprintFactory` (`BlueprintService.create_blueprint` was removed in the Epic-overlap
+consolidation — Blueprint creation is engine-side now).
 
 ### Discovery Workflow
 
@@ -27,29 +28,27 @@ result = discover_python_module("unreal", name_filter="StateTreeTask")
 # Review returned names — look for the blueprint-safe base class
 # Typical result: "StateTreeTaskBlueprintBase" (short name used directly below)
 
-# Step 2: Use the exact name from discovery — create_blueprint resolves it via object search
-path = unreal.BlueprintService.create_blueprint(
-    "STT_MyTask",               # blueprint name
-    "StateTreeTaskBlueprintBase",  # exact name from Step 1
-    "/Game/StateTree"           # destination folder
-)
-assert path, "create_blueprint returned empty — class name not found or plugin not loaded"
-print(f"Created: {path}")
+# Step 2: Create with the engine BlueprintFactory, ParentClass = the class from Step 1
+factory = unreal.BlueprintFactory()
+factory.set_editor_property("ParentClass", unreal.StateTreeTaskBlueprintBase)
+bp = unreal.AssetToolsHelpers.get_asset_tools().create_asset(
+    "STT_MyTask", "/Game/StateTree", unreal.Blueprint, factory)
+assert bp, "create_asset returned None — folder invalid or an asset with that name already exists"
+print(f"Created: {bp.get_path_name()}")
 ```
 
-The short class name (e.g. `"StateTreeTaskBlueprintBase"`) is resolved via a full object search
-across all loaded modules — the same string works for both `create_blueprint` and `reparent_blueprint`.
-If `create_blueprint` returns an empty string, the class was not found.
+`unreal.<ClassName>` must exist for the discovered short name (it does for any loaded class);
+if Python raises AttributeError, the plugin that defines the class is not loaded.
 
 ### ⚠️ Never Guess the Parent Class — Discover First
 
 ```python
-# WRONG — guessing; creates a plain Actor, not usable as a StateTree task
-unreal.BlueprintService.create_blueprint("STT_MyTask", "Actor", "/Game/StateTree")
+# WRONG — guessing; a plain Actor parent is not usable as a StateTree task
+factory.set_editor_property("ParentClass", unreal.Actor)
 
-# CORRECT — discover exact name, then pass it
+# CORRECT — discover the exact class first, then set it as ParentClass
 # discover_python_module("unreal", name_filter="StateTreeTask") → confirms "StateTreeTaskBlueprintBase"
-unreal.BlueprintService.create_blueprint("STT_MyTask", "StateTreeTaskBlueprintBase", "/Game/StateTree")
+factory.set_editor_property("ParentClass", unreal.StateTreeTaskBlueprintBase)
 ```
 
 ### StateTree Task Blueprint Event Functions
@@ -82,7 +81,7 @@ print(f"Enter node: {enter_id}")
 exit_id = unreal.BlueprintService.add_event_node(bp_path, "EventGraph", "ReceiveExitState", 0, 400)
 print(f"Exit node: {exit_id}")
 
-unreal.BlueprintService.compile_blueprint(bp_path)
+unreal.BlueprintEditorLibrary.compile_blueprint(unreal.EditorAssetLibrary.load_asset(bp_path))
 unreal.EditorAssetLibrary.save_asset(bp_path)
 ```
 

--- a/Content/Skills/state-trees/event-payloads.md
+++ b/Content/Skills/state-trees/event-payloads.md
@@ -72,3 +72,16 @@ result = unreal.BlueprintService.build_graph(
   new nodes in between.
 - Not passing the `struct` param to `instanced_struct` — the `Value` pin stays a wildcard and
   connections will fail at compile time.
+
+## Tag-only events, and sending from Python (live-verified 2026-07-03)
+
+- `FGameplayTag` **cannot be constructed from Python** (TagName is read-only; the constructor
+  routes to MakeLiteralGameplayTag which takes a tag, not a name). To send a tagged StateTree
+  event from a script, author a one-shot Blueprint chain instead: custom event ->
+  `make_struct` (`/Script/StateTreeModule.StateTreeEvent`, full path required) -> set the `Tag`
+  pin default to `(TagName="My.Tag")` -> `SendStateTreeEvent` on the StateTree component — then
+  trigger it with `controller_or_actor.call_method("MyCustomEvent")`.
+- An `OnEvent` transition's tag must be a **registered** gameplay tag before
+  `update_transition(..., event_tag=...)` sticks — otherwise the compile keeps failing with
+  "On Event Transition requires at least tag or payload". Register via the engine
+  `GameplayTagsToolset.AddTag` (`tagName`, `tagSource="DefaultGameplayTags.ini"`).

--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -1848,6 +1848,54 @@ bool UBlueprintService::ReparentComponent(
 // VARIABLE MANAGEMENT (Phase 1)
 // ============================================================================
 
+bool UBlueprintService::AddMemberVariable(
+	const FString& BlueprintPath,
+	const FString& VariableName,
+	const FString& VariableType,
+	const FString& DefaultValue,
+	bool bIsArray,
+	const FString& ContainerType)
+{
+	UBlueprint* Blueprint = LoadBlueprint(BlueprintPath);
+	if (!Blueprint)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddMemberVariable: Failed to load blueprint: %s"), *BlueprintPath);
+		return false;
+	}
+
+	for (const FBPVariableDescription& Var : Blueprint->NewVariables)
+	{
+		if (Var.VarName.ToString() == VariableName)
+		{
+			UE_LOG(LogTemp, Warning, TEXT("AddMemberVariable: Variable '%s' already exists in %s"), *VariableName, *BlueprintPath);
+			return false;
+		}
+	}
+
+	FEdGraphPinType PinType;
+	FString ErrorMessage;
+	if (!FBlueprintTypeParser::ParseTypeString(VariableType, PinType, bIsArray, ContainerType, ErrorMessage))
+	{
+		UE_LOG(LogTemp, Error, TEXT("AddMemberVariable: Failed to parse type '%s': %s"), *VariableType, *ErrorMessage);
+		return false;
+	}
+
+	FBPVariableDescription NewVar;
+	NewVar.VarName = FName(*VariableName);
+	NewVar.VarGuid = FGuid::NewGuid();
+	NewVar.VarType = PinType;
+	NewVar.FriendlyName = VariableName;
+	NewVar.Category = FText::FromString(TEXT("Default"));
+	NewVar.DefaultValue = DefaultValue;
+	NewVar.PropertyFlags = CPF_Edit | CPF_BlueprintVisible | CPF_DisableEditOnInstance;
+
+	Blueprint->NewVariables.Add(NewVar);
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
+
+	UE_LOG(LogTemp, Log, TEXT("AddMemberVariable: Added variable '%s' of type '%s' to %s"), *VariableName, *VariableType, *BlueprintPath);
+	return true;
+}
+
 bool UBlueprintService::SetVariableDefaultValue(
 	const FString& BlueprintPath,
 	const FString& VariableName,

--- a/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
+++ b/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
@@ -1508,7 +1508,7 @@ public:
 	 * @param BlueprintPath - Full path to the blueprint
 	 * @param DispatcherName - Name of the event dispatcher
 	 * @param ParameterName - Name of the new parameter
-	 * @param ParameterType - Type string (same format as add_variable)
+	 * @param ParameterType - Type string (same type-string format as add_function_local_variable)
 	 * @param bIsArray - Whether the parameter is an array
 	 * @param ContainerType - Container type: "Array", "Set", "Map", or empty
 	 * @return True if successful
@@ -1590,7 +1590,7 @@ public:
 	 * @param BlueprintPath - Full path to the blueprint
 	 * @param FunctionName - Name of the function
 	 * @param ParameterName - Name of the parameter
-	 * @param ParameterType - Type string (same format as AddVariable)
+	 * @param ParameterType - Type string (same type-string format as add_function_local_variable)
 	 * @param bIsOutput - Whether this is an output parameter
 	 * @param bIsReference - Whether this is passed by reference
 	 * @param DefaultValue - Default value as a string (optional)
@@ -1621,7 +1621,7 @@ public:
 	 * @param BlueprintPath - Full path to the blueprint
 	 * @param FunctionName - Name of the function
 	 * @param VariableName - Name of the local variable
-	 * @param VariableType - Type string (same format as AddVariable)
+	 * @param VariableType - Type string (same type-string format as add_function_local_variable)
 	 * @param DefaultValue - Default value as a string (optional)
 	 * @param bIsArray - Whether this is an array type
 	 * @param ContainerType - Container type: "Array", "Set", "Map", or empty
@@ -2044,7 +2044,7 @@ public:
 	 * @param GraphName - Name of the graph containing the node (e.g. "EventGraph")
 	 * @param NodeId - GUID of the Custom Event node
 	 * @param ParameterName - Name of the new input pin
-	 * @param ParameterType - Type string (same format as add_variable, e.g. "float", "FRotator", "AActor")
+	 * @param ParameterType - Type string (same type-string format as add_function_local_variable, e.g. "float", "FRotator", "AActor")
 	 * @param bIsArray - Whether the parameter is an array
 	 * @param ContainerType - Container type: "Array", "Set", "Map", or empty
 	 * @return True if the pin was added
@@ -2093,7 +2093,7 @@ public:
 	 * @param NodeId - GUID of the Custom Event node
 	 * @param ParameterName - Current name of the input pin to modify
 	 * @param NewName - New name for the pin, or empty to keep the current name
-	 * @param NewType - New type string (same format as add_variable), or empty to keep the current type
+	 * @param NewType - New type string (same type-string format as add_function_local_variable), or empty to keep the current type
 	 * @param bIsArray - Whether the new type is an array (only used when NewType is provided)
 	 * @param ContainerType - Container type for the new type: "Array", "Set", "Map", or empty (only used when NewType is provided)
 	 * @return True if the pin was found and modified
@@ -3102,7 +3102,8 @@ public:
 	 *
 	 * Example:
 	 *   if not unreal.BlueprintService.blueprint_exists("/Game/Blueprints/BP_Enemy"):
-	 *       unreal.BlueprintService.create_blueprint("BP_Enemy", "Actor", "/Game/Blueprints")
+	 *       # Create engine-side: BlueprintFactory (set ParentClass) + AssetTools.create_asset.
+	 *       pass
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Blueprints|Exists")
 	static bool BlueprintExists(const FString& BlueprintPath);
@@ -3116,7 +3117,8 @@ public:
 	 *
 	 * Example:
 	 *   if not unreal.BlueprintService.variable_exists(bp_path, "Health"):
-	 *       unreal.BlueprintService.add_variable(bp_path, "Health", "float")
+	 *       # Add engine-side: BlueprintTools.add_variable via execute_tool (basic types only).
+	 *       pass
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Blueprints|Exists")
 	static bool VariableExists(const FString& BlueprintPath, const FString& VariableName);

--- a/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
+++ b/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
@@ -1392,6 +1392,38 @@ public:
 	// ============================================================================
 
 	/**
+	 * Add a member variable to a blueprint, with full type-string support (struct, object,
+	 * enum, and container types — parsed by the same type parser as function local variables).
+	 *
+	 * This is the Epic-less delta of variable creation: the engine's BlueprintTools.add_variable
+	 * covers BASIC types only (bool/int/float/name/string/text/Vector/Rotator/Transform...).
+	 * Use this method when the variable's type is a struct, object, or enum — e.g. the
+	 * FStateTreeDelegateDispatcher member that bind_transition_to_delegate requires.
+	 *
+	 * @param BlueprintPath - Full path to the blueprint
+	 * @param VariableName - Name for the new variable (fails if it already exists)
+	 * @param VariableType - Type string, e.g. "float", "FVector", "FStateTreeDelegateDispatcher",
+	 *                       "AActor" (same format as add_function_local_variable)
+	 * @param DefaultValue - Optional default value as a string
+	 * @param bIsArray - Make it an array of VariableType
+	 * @param ContainerType - "", "Array", "Set", or "Map" (overrides bIsArray when set)
+	 * @return True if the variable was added
+	 *
+	 * Example:
+	 *   if not unreal.BlueprintService.variable_exists(bp_path, "FinishRotatingDispatcher"):
+	 *       unreal.BlueprintService.add_member_variable(bp_path, "FinishRotatingDispatcher", "FStateTreeDelegateDispatcher")
+	 *       unreal.BlueprintEditorLibrary.compile_blueprint(unreal.EditorAssetLibrary.load_asset(bp_path))
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Blueprints")
+	static bool AddMemberVariable(
+		const FString& BlueprintPath,
+		const FString& VariableName,
+		const FString& VariableType,
+		const FString& DefaultValue = TEXT(""),
+		bool bIsArray = false,
+		const FString& ContainerType = TEXT(""));
+
+	/**
 	 * Set the default value of an existing variable.
 	 *
 	 * @param BlueprintPath - Full path to the blueprint
@@ -3117,8 +3149,7 @@ public:
 	 *
 	 * Example:
 	 *   if not unreal.BlueprintService.variable_exists(bp_path, "Health"):
-	 *       # Add engine-side: BlueprintTools.add_variable via execute_tool (basic types only).
-	 *       pass
+	 *       unreal.BlueprintService.add_member_variable(bp_path, "Health", "float")
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Blueprints|Exists")
 	static bool VariableExists(const FString& BlueprintPath, const FString& VariableName);


### PR DESCRIPTION
**Stacked on #501** — the last commit here is the only new one; review that alone, or merge #501 first and this rebases to a one-commit diff.

## The gap

The Epic-overlap consolidation cut `BlueprintService.add_variable` assuming the engine covers it. For **struct-typed member variables** it doesn't, and every remaining door is closed (each verified live on a Linux 5.8 editor):

- engine `BlueprintTools.add_variable` → basic types only (`Unknown type "FStateTreeDelegateDispatcher"`)
- `BlueprintEditorLibrary.add_member_variable` via Python → needs an `EdGraphPinType`, whose construction the Python safety layer blocks (`PYTHON_UNSAFE_CODE`)
- `add_function_local_variable` → function-local scope, not a member

Net effect: `bind_transition_to_delegate`'s own documented prerequisite — a `FStateTreeDelegateDispatcher` member variable on the task — was impossible for an agent to satisfy, so the whole OnDelegate-transition flow needed a human in the editor.

## The fix

`AddMemberVariable(BlueprintPath, Name, TypeString, Default = "", bIsArray = false, ContainerType = "")` — the pre-consolidation implementation restored on top of the surviving `FBlueprintTypeParser`, deliberately scoped to the **Epic-less delta**: the doc comment steers basic types to the engine tool and reserves this for struct/object/enum/container types (the name avoids re-shadowing `add_variable`).

## Verification (live, headless 5.8)

The full previously-impossible flow now passes end-to-end: create STT task Blueprint → `add_member_variable(bp, "FinishRotatingDispatcher", "FStateTreeDelegateDispatcher")` → OnDelegate transition → `bind_transition_to_delegate` → **StateTree compiles clean**. Also covered: `float` with default, `FVector` array, duplicate-name refusal, unknown-type refusal.

`api-bindings.md` is updated from #501's known-gap note back to the working recipe, plus one newly-found gotcha documented: `bind_transition_to_delegate` matches tasks by **registered class name** (`STT_X_C`) — the asset path that `add_task` accepts is not accepted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)