### PR TITLE
PerformanceService: hitch validation, budget gate, and shareable HTML report

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/PerformanceServiceTests.cpp
+++ b/Source/VibeUE/Private/PythonAPI/PerformanceServiceTests.cpp
@@ -1,0 +1,413 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#include "Misc/AutomationTest.h"
+
+#if WITH_AUTOMATION_TESTS
+
+#include "PythonAPI/PerformanceVerdict.h"
+#include "PythonAPI/UPerformanceService.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Dom/JsonObject.h"
+#include "HAL/FileManager.h"
+
+// Pure verdict/budget logic (PerformanceVerdict.h) is exercised headless — no editor, no live frame
+// globals — and FrameTiming routes through the same helpers, so green here means the shipping verdict
+// is green. The two live smoke tests additionally assert the JSON contract and input validation.
+
+static const EAutomationTestFlags kPerfTestFlags =
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter;
+
+// ---------------------------------------------------------------------------
+// Verdict classification
+// ---------------------------------------------------------------------------
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibePerfVerdictClearTest,
+	"VibeUE.Performance.Verdict.ClearWinners", kPerfTestFlags)
+bool FVibePerfVerdictClearTest::RunTest(const FString&)
+{
+	using namespace PerformanceVerdict;
+
+	// Game clearly slowest -> GameThread, clear, runner-up is the next-slowest (GPU at 11).
+	{
+		const FVerdict V = Classify(25.0, 8.0, /*Rhi*/ 0.0, 11.0, /*bRhi*/ false, /*bGpuAvailable*/ true);
+		TestEqual(TEXT("game bound"), V.Bound, FString(TEXT("GameThread")));
+		TestEqual(TEXT("game confidence"), V.Confidence, FString(TEXT("clear")));
+		TestFalse(TEXT("game not contested"), V.bContested);
+		TestEqual(TEXT("game runner-up"), V.RunnerName, FString(TEXT("GPU")));
+		TestEqual(TEXT("game margin"), V.MarginMs, 14.0, 1e-6);
+	}
+	// Render clearly slowest.
+	{
+		const FVerdict V = Classify(8.0, 25.0, 0.0, 11.0, false, true);
+		TestEqual(TEXT("render bound"), V.Bound, FString(TEXT("RenderThread")));
+		TestEqual(TEXT("render confidence"), V.Confidence, FString(TEXT("clear")));
+	}
+	// GPU clearly slowest.
+	{
+		const FVerdict V = Classify(8.0, 11.0, 0.0, 25.0, false, true);
+		TestEqual(TEXT("gpu bound"), V.Bound, FString(TEXT("GPU")));
+		TestEqual(TEXT("gpu confidence"), V.Confidence, FString(TEXT("clear")));
+	}
+	// RHI clearly slowest (RHI-threading on) -> a distinct RHI-bound verdict.
+	{
+		const FVerdict V = Classify(8.0, 11.0, /*Rhi*/ 25.0, 9.0, /*bRhi*/ true, true);
+		TestEqual(TEXT("rhi bound"), V.Bound, FString(TEXT("RHIThread")));
+		TestEqual(TEXT("rhi confidence"), V.Confidence, FString(TEXT("clear")));
+		TestFalse(TEXT("rhi not contested"), V.bContested);
+		TestEqual(TEXT("rhi runner-up is render"), V.RunnerName, FString(TEXT("RenderThread")));
+	}
+	// RHI available but not the winner -> existing game verdict is unchanged, RHI just joins the ranking.
+	{
+		const FVerdict V = Classify(25.0, 8.0, /*Rhi*/ 9.0, 11.0, /*bRhi*/ true, true);
+		TestEqual(TEXT("still game bound"), V.Bound, FString(TEXT("GameThread")));
+		TestEqual(TEXT("still clear"), V.Confidence, FString(TEXT("clear")));
+		TestFalse(TEXT("rhi present but not contested"), V.bContested);
+	}
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibePerfVerdictContestedTest,
+	"VibeUE.Performance.Verdict.Contested", kPerfTestFlags)
+bool FVibePerfVerdictContestedTest::RunTest(const FString&)
+{
+	using namespace PerformanceVerdict;
+
+	// Top two within 10% -> a tie: contested, confidence downgraded to marginal, runner-up named.
+	const FVerdict V = Classify(25.0, 24.0, 0.0, 5.0, false, true);
+	TestEqual(TEXT("bound is the nominal top"), V.Bound, FString(TEXT("GameThread")));
+	TestTrue(TEXT("contested"), V.bContested);
+	TestEqual(TEXT("confidence marginal"), V.Confidence, FString(TEXT("marginal")));
+	TestEqual(TEXT("contested_with"), V.RunnerName, FString(TEXT("RenderThread")));
+
+	// marginal (tie) must win over moderate (GPU-unavailable) when both apply.
+	const FVerdict M = Classify(10.0, 9.5, 0.0, 0.0, false, /*bGpuAvailable*/ false);
+	TestTrue(TEXT("tie contested even w/o gpu"), M.bContested);
+	TestEqual(TEXT("marginal beats moderate"), M.Confidence, FString(TEXT("marginal")));
+
+	// RHI can contest the render thread -> contested tie names RHIThread as the runner-up.
+	const FVerdict R = Classify(8.0, 25.0, /*Rhi*/ 24.0, 5.0, /*bRhi*/ true, true);
+	TestEqual(TEXT("render nominally top"), R.Bound, FString(TEXT("RenderThread")));
+	TestTrue(TEXT("render/rhi contested"), R.bContested);
+	TestEqual(TEXT("contested_with rhi"), R.RunnerName, FString(TEXT("RHIThread")));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibePerfVerdictBoundaryTest,
+	"VibeUE.Performance.Verdict.ContestedBoundary", kPerfTestFlags)
+bool FVibePerfVerdictBoundaryTest::RunTest(const FString&)
+{
+	using namespace PerformanceVerdict;
+
+	// Exactly 10% margin is NOT contested (strict < CONTESTED_PCT). 10 vs 9 -> 1/10 == 0.10 -> clear.
+	const FVerdict V = Classify(10.0, 9.0, 0.0, 3.0, false, true);
+	TestFalse(TEXT("exactly 10% is not contested"), V.bContested);
+	TestEqual(TEXT("boundary is clear"), V.Confidence, FString(TEXT("clear")));
+
+	// Just inside 10% (9.5/10 -> margin 0.5, 5%) IS contested.
+	const FVerdict C = Classify(10.0, 9.5, 0.0, 3.0, false, true);
+	TestTrue(TEXT("just under 10% is contested"), C.bContested);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibePerfVerdictGpuUnavailableTest,
+	"VibeUE.Performance.Verdict.GpuUnavailable", kPerfTestFlags)
+bool FVibePerfVerdictGpuUnavailableTest::RunTest(const FString&)
+{
+	using namespace PerformanceVerdict;
+
+	// GPU timing unavailable: GPU is dropped from the ranking, and a clear CPU winner is downgraded to
+	// "moderate" because a hidden GPU cost can't be ruled out.
+	const FVerdict V = Classify(25.0, 8.0, 0.0, 0.0, false, /*bGpuAvailable*/ false);
+	TestEqual(TEXT("bound game"), V.Bound, FString(TEXT("GameThread")));
+	TestEqual(TEXT("confidence moderate"), V.Confidence, FString(TEXT("moderate")));
+	TestFalse(TEXT("not contested"), V.bContested);
+	TestEqual(TEXT("runner is render (gpu excluded)"), V.RunnerName, FString(TEXT("RenderThread")));
+
+	// RHI unavailable must NOT downgrade confidence (its work was counted on the render thread) — only a
+	// missing GPU number does. GPU present + RHI absent + clear CPU winner stays "clear".
+	const FVerdict G = Classify(25.0, 8.0, /*Rhi*/ 0.0, 11.0, /*bRhi*/ false, /*bGpuAvailable*/ true);
+	TestEqual(TEXT("rhi-absent stays clear"), G.Confidence, FString(TEXT("clear")));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibePerfVerdictNoneTest,
+	"VibeUE.Performance.Verdict.NoTiming", kPerfTestFlags)
+bool FVibePerfVerdictNoneTest::RunTest(const FString&)
+{
+	using namespace PerformanceVerdict;
+
+	// No meaningful timing yet -> confidence "none", not contested.
+	const FVerdict V = Classify(0.0, 0.0, 0.0, 0.0, false, true);
+	TestEqual(TEXT("confidence none"), V.Confidence, FString(TEXT("none")));
+	TestFalse(TEXT("zero not contested"), V.bContested);
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Budget gate
+// ---------------------------------------------------------------------------
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibePerfBudgetGateTest,
+	"VibeUE.Performance.Budget.Gate", kPerfTestFlags)
+bool FVibePerfBudgetGateTest::RunTest(const FString&)
+{
+	using namespace PerformanceVerdict;
+
+	// 10 ms frame vs 60 FPS (16.67 ms) -> PASS with positive headroom.
+	{
+		const FBudget B = ComputeBudget(10.0, 60.0f);
+		TestEqual(TEXT("budget ms"), B.BudgetMs, 1000.0 / 60.0, 1e-6);
+		TestTrue(TEXT("10ms meets 60"), B.bMeetsTarget);
+		TestEqual(TEXT("headroom"), B.FrameHeadroomMs, (1000.0 / 60.0) - 10.0, 1e-6);
+	}
+	// 25 ms frame vs 60 FPS -> FAIL, negative headroom.
+	{
+		const FBudget B = ComputeBudget(25.0, 60.0f);
+		TestFalse(TEXT("25ms fails 60"), B.bMeetsTarget);
+		TestTrue(TEXT("negative headroom"), B.FrameHeadroomMs < 0.0);
+	}
+	// A zero frame time is not a pass (no real timing).
+	{
+		const FBudget B = ComputeBudget(0.0, 60.0f);
+		TestFalse(TEXT("zero frame not a pass"), B.bMeetsTarget);
+	}
+	// Other target: 8 ms vs 120 FPS (8.33 ms) -> PASS.
+	{
+		const FBudget B = ComputeBudget(8.0, 120.0f);
+		TestEqual(TEXT("120fps budget"), B.BudgetMs, 1000.0 / 120.0, 1e-6);
+		TestTrue(TEXT("8ms meets 120"), B.bMeetsTarget);
+	}
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibePerfBudgetSafeFpsTest,
+	"VibeUE.Performance.Budget.SafeTargetFps", kPerfTestFlags)
+bool FVibePerfBudgetSafeFpsTest::RunTest(const FString&)
+{
+	using namespace PerformanceVerdict;
+
+	// Invalid targets fall back to 60 FPS rather than dividing by zero / NaN.
+	TestEqual(TEXT("zero -> 60"),     SafeTargetFps(0.0f),  60.0, 1e-9);
+	TestEqual(TEXT("negative -> 60"), SafeTargetFps(-5.0f), 60.0, 1e-9);
+	TestEqual(TEXT("nan -> 60"),      SafeTargetFps(FMath::Sqrt(-1.0f)), 60.0, 1e-9);
+	TestEqual(TEXT("valid passes through"), SafeTargetFps(30.0f), 30.0, 1e-9);
+
+	// ComputeBudget with a bad FPS still yields the 60 FPS budget.
+	const FBudget B = ComputeBudget(10.0, 0.0f);
+	TestEqual(TEXT("bad fps budget"), B.BudgetMs, 1000.0 / 60.0, 1e-6);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibePerfBudgetPerThreadTest,
+	"VibeUE.Performance.Budget.PerThreadOverBudget", kPerfTestFlags)
+bool FVibePerfBudgetPerThreadTest::RunTest(const FString&)
+{
+	using namespace PerformanceVerdict;
+	const double Budget = 1000.0 / 60.0; // 16.67 ms
+
+	TestTrue(TEXT("20ms over 16.67"),  IsOverBudget(20.0, Budget));
+	TestFalse(TEXT("10ms under"),      IsOverBudget(10.0, Budget));
+	TestFalse(TEXT("exactly budget is not over"), IsOverBudget(Budget, Budget));
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Live smoke tests — run in-editor, exercise the real AICallable surface
+// ---------------------------------------------------------------------------
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibePerfFrameTimingShapeTest,
+	"VibeUE.Performance.FrameTiming.JsonShape", kPerfTestFlags)
+bool FVibePerfFrameTimingShapeTest::RunTest(const FString&)
+{
+	const FString Json = UPerformanceService::FrameTiming(60.0f);
+
+	TSharedPtr<FJsonObject> Obj;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
+	if (!FJsonSerializer::Deserialize(Reader, Obj) || !Obj.IsValid())
+	{
+		AddError(FString::Printf(TEXT("FrameTiming did not return valid JSON: %s"), *Json.Left(200)));
+		return false;
+	}
+
+	TestTrue(TEXT("success"), Obj->GetBoolField(TEXT("success")));
+
+	// Required top-level fields of the verdict contract.
+	for (const TCHAR* Field : { TEXT("game_thread_ms"), TEXT("render_thread_ms"), TEXT("rhi_thread_ms"),
+		TEXT("gpu_ms"), TEXT("frame_ms"), TEXT("fps"), TEXT("bound"), TEXT("bound_confidence"),
+		TEXT("margin_ms"), TEXT("contested"), TEXT("hint"), TEXT("pie_running") })
+	{
+		TestTrue(FString::Printf(TEXT("has field %s"), Field), Obj->HasField(Field));
+	}
+
+	// Budget sub-object contract.
+	const TSharedPtr<FJsonObject>* Budget = nullptr;
+	if (TestTrue(TEXT("has budget object"), Obj->TryGetObjectField(TEXT("budget"), Budget)) && Budget)
+	{
+		for (const TCHAR* Field : { TEXT("target_fps"), TEXT("budget_ms"), TEXT("threads"),
+			TEXT("frame_headroom_ms"), TEXT("meets_target"), TEXT("verdict") })
+		{
+			TestTrue(FString::Printf(TEXT("budget has %s"), Field), (*Budget)->HasField(Field));
+		}
+	}
+
+	// The live bound must be one of the known verdicts (or none when there's no timing).
+	const FString Bound = Obj->GetStringField(TEXT("bound"));
+	const bool bKnown = Bound == TEXT("GameThread") || Bound == TEXT("RenderThread")
+		|| Bound == TEXT("RHIThread") || Bound == TEXT("GPU");
+	TestTrue(FString::Printf(TEXT("bound is a known thread: %s"), *Bound), bKnown);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibePerfForceHitchValidationTest,
+	"VibeUE.Performance.ForceHitch.RejectsBadThread", kPerfTestFlags)
+bool FVibePerfForceHitchValidationTest::RunTest(const FString&)
+{
+	// An unknown thread name must be rejected up front (before any stall is scheduled).
+	const FString Json = UPerformanceService::ForceHitch(TEXT("banana"), 1.0f, 1);
+
+	TSharedPtr<FJsonObject> Obj;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
+	if (!FJsonSerializer::Deserialize(Reader, Obj) || !Obj.IsValid())
+	{
+		AddError(TEXT("ForceHitch did not return valid JSON"));
+		return false;
+	}
+	TestFalse(TEXT("bad thread not success"), Obj->GetBoolField(TEXT("success")));
+	TestEqual(TEXT("error code"), Obj->GetStringField(TEXT("error_code")), FString(TEXT("BAD_THREAD")));
+	return true;
+}
+
+// Race-free self-validation logic: given the peak per-thread ms a hitch induced, decide whether it landed
+// on the requested thread(s). Pure -> exercised headless, no live timing.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibePerfHitchExpectTest,
+	"VibeUE.Performance.ForceHitch.MatchesExpect", kPerfTestFlags)
+bool FVibePerfHitchExpectTest::RunTest(const FString&)
+{
+	using namespace PerformanceVerdict;
+	const double Min = 125.0; // half of a 250 ms stall
+
+	// game: game peak clears the floor AND dominates render -> match; render untouched must not match "game".
+	TestTrue (TEXT("game hit"),          HitchMatchesExpect(TEXT("game"),   250.0,   0.0, Min));
+	TestFalse(TEXT("game undershoot"),   HitchMatchesExpect(TEXT("game"),    50.0,   0.0, Min));
+	TestFalse(TEXT("game but render bigger"), HitchMatchesExpect(TEXT("game"), 250.0, 300.0, Min));
+
+	// render: symmetric.
+	TestTrue (TEXT("render hit"),        HitchMatchesExpect(TEXT("render"),   0.0, 250.0, Min));
+	TestFalse(TEXT("render undershoot"), HitchMatchesExpect(TEXT("render"),   0.0,  50.0, Min));
+
+	// both: both threads must clear the floor.
+	TestTrue (TEXT("both hit"),          HitchMatchesExpect(TEXT("both"),   250.0, 250.0, Min));
+	TestFalse(TEXT("both one short"),    HitchMatchesExpect(TEXT("both"),   250.0,  50.0, Min));
+
+	// rhi: the RHI peak (5th arg) must clear the floor AND dominate both CPU threads.
+	TestTrue (TEXT("rhi hit"),           HitchMatchesExpect(TEXT("rhi"),      0.0,   0.0, Min, /*Rhi*/ 250.0));
+	TestFalse(TEXT("rhi undershoot"),    HitchMatchesExpect(TEXT("rhi"),      0.0,   0.0, Min, /*Rhi*/  50.0));
+	TestFalse(TEXT("rhi but render bigger"), HitchMatchesExpect(TEXT("rhi"),  0.0, 300.0, Min, /*Rhi*/ 250.0));
+	// rhi with no RHI peak (threading off -> stall folded into render) must not falsely match.
+	TestFalse(TEXT("rhi threading off"), HitchMatchesExpect(TEXT("rhi"),      0.0, 250.0, Min, /*Rhi*/   0.0));
+
+	// gpu / unknown are never self-validated by CPU peaks.
+	TestFalse(TEXT("gpu not matched here"), HitchMatchesExpect(TEXT("gpu"), 999.0, 999.0, Min));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibePerfForceHitchSelfMeasureTest,
+	"VibeUE.Performance.ForceHitch.SelfMeasure", kPerfTestFlags)
+bool FVibePerfForceHitchSelfMeasureTest::RunTest(const FString&)
+{
+	// A game-thread stall must be induced AND measured within the single call: the response carries the
+	// observed peak and verdict_matched_expect=true, with no follow-up FrameTiming.
+	const FString Json = UPerformanceService::ForceHitch(TEXT("game"), 20.0f, 1);
+
+	TSharedPtr<FJsonObject> Obj;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
+	if (!FJsonSerializer::Deserialize(Reader, Obj) || !Obj.IsValid())
+	{
+		AddError(FString::Printf(TEXT("ForceHitch did not return valid JSON: %s"), *Json.Left(200)));
+		return false;
+	}
+
+	TestTrue(TEXT("success"), Obj->GetBoolField(TEXT("success")));
+	TestTrue(TEXT("has observed_peak_game_ms"), Obj->HasField(TEXT("observed_peak_game_ms")));
+	TestTrue(TEXT("has verdict_matched_expect"), Obj->HasField(TEXT("verdict_matched_expect")));
+
+	// The 20 ms sleep should measure at least the 10 ms match floor (sleep never undershoots by half).
+	const double Peak = Obj->GetNumberField(TEXT("observed_peak_game_ms"));
+	TestTrue(FString::Printf(TEXT("induced >= 10ms (got %.1f)"), Peak), Peak >= 10.0);
+	TestTrue(TEXT("verdict matched"), Obj->GetBoolField(TEXT("verdict_matched_expect")));
+	return true;
+}
+
+// The rhi arm is a ground-truth trigger for the RHIThread verdict. Headless runs under -nullrhi with no
+// separate RHI thread, so this asserts the graceful fallback: the mode is accepted (not BAD_THREAD),
+// rhi_threading reports false, a warning is surfaced, and nothing was validated. The live RHIThread-wins
+// path can only be confirmed in a session with RHI-threading ON.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibePerfForceHitchRhiTest,
+	"VibeUE.Performance.ForceHitch.RhiArm", kPerfTestFlags)
+bool FVibePerfForceHitchRhiTest::RunTest(const FString&)
+{
+	const FString Json = UPerformanceService::ForceHitch(TEXT("rhi"), 20.0f, 1);
+
+	TSharedPtr<FJsonObject> Obj;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
+	if (!FJsonSerializer::Deserialize(Reader, Obj) || !Obj.IsValid())
+	{
+		AddError(FString::Printf(TEXT("ForceHitch rhi did not return valid JSON: %s"), *Json.Left(200)));
+		return false;
+	}
+
+	// 'rhi' is a valid mode — accepted, not rejected as BAD_THREAD.
+	TestTrue(TEXT("success"), Obj->GetBoolField(TEXT("success")));
+	TestEqual(TEXT("forcing rhi"), Obj->GetStringField(TEXT("forcing")), FString(TEXT("rhi")));
+	TestTrue(TEXT("has rhi_threading"), Obj->HasField(TEXT("rhi_threading")));
+
+	// Headless nullrhi has no separate RHI thread: expect the flagged fallback, no induced verdict.
+	if (!Obj->GetBoolField(TEXT("rhi_threading")))
+	{
+		TestTrue(TEXT("warns rhi-threading off"), Obj->HasField(TEXT("rhi_warning")));
+		TestFalse(TEXT("nothing validated w/o rhi thread"), Obj->GetBoolField(TEXT("verdict_matched_expect")));
+	}
+	return true;
+}
+
+// Report() renders a self-contained HTML "printout" from the live verdict + capture summary. Headless
+// (nullrhi, no trace) exercises the no-capture path: the file must still be written and the JSON contract
+// (report_file / fix_count / included_capture) honoured.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibePerfReportSmokeTest,
+	"VibeUE.Performance.Report.WritesFile", kPerfTestFlags)
+bool FVibePerfReportSmokeTest::RunTest(const FString&)
+{
+	const FString Json = UPerformanceService::Report(TEXT("Smoke Test"), TEXT("both"), TEXT(""));
+
+	TSharedPtr<FJsonObject> Obj;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
+	if (!FJsonSerializer::Deserialize(Reader, Obj) || !Obj.IsValid())
+	{
+		AddError(FString::Printf(TEXT("Report did not return valid JSON: %s"), *Json.Left(200)));
+		return false;
+	}
+
+	TestTrue(TEXT("success"), Obj->GetBoolField(TEXT("success")));
+
+	// Contract fields.
+	TestTrue(TEXT("has report_file"), Obj->HasField(TEXT("report_file")));
+	TestTrue(TEXT("has fix_count"), Obj->HasField(TEXT("fix_count")));
+	TestTrue(TEXT("has included_capture"), Obj->HasField(TEXT("included_capture")));
+
+	// No trace is available headless, so the capture column must be absent.
+	TestFalse(TEXT("no capture headless"), Obj->GetBoolField(TEXT("included_capture")));
+
+	// The reported path must point at a real, non-empty file on disk.
+	const FString Path = Obj->GetStringField(TEXT("report_file"));
+	TestTrue(TEXT("report_file non-empty"), !Path.IsEmpty());
+	IFileManager& FM = IFileManager::Get();
+	if (TestTrue(FString::Printf(TEXT("file exists: %s"), *Path), FM.FileExists(*Path)))
+	{
+		TestTrue(TEXT("file has content"), FM.FileSize(*Path) > 0);
+		FM.Delete(*Path); // don't litter the project's Saved dir with test artifacts
+	}
+	return true;
+}
+
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/VibeUE/Private/PythonAPI/PerformanceVerdict.h
+++ b/Source/VibeUE/Private/PythonAPI/PerformanceVerdict.h
@@ -1,0 +1,112 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+// Pure, side-effect-free verdict + budget logic, factored out of UPerformanceService::FrameTiming so it
+// can be exercised headless by automation tests (no editor, no live frame globals). FrameTiming routes
+// through these so the tests and the shipping method share one implementation and can never disagree.
+namespace PerformanceVerdict
+{
+	// Result of classifying which thread bounds the frame. Mirrors the fields FrameTiming emits.
+	struct FVerdict
+	{
+		FString Bound;          // "GameThread" | "RenderThread" | "RHIThread" | "GPU"
+		FString Confidence;     // "clear" | "moderate" | "marginal" | "none"
+		double  TopMs = 0.0;    // the bottleneck thread's ms
+		double  RunnerMs = 0.0; // the runner-up's ms
+		FString RunnerName;     // runner-up thread name ("" when only one thread ranked)
+		double  MarginMs = 0.0; // TopMs - RunnerMs
+		bool    bContested = false; // top two within CONTESTED_PCT -> a genuine tie
+	};
+
+	// Top must lead the runner-up by more than this fraction of its own cost to be a clear win.
+	static constexpr double CONTESTED_PCT = 0.10;
+
+	// Rank game/render/RHI/GPU, then judge how decisive the winner is. RHI and GPU each count only when
+	// their timing is available: GRHIThreadTime is 0 when RHI-threading is off (its cost then folds into the
+	// render thread, so ranking it would double-count), and GPU timing isn't always present. RHI IS a real
+	// distinct bottleneck -- draw-call submission can saturate it independently of render-thread scene setup.
+	// Note only GPU-unavailable downgrades confidence to "moderate": a missing GPU number hides a possible
+	// bottleneck, whereas missing RHI just means its work was already counted on the render thread.
+	inline FVerdict Classify(double GameMs, double RenderMs, double RhiMs, double GpuMs,
+	                         bool bRhiAvailable, bool bGpuAvailable)
+	{
+		struct FThread { const TCHAR* Name; double Ms; };
+		TArray<FThread, TInlineAllocator<4>> Threads;
+		Threads.Add({ TEXT("GameThread"),   GameMs });
+		Threads.Add({ TEXT("RenderThread"), RenderMs });
+		if (bRhiAvailable) Threads.Add({ TEXT("RHIThread"), RhiMs });
+		if (bGpuAvailable) Threads.Add({ TEXT("GPU"), GpuMs });
+		Threads.Sort([](const FThread& A, const FThread& B) { return A.Ms > B.Ms; });
+
+		FVerdict V;
+		V.Bound      = Threads[0].Name;
+		V.TopMs      = Threads[0].Ms;
+		V.RunnerMs   = Threads.Num() > 1 ? Threads[1].Ms : 0.0;
+		V.RunnerName = Threads.Num() > 1 ? FString(Threads[1].Name) : FString();
+		V.MarginMs   = V.TopMs - V.RunnerMs;
+
+		V.bContested = V.TopMs > 0.0 && (V.MarginMs / V.TopMs) < CONTESTED_PCT;
+
+		if (V.TopMs <= 0.0)      V.Confidence = TEXT("none");     // no meaningful timing yet
+		else if (V.bContested)   V.Confidence = TEXT("marginal"); // a tie
+		else if (!bGpuAvailable) V.Confidence = TEXT("moderate"); // CPU winner, GPU unknown
+		else                     V.Confidence = TEXT("clear");
+		return V;
+	}
+
+	// Coerce a caller-supplied target FPS to something sane (NaN/inf/<=0 -> 60).
+	inline double SafeTargetFps(float TargetFPS)
+	{
+		return (FMath::IsFinite(TargetFPS) && TargetFPS > 0.0f) ? (double)TargetFPS : 60.0;
+	}
+
+	// A single thread finishes inside the per-frame budget iff its ms does not exceed it.
+	inline bool IsOverBudget(double Ms, double BudgetMs)
+	{
+		return Ms > BudgetMs;
+	}
+
+	struct FBudget
+	{
+		double TargetFps = 60.0;
+		double BudgetMs = 0.0;
+		double FrameMs = 0.0;
+		double FrameHeadroomMs = 0.0;
+		bool   bMeetsTarget = false; // PASS iff the frame has real timing AND fits the budget
+	};
+
+	inline FBudget ComputeBudget(double FrameMs, float TargetFPS)
+	{
+		FBudget B;
+		B.TargetFps        = SafeTargetFps(TargetFPS);
+		B.BudgetMs         = 1000.0 / B.TargetFps;
+		B.FrameMs          = FrameMs;
+		B.FrameHeadroomMs  = B.BudgetMs - FrameMs;
+		B.bMeetsTarget     = FrameMs > 0.0 && FrameMs <= B.BudgetMs;
+		return B;
+	}
+
+	// Race-free self-validation for ForceHitch. Given the peak per-thread ms the hitch actually induced --
+	// measured synchronously by ForceHitch itself, NOT read back via a follow-up FrameTiming that races the
+	// stall on the game thread -- did the stall land on the thread(s) the caller asked for? MinExpectedMs is
+	// the floor a thread's induced time must clear to count as hit (set below the requested stall to tolerate
+	// scheduler slop). "gpu" is not validated here: its cost is scene-dependent and can't be measured
+	// synchronously, so it keeps the read-a-following-frame path. "rhi" self-validates only when RHI-threading
+	// is on (a distinct RHI thread exists to stall); the peak must clear the floor AND dominate both CPU
+	// threads, or the stall folded into the render thread and there's no RHIThread verdict to confirm.
+	inline bool HitchMatchesExpect(const FString& Mode, double PeakGameMs, double PeakRenderMs,
+	                               double MinExpectedMs, double PeakRhiMs = 0.0)
+	{
+		const bool bGameHit   = PeakGameMs   >= MinExpectedMs;
+		const bool bRenderHit = PeakRenderMs >= MinExpectedMs;
+		const bool bRhiHit    = PeakRhiMs    >= MinExpectedMs;
+		if (Mode == TEXT("game"))   return bGameHit   && PeakGameMs   > PeakRenderMs;
+		if (Mode == TEXT("render")) return bRenderHit && PeakRenderMs > PeakGameMs;
+		if (Mode == TEXT("both"))   return bGameHit   && bRenderHit;
+		if (Mode == TEXT("rhi"))    return bRhiHit    && PeakRhiMs > PeakRenderMs && PeakRhiMs > PeakGameMs;
+		return false; // gpu / unknown -- not self-validated by induced CPU peaks
+	}
+}

--- a/Source/VibeUE/Private/PythonAPI/UPerformanceService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UPerformanceService.cpp
@@ -1,6 +1,7 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
 #include "PythonAPI/UPerformanceService.h"
+#include "PythonAPI/PerformanceVerdict.h"
 #include "Json.h"
 #include "Misc/Paths.h"
 #include "Misc/FileHelper.h"
@@ -8,6 +9,10 @@
 #include "HAL/FileManager.h"
 #include "HAL/PlatformProcess.h"
 #include "HAL/PlatformTime.h"
+#include "HAL/IConsoleManager.h"
+#include "Containers/Ticker.h"
+#include "RenderingThread.h"   // ENQUEUE_RENDER_COMMAND
+#include "RHICommandList.h"    // FRHICommandListImmediate
 #include "Modules/ModuleManager.h"
 #include "ProfilingDebugging/TraceAuxiliary.h"
 #include "ProfilingDebugging/MiscTrace.h"
@@ -258,6 +263,13 @@ static FString AnalyseLogs(const FString& LogFile)
 	FString Content;
 	if (!FFileHelper::LoadFileToString(Content, *LogFile))
 	{
+		// LoadFileToString fails both when the file is absent AND when it exists but is locked open by
+		// another process (e.g. the editor's own live log). Distinguish the two so the caller isn't
+		// misled into thinking a present-but-locked log is missing.
+		if (FPaths::FileExists(LogFile))
+		{
+			return ErrJson(TEXT("LOG_LOCKED"), FString::Printf(TEXT("Log file exists but could not be read (likely held open by another process): %s"), *LogFile));
+		}
 		return ErrJson(TEXT("LOG_NOT_FOUND"), FString::Printf(TEXT("Log file not found: %s"), *LogFile));
 	}
 
@@ -350,7 +362,26 @@ static FString AnalyseBoth(const FString& TraceFile, const FString& LogFile)
 // AICallable methods
 // ===========================================================================
 
-FString UPerformanceService::FrameTiming()
+// Per-thread advice keyed by the winning bottleneck. Kept next to FrameTiming so the verdict and its
+// remediation hint stay in lockstep.
+static FString BoundHint(const FString& Bound)
+{
+	if (Bound == TEXT("GPU"))
+	{
+		return TEXT("GPU-bound. NOW it is worth profiling the GPU: StartTrace (channels frame,gpu,cpu), then 'r.ProfileGPU.ShowUI 0' + 'ProfileGPU' and read the pass breakdown from the log. Levers: shadows (Virtual Shadow Maps), Lumen GI/reflections, translucency, post-process, ScreenPercentage. Confirm with the resolution test: 'r.ScreenPercentage 50' should noticeably raise FPS if truly GPU-bound.");
+	}
+	if (Bound == TEXT("RenderThread"))
+	{
+		return TEXT("CPU render-thread bound. Usual cause: too many draw calls / primitives, or many dynamic shadow-casting lights. Check 'stat scenerendering'. Levers: merge/instance meshes, enable Nanite, cut dynamic lights and per-light shadows. NOTE: dropping r.ScreenPercentage will NOT help a render-thread-bound frame.");
+	}
+	if (Bound == TEXT("RHIThread"))
+	{
+		return TEXT("CPU RHI-thread bound — the thread submitting GPU commands is the bottleneck, distinct from render-thread scene setup. Usual cause: too many draw calls / state changes saturating command submission. Check 'stat rhi' and 'stat scenerendering' (draw-call count). Levers: cut draw calls via merging/instancing/HISM, enable Nanite, reduce material/state permutations. NOTE: dropping r.ScreenPercentage will NOT help an RHI-thread-bound frame.");
+	}
+	return TEXT("CPU game-thread bound. Usual cause: Tick / Blueprint / AI / animation cost. Run 'stat dumpframe -ms=0.5 -root=gamethread' on the PIE world then read the result. Levers: throttle/disable unnecessary Tick, reduce ticking actors & AI, cut expensive Blueprint tick logic. NOTE: dropping r.ScreenPercentage will NOT help a game-thread-bound frame.");
+}
+
+FString UPerformanceService::FrameTiming(float TargetFPS)
 {
 	const double GameMs   = FPlatformTime::ToMilliseconds(GGameThreadTime);
 	const double RenderMs = FPlatformTime::ToMilliseconds(GRenderThreadTime);
@@ -365,40 +396,642 @@ FString UPerformanceService::FrameTiming()
 	R->SetNumberField(TEXT("rhi_thread_ms"),    Round2(RHIMs));
 	R->SetNumberField(TEXT("gpu_ms"),           Round2(GpuMs));
 
-	const double FrameMs = FMath::Max3(GameMs, RenderMs, GpuMs);
+	const bool bRhiAvailable = RHIMs > 0.0;
+	const bool bGpuAvailable = GpuMs > 0.0;
+	// Every ranked thread runs in parallel, so the frame is bounded by the slowest of them. RHIMs/GpuMs are
+	// 0 when unavailable, so Max is safe — an absent thread can never be the max.
+	const double FrameMs = FMath::Max(FMath::Max3(GameMs, RenderMs, GpuMs), RHIMs);
 	R->SetNumberField(TEXT("frame_ms"), Round2(FrameMs));
 	R->SetNumberField(TEXT("fps"), FrameMs > 0.0 ? Round2(1000.0 / FrameMs) : 0.0);
 
-	FString Bound;
-	FString Hint;
-	if (GpuMs >= GameMs && GpuMs >= RenderMs && GpuMs > 0.0)
-	{
-		Bound = TEXT("GPU");
-		Hint  = TEXT("GPU-bound. NOW it is worth profiling the GPU: StartTrace (channels frame,gpu,cpu), then 'r.ProfileGPU.ShowUI 0' + 'ProfileGPU' and read the pass breakdown from the log. Levers: shadows (Virtual Shadow Maps), Lumen GI/reflections, translucency, post-process, ScreenPercentage. Confirm with the resolution test: 'r.ScreenPercentage 50' should noticeably raise FPS if truly GPU-bound.");
-	}
-	else if (RenderMs >= GameMs)
-	{
-		Bound = TEXT("RenderThread");
-		Hint  = TEXT("CPU render-thread bound. Usual cause: too many draw calls / primitives, or many dynamic shadow-casting lights. Check 'stat scenerendering'. Levers: merge/instance meshes, enable Nanite, cut dynamic lights and per-light shadows. NOTE: dropping r.ScreenPercentage will NOT help a render-thread-bound frame.");
-	}
-	else
-	{
-		Bound = TEXT("GameThread");
-		Hint  = TEXT("CPU game-thread bound. Usual cause: Tick / Blueprint / AI / animation cost. Run 'stat dumpframe -ms=0.5 -root=gamethread' on the PIE world then read the result. Levers: throttle/disable unnecessary Tick, reduce ticking actors & AI, cut expensive Blueprint tick logic. NOTE: dropping r.ScreenPercentage will NOT help a game-thread-bound frame.");
-	}
+	// --- Robust verdict -------------------------------------------------------
+	// Rank the candidate threads (GPU only counts when its timing is available) and judge how decisive
+	// the winner is. Pure logic lives in PerformanceVerdict::Classify so it can be unit-tested headless.
+	const PerformanceVerdict::FVerdict Verdict = PerformanceVerdict::Classify(GameMs, RenderMs, RHIMs, GpuMs, bRhiAvailable, bGpuAvailable);
+	const FString Bound      = Verdict.Bound;
+	const double  TopMs      = Verdict.TopMs;
+	const double  RunnerMs   = Verdict.RunnerMs;
+	const FString RunnerName = Verdict.RunnerName;
+	const double  MarginMs   = Verdict.MarginMs;
+	const bool    bContested = Verdict.bContested;
+
 	R->SetStringField(TEXT("bound"), Bound);
+	R->SetStringField(TEXT("bound_confidence"), Verdict.Confidence);
+	R->SetNumberField(TEXT("margin_ms"), Round2(MarginMs));
+	R->SetBoolField(TEXT("contested"), bContested);
+
+	FString Hint = BoundHint(Bound);
+	if (bContested && !RunnerName.IsEmpty())
+	{
+		R->SetStringField(TEXT("contested_with"), RunnerName);
+		Hint = FString::Printf(
+			TEXT("CONTESTED: %s (%.2f ms) and %s (%.2f ms) are within %.2f ms — frame-to-frame noise can flip which one 'wins', so treat both as bottlenecks. Take several readings, or trace both. %s"),
+			*Bound, TopMs, *RunnerName, RunnerMs, MarginMs, *BoundHint(Bound));
+	}
+	else if (!bGpuAvailable && Bound != TEXT("GPU"))
+	{
+		Hint = FString::Printf(
+			TEXT("%s NOTE: GPU timing is unavailable this frame, so this CPU verdict is unconfirmed — a hidden GPU cost could still be the real bottleneck. Confirm with the 'r.ScreenPercentage 50' test."),
+			*Hint);
+	}
 	R->SetStringField(TEXT("hint"), Hint);
+
+	// --- Frame-time budget gate ----------------------------------------------
+	// FPS is 1000/frame_ms, and the threads run in parallel, so EACH thread must individually finish
+	// inside the per-frame budget. Report every thread's headroom against the target and gate on the
+	// bottleneck — this is what turns a one-shot reading into a pass/fail guard.
+	const PerformanceVerdict::FBudget Gate = PerformanceVerdict::ComputeBudget(FrameMs, TargetFPS);
+	const double BudgetMs = Gate.BudgetMs;
+
+	TSharedPtr<FJsonObject> Budget = MakeShared<FJsonObject>();
+	Budget->SetNumberField(TEXT("target_fps"), Round2(Gate.TargetFps));
+	Budget->SetNumberField(TEXT("budget_ms"), Round2(BudgetMs));
+
+	auto ThreadBudget = [&](double Ms, bool bAvailable) -> TSharedPtr<FJsonValue>
+	{
+		TSharedPtr<FJsonObject> T = MakeShared<FJsonObject>();
+		T->SetNumberField(TEXT("ms"), Round2(Ms));
+		if (bAvailable)
+		{
+			T->SetNumberField(TEXT("headroom_ms"), Round2(BudgetMs - Ms));
+			T->SetBoolField(TEXT("over_budget"), PerformanceVerdict::IsOverBudget(Ms, BudgetMs));
+		}
+		else
+		{
+			T->SetBoolField(TEXT("available"), false);
+		}
+		return MakeShared<FJsonValueObject>(T);
+	};
+
+	TSharedPtr<FJsonObject> PerThread = MakeShared<FJsonObject>();
+	PerThread->SetField(TEXT("game_thread"),   ThreadBudget(GameMs, true));
+	PerThread->SetField(TEXT("render_thread"), ThreadBudget(RenderMs, true));
+	PerThread->SetField(TEXT("gpu"),           ThreadBudget(GpuMs, bGpuAvailable));
+	Budget->SetObjectField(TEXT("threads"), PerThread);
+
+	Budget->SetNumberField(TEXT("frame_headroom_ms"), Round2(Gate.FrameHeadroomMs));
+	const bool bMeetsTarget = Gate.bMeetsTarget;
+	Budget->SetBoolField(TEXT("meets_target"), bMeetsTarget);
+	Budget->SetStringField(TEXT("verdict"), bMeetsTarget ? TEXT("PASS") : TEXT("FAIL"));
+	if (!bMeetsTarget && FrameMs > 0.0)
+	{
+		Budget->SetStringField(TEXT("budget_note"), FString::Printf(
+			TEXT("%s is %.2f ms over the %.2f ms budget for %g FPS — that thread alone caps you at ~%.0f FPS. Fix the bottleneck thread, not whichever is cheapest."),
+			*Bound, TopMs - BudgetMs, BudgetMs, Gate.TargetFps, FrameMs > 0.0 ? 1000.0 / FrameMs : 0.0));
+	}
+	R->SetObjectField(TEXT("budget"), Budget);
 
 	const bool bPIE = IsPIERunning();
 	R->SetBoolField(TEXT("pie_running"), bPIE);
 	R->SetStringField(TEXT("note"),
 		bPIE
 		? TEXT("Values are for the most recently rendered PIE frame. Park in a representative/worst spot for a clean read.")
-		: TEXT("PIE is NOT running — these values reflect the EDITOR viewport, not your game. Start PIE (Epic's EditorAppToolset.StartPIE) for a real game-bound reading."));
+		: TEXT("PIE is NOT running — these values reflect the EDITOR viewport, not your game. Start PIE (Epic's EditorAppToolset.StartPIE, or VibeUE's StartPIE) for a real game-bound reading."));
 	if (GpuMs <= 0.0)
 	{
 		R->SetStringField(TEXT("gpu_note"), TEXT("gpu_ms is 0 (GPU timing unavailable this frame) — rely on the game vs render comparison, and confirm GPU-bound with the r.ScreenPercentage 50 test."));
 	}
+	return OkJson(R);
+}
+
+FString UPerformanceService::ForceHitch(const FString& Thread, float Milliseconds, int32 Frames)
+{
+	const FString Mode = Thread.IsEmpty() ? TEXT("game") : Thread.ToLower();
+	const bool bGame   = (Mode == TEXT("game")   || Mode == TEXT("both"));
+	const bool bRender = (Mode == TEXT("render") || Mode == TEXT("both"));
+	const bool bRhi    = (Mode == TEXT("rhi"));
+	const bool bGpu    = (Mode == TEXT("gpu"));
+
+	if (!bGame && !bRender && !bRhi && !bGpu)
+	{
+		return ErrJson(TEXT("BAD_THREAD"), FString::Printf(
+			TEXT("Unknown Thread '%s'. Use 'game', 'render', 'both', 'rhi', or 'gpu'."), *Thread));
+	}
+
+	// Clamp so a fat-fingered value can't freeze the editor for a minute or spin forever.
+	const float StallMs      = FMath::Clamp(Milliseconds, 1.0f, 5000.0f);
+	const int32 HitchFrames  = FMath::Clamp(Frames, 1, 600);
+	const float StallSeconds = StallMs / 1000.0f;
+
+	// Tell the caller exactly what to expect from the verdict, so validation is a direct compare.
+	const TCHAR* Expect =
+		  (Mode == TEXT("both"))   ? TEXT("contested=true (GameThread and RenderThread within margin)")
+		: (Mode == TEXT("render"))? TEXT("bound=RenderThread")
+		: (Mode == TEXT("rhi"))   ? TEXT("bound=RHIThread WHEN RHI-threading is on; otherwise the stall folds into the render thread (no distinct RHIThread verdict)")
+		: (Mode == TEXT("gpu"))   ? TEXT("bound=GPU IF the scene's GPU cost now exceeds the CPU threads (scene-dependent)")
+		:                           TEXT("bound=GameThread");
+
+	TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+	R->SetStringField(TEXT("forcing"), Mode);
+	R->SetStringField(TEXT("expect"), Expect);
+
+	// GPU forcing stays async: supersample by driving r.ScreenPercentage up, restored when the countdown
+	// ends over HitchFrames frames. It's the only scene-agnostic GPU lever we have — the actual cost still
+	// depends on what's on screen, so a trivial PIE scene may not tip the frame GPU-bound (best-effort). GPU
+	// cost persists across the frames the reader sees, so unlike the CPU paths a follow-up FrameTiming reads
+	// it back cleanly — which is why gpu keeps the read-a-following-frame flow instead of self-measuring.
+	if (bGpu)
+	{
+		constexpr float GpuScreenPercentage = 400.0f;
+		float SavedScreenPercentage = 100.0f;
+		IConsoleVariable* ScreenPctCVar = IConsoleManager::Get().FindConsoleVariable(TEXT("r.ScreenPercentage"));
+		if (ScreenPctCVar)
+		{
+			SavedScreenPercentage = ScreenPctCVar->GetFloat();
+			ScreenPctCVar->Set(GpuScreenPercentage, ECVF_SetByConsole);
+		}
+
+		TSharedRef<int32> Remaining = MakeShared<int32>(HitchFrames);
+		FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateLambda(
+			[Remaining, ScreenPctCVar, SavedScreenPercentage](float) -> bool
+			{
+				if (--(*Remaining) > 0)
+				{
+					return true; // keep the supersample up for the next frame
+				}
+				if (ScreenPctCVar)
+				{
+					ScreenPctCVar->Set(SavedScreenPercentage, ECVF_SetByConsole); // restore + unregister
+				}
+				return false;
+			}));
+
+		R->SetNumberField(TEXT("frames"), HitchFrames);
+		if (ScreenPctCVar)
+		{
+			R->SetNumberField(TEXT("screen_percentage"), GpuScreenPercentage);
+			R->SetNumberField(TEXT("restore_screen_percentage"), SavedScreenPercentage);
+		}
+		else
+		{
+			R->SetStringField(TEXT("gpu_warning"), TEXT("r.ScreenPercentage cvar not found — GPU load NOT applied."));
+		}
+		if (!IsPIERunning())
+		{
+			R->SetStringField(TEXT("note"), TEXT("PIE is not running — the GPU load lands on the editor viewport frame. Start PIE for a game-representative validation."));
+		}
+		R->SetStringField(TEXT("hint"), TEXT("GPU cost is scene-dependent and not self-measured — call FrameTiming on a following frame and confirm bound=GPU. Unlike the CPU paths this reads back cleanly (the GPU cost persists across frames)."));
+		return OkJson(R);
+	}
+
+	// CPU paths (game/render/both) — SELF-MEASURING, so validation is race-free. The naive approach schedules
+	// the stall on a future frame and relies on a follow-up FrameTiming to catch it, but that read runs on the
+	// game thread the stall blocks and reliably lands on a clean frame. Here we apply the stall synchronously
+	// inside this call and time it directly, then return the induced peak per-thread ms and a
+	// verdict_matched_expect flag — the caller validates from THIS single response, no second call.
+	// Cap total synchronous blocking so a fat-fingered frames*ms can't freeze the editor for minutes.
+	constexpr double TotalCapMs = 10000.0;
+	const int32 EffectiveFrames = FMath::Min(HitchFrames, FMath::Max(1, (int32)(TotalCapMs / StallMs)));
+
+	// "rhi" self-measures only when a separate RHI thread exists to stall. With RHI-threading off the RHI
+	// work runs inline on the render thread, so there's no distinct RHIThread to bind the frame — we skip
+	// the stall and flag it, mirroring how the verdict drops RHI from the ranking in that case.
+	const bool bRhiThreaded = bRhi && IsRunningRHIInSeparateThread();
+
+	double PeakGameMs = 0.0;
+	double PeakRenderMs = 0.0;
+	double PeakRhiMs = 0.0;
+	for (int32 i = 0; i < EffectiveFrames; ++i)
+	{
+		if (bGame)
+		{
+			const double T0 = FPlatformTime::Seconds();
+			FPlatformProcess::Sleep(StallSeconds);
+			PeakGameMs = FMath::Max(PeakGameMs, (FPlatformTime::Seconds() - T0) * 1000.0);
+		}
+		if (bRender)
+		{
+			// Stall the render thread and have IT time its own sleep into a shared slot; FlushRenderingCommands
+			// blocks the game thread until that command completes, so the measurement is done before we read it.
+			TSharedRef<double, ESPMode::ThreadSafe> RtMs = MakeShared<double, ESPMode::ThreadSafe>(0.0);
+			const float RtSeconds = StallSeconds;
+			ENQUEUE_RENDER_COMMAND(VibePerfForceHitch)(
+				[RtSeconds, RtMs](FRHICommandListImmediate&)
+				{
+					const double T0 = FPlatformTime::Seconds();
+					FPlatformProcess::Sleep(RtSeconds);
+					*RtMs = (FPlatformTime::Seconds() - T0) * 1000.0;
+				});
+			FlushRenderingCommands();
+			PeakRenderMs = FMath::Max(PeakRenderMs, *RtMs);
+		}
+		if (bRhiThreaded)
+		{
+			// Stall the RHI thread specifically: from the render thread, enqueue a lambda onto the command
+			// list (it executes on the RHI thread when threading is on) that times its own sleep, then flush
+			// the RHI thread so the game thread blocks until that lambda has run and the slot is filled.
+			TSharedRef<double, ESPMode::ThreadSafe> RhMs = MakeShared<double, ESPMode::ThreadSafe>(0.0);
+			const float RhSeconds = StallSeconds;
+			ENQUEUE_RENDER_COMMAND(VibePerfForceHitchRHI)(
+				[RhSeconds, RhMs](FRHICommandListImmediate& RHICmdList)
+				{
+					RHICmdList.EnqueueLambda([RhSeconds, RhMs](FRHICommandListBase&)
+					{
+						const double T0 = FPlatformTime::Seconds();
+						FPlatformProcess::Sleep(RhSeconds);
+						*RhMs = (FPlatformTime::Seconds() - T0) * 1000.0;
+					});
+					RHICmdList.ImmediateFlush(EImmediateFlushType::FlushRHIThread);
+				});
+			FlushRenderingCommands();
+			PeakRhiMs = FMath::Max(PeakRhiMs, *RhMs);
+		}
+	}
+
+	// A thread counts as "hit" if it induced at least half the requested stall (tolerates scheduler slop).
+	const double MinExpectedMs = 0.5 * StallMs;
+	const bool bMatched = PerformanceVerdict::HitchMatchesExpect(Mode, PeakGameMs, PeakRenderMs, MinExpectedMs, PeakRhiMs);
+
+	R->SetNumberField(TEXT("frames"), EffectiveFrames);
+	if (EffectiveFrames < HitchFrames)
+	{
+		R->SetNumberField(TEXT("frames_requested"), HitchFrames);
+		R->SetStringField(TEXT("frames_note"), FString::Printf(
+			TEXT("Capped to %d frame(s) (~%.0f ms total) so the synchronous stall can't freeze the editor."),
+			EffectiveFrames, TotalCapMs));
+	}
+	R->SetNumberField(TEXT("stall_ms_per_frame"), StallMs);
+	if (bGame)   { R->SetNumberField(TEXT("observed_peak_game_ms"), PeakGameMs); }
+	if (bRender) { R->SetNumberField(TEXT("observed_peak_render_ms"), PeakRenderMs); }
+	if (bRhi)
+	{
+		R->SetBoolField(TEXT("rhi_threading"), bRhiThreaded);
+		if (bRhiThreaded)
+		{
+			R->SetNumberField(TEXT("observed_peak_rhi_ms"), PeakRhiMs);
+		}
+		else
+		{
+			R->SetStringField(TEXT("rhi_warning"), TEXT("RHI-threading is OFF — no separate RHI thread to stall, so no RHIThread verdict was induced. Re-run with RHI-threading on (r.RHIThread.Enable 1, or a platform where it's default) to validate the RHIThread bound."));
+		}
+	}
+	R->SetBoolField(TEXT("verdict_matched_expect"), bMatched);
+	if (!IsPIERunning())
+	{
+		R->SetStringField(TEXT("note"), TEXT("PIE is not running — the stall was still induced and measured directly on the editor frame, so verdict_matched_expect is valid. Start PIE for a game-representative FrameTiming reading."));
+	}
+	R->SetStringField(TEXT("hint"), TEXT("Validation is self-contained: 'verdict_matched_expect' compares the stall this call actually induced ('observed_peak_*_ms') against 'expect' — no follow-up FrameTiming needed (that read races the stall on the game thread and misses it)."));
+	return OkJson(R);
+}
+
+// ---------------------------------------------------------------------------
+// Report — render a self-contained HTML "printout" from the verdict + capture
+// ---------------------------------------------------------------------------
+
+// Verified UE 5.8 documentation URLs, linked per fix so the report tells you where to go next.
+namespace PerformanceDocs
+{
+	static const TCHAR* PsoPrecache = TEXT("https://dev.epicgames.com/documentation/en-us/unreal-engine/pso-precaching-for-unreal-engine");
+	static const TCHAR* PsoCaches   = TEXT("https://dev.epicgames.com/documentation/en-us/unreal-engine/optimizing-rendering-with-pso-caches-in-unreal-engine");
+	static const TCHAR* Profiling   = TEXT("https://dev.epicgames.com/documentation/en-us/unreal-engine/introduction-to-performance-profiling-and-configuration-in-unreal-engine");
+	static const TCHAR* StatCommands= TEXT("https://dev.epicgames.com/documentation/en-us/unreal-engine/stat-commands-in-unreal-engine");
+	static const TCHAR* Insights    = TEXT("https://dev.epicgames.com/documentation/en-us/unreal-engine/unreal-insights-in-unreal-engine");
+}
+
+// Escape text destined for HTML body/attributes (paths, log lines, verdict strings).
+static FString PerfHtmlEscape(const FString& In)
+{
+	FString Out = In;
+	Out.ReplaceInline(TEXT("&"), TEXT("&amp;"));
+	Out.ReplaceInline(TEXT("<"), TEXT("&lt;"));
+	Out.ReplaceInline(TEXT(">"), TEXT("&gt;"));
+	Out.ReplaceInline(TEXT("\""), TEXT("&quot;"));
+	return Out;
+}
+
+// One recommended fix, rendered as a numbered card: what/why + the exact commands + a doc link.
+struct FPerfFix
+{
+	FString Title;
+	FString Why;
+	FString How;      // concrete stat/console commands — shown in a mono block
+	FString DocUrl;
+	FString DocLabel;
+};
+
+// The report's stylesheet — inlined so the file is fully self-contained and opens anywhere. Mono headings,
+// teal "trace" accent, semantic good/warn/crit, and both light + dark themes driven by tokens.
+static const TCHAR* PerfReportCss = TEXT(R"CSS(<style>
+:root{--bg:#eef2f1;--surface:#fff;--surface-2:#f6f9f8;--ink:#13201e;--muted:#586b68;--border:#dde5e3;--border-strong:#c7d2d0;--accent:#0c9a8b;--accent-ink:#0a7c70;--good:#1c8f52;--good-bg:#1c8f5216;--warn:#b1780a;--warn-bg:#b1780a18;--crit:#cc453b;--crit-bg:#cc453b16;--mono:"SFMono-Regular","Cascadia Code","JetBrains Mono","Fira Code",Menlo,Consolas,monospace;--sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
+@media(prefers-color-scheme:dark){:root{--bg:#0c1312;--surface:#111b1a;--surface-2:#0f1817;--ink:#e7f0ee;--muted:#93a6a3;--border:#22302e;--border-strong:#2d3d3a;--accent:#3ad6c6;--accent-ink:#5ee0d2;--good:#45c07e;--good-bg:#45c07e1f;--warn:#e0a53c;--warn-bg:#e0a53c22;--crit:#ec6f63;--crit-bg:#ec6f6320}}
+*{box-sizing:border-box}
+body{margin:0}
+.wrap{background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.5;padding:clamp(20px,4vw,52px);-webkit-font-smoothing:antialiased}
+.sheet{max-width:960px;margin:0 auto}
+.eyebrow{font-family:var(--mono);font-size:12px;letter-spacing:.18em;text-transform:uppercase;color:var(--accent-ink);display:flex;align-items:center;gap:10px;margin:0 0 14px}
+.eyebrow::before{content:"";width:26px;height:2px;background:var(--accent);display:inline-block}
+h1{font-family:var(--mono);font-weight:650;font-size:clamp(24px,4vw,36px);letter-spacing:-.01em;line-height:1.1;margin:0 0 10px}
+.lede{font-size:15px;color:var(--muted);max-width:64ch;margin:0 0 30px}
+.tiles{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:14px;margin:0 0 30px}
+.tile{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:16px 18px;position:relative;overflow:hidden}
+.tile::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--tc,var(--accent))}
+.tile.good{--tc:var(--good)}.tile.warn{--tc:var(--warn)}.tile.crit{--tc:var(--crit)}
+.tile .k{font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);margin:0 0 8px}
+.tile .v{font-family:var(--mono);font-size:clamp(22px,3vw,29px);font-weight:650;line-height:1;font-variant-numeric:tabular-nums}
+.tile .v small{font-size:14px;font-weight:500;color:var(--muted);margin-left:3px}
+.tile .s{font-size:12.5px;color:var(--muted);margin:8px 0 0}
+thead th.rec{color:var(--accent-ink)}
+tbody td{vertical-align:top}
+.dim{font-weight:600;color:var(--ink);white-space:nowrap}
+.dim small{display:block;font-weight:400;font-family:var(--mono);font-size:10.5px;letter-spacing:.04em;color:var(--muted);margin-top:3px;text-transform:uppercase}
+td.warm,td.cold{color:var(--muted)}
+td.warm b,td.cold b{color:var(--ink);font-family:var(--mono);font-variant-numeric:tabular-nums;font-weight:600}
+td.rec-cell{color:var(--ink);border-left:1px solid var(--border)}
+td.rec-cell code,td.warm code,td.cold code{font-family:var(--mono);font-size:12px;background:var(--surface-2);border:1px solid var(--border);padding:1px 5px;border-radius:4px}
+.tag{display:inline-block;font-family:var(--mono);font-size:11px;font-weight:600;letter-spacing:.03em;padding:2px 7px;border-radius:5px;white-space:nowrap}
+.tag.hidden{color:var(--crit);background:var(--crit-bg)}
+.tag.caught{color:var(--good);background:var(--good-bg)}
+.tag.warn{color:var(--warn);background:var(--warn-bg)}
+h2{font-family:var(--mono);font-size:13px;letter-spacing:.1em;text-transform:uppercase;color:var(--accent-ink);margin:34px 0 14px}
+.card{background:var(--surface);border:1px solid var(--border);border-radius:12px;overflow:hidden}
+.table-scroll{overflow-x:auto}
+table{border-collapse:collapse;width:100%;min-width:520px;font-size:14px}
+thead th{text-align:left;font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);font-weight:600;padding:12px 16px;background:var(--surface-2);border-bottom:1px solid var(--border-strong);white-space:nowrap}
+tbody td{padding:11px 16px;border-bottom:1px solid var(--border);font-variant-numeric:tabular-nums}
+tbody tr:last-child td{border-bottom:none}
+tbody tr.bound td{background:var(--accent-wash,transparent)}
+.th-name{font-family:var(--mono);font-weight:600}
+.num{font-family:var(--mono)}
+.pill{display:inline-block;font-family:var(--mono);font-size:11px;font-weight:600;padding:2px 8px;border-radius:20px;white-space:nowrap}
+.pill.good{color:var(--good);background:var(--good-bg)}.pill.warn{color:var(--warn);background:var(--warn-bg)}.pill.crit{color:var(--crit);background:var(--crit-bg)}
+.fixes{display:flex;flex-direction:column;gap:14px;counter-reset:fx}
+.fix{counter-increment:fx;background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:18px 20px;display:grid;grid-template-columns:auto 1fr;gap:16px}
+.fix::before{content:counter(fx);font-family:var(--mono);font-weight:650;font-size:15px;color:var(--accent);width:30px;height:30px;display:grid;place-items:center;border:1px solid var(--border-strong);border-radius:8px;align-self:start}
+.fix .ft{font-weight:600;margin:0 0 4px}
+.fix .fw{color:var(--muted);font-size:13.5px;margin:0 0 12px}
+.fix .how-l{font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--accent-ink);margin:0 0 6px}
+.fix pre{font-family:var(--mono);font-size:12.5px;background:var(--surface-2);border:1px solid var(--border);border-radius:7px;padding:10px 12px;margin:0 0 12px;overflow-x:auto;color:var(--ink);white-space:pre-wrap}
+.fix a.doc{font-size:13px;color:var(--accent-ink);text-decoration:none;font-weight:600;border-bottom:1px solid var(--accent)}
+.fix a.doc:hover{opacity:.8}
+.guide{margin:20px 0 0;padding:16px 20px;border:1px dashed var(--border-strong);border-radius:12px;font-size:13.5px;color:var(--muted)}
+.guide b{color:var(--ink)}
+.worst{list-style:none;margin:0;padding:0;font-family:var(--mono);font-size:13px}
+.worst li{display:flex;justify-content:space-between;gap:14px;padding:8px 16px;border-bottom:1px solid var(--border);font-variant-numeric:tabular-nums}
+.worst li:last-child{border-bottom:none}
+.worst .fm{color:var(--muted)}
+footer{margin:28px 2px 0;font-family:var(--mono);font-size:11px;letter-spacing:.03em;color:var(--muted);display:flex;flex-wrap:wrap;gap:6px 18px}
+footer b{color:var(--ink);font-weight:600}
+a:focus-visible,.doc:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+</style>)CSS");
+
+FString UPerformanceService::Report(const FString& Title, const FString& Source, const FString& File)
+{
+	auto Deserialize = [](const FString& Json) -> TSharedPtr<FJsonObject>
+	{
+		TSharedPtr<FJsonObject> Obj;
+		TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
+		FJsonSerializer::Deserialize(Reader, Obj);
+		return Obj;
+	};
+	auto Num = [](const TSharedPtr<FJsonObject>& O, const TCHAR* K, double D = 0.0) -> double
+	{ double V = D; if (O.IsValid()) { O->TryGetNumberField(K, V); } return V; };
+	auto Str = [](const TSharedPtr<FJsonObject>& O, const TCHAR* K) -> FString
+	{ FString V; if (O.IsValid()) { O->TryGetStringField(K, V); } return V; };
+
+	// --- Gather: live verdict + budget, and the capture summary (best-effort) --------------------------
+	const TSharedPtr<FJsonObject> FT = Deserialize(FrameTiming(60.0f));
+	if (!FT.IsValid())
+	{
+		return ErrJson(TEXT("REPORT_NO_TIMING"), TEXT("FrameTiming returned no parseable data to report on."));
+	}
+	const TSharedPtr<FJsonObject>* BudgetPtr = nullptr;
+	FT->TryGetObjectField(TEXT("budget"), BudgetPtr);
+	const TSharedPtr<FJsonObject> Budget = BudgetPtr ? *BudgetPtr : nullptr;
+
+	const TSharedPtr<FJsonObject> AN = Deserialize(Analyse(Source, File));
+	const TSharedPtr<FJsonObject>* TracePtr = nullptr;
+	const TSharedPtr<FJsonObject>* LogsPtr  = nullptr;
+	if (AN.IsValid()) { AN->TryGetObjectField(TEXT("trace"), TracePtr); AN->TryGetObjectField(TEXT("logs"), LogsPtr); }
+	const TSharedPtr<FJsonObject> Trace = TracePtr ? *TracePtr : nullptr;
+	const TSharedPtr<FJsonObject> Logs  = LogsPtr  ? *LogsPtr  : nullptr;
+
+	const double GameMs   = Num(FT, TEXT("game_thread_ms"));
+	const double RenderMs = Num(FT, TEXT("render_thread_ms"));
+	const double RhiMs    = Num(FT, TEXT("rhi_thread_ms"));
+	const double GpuMs    = Num(FT, TEXT("gpu_ms"));
+	const double FrameMs  = Num(FT, TEXT("frame_ms"));
+	const double Fps      = Num(FT, TEXT("fps"));
+	const FString Bound   = Str(FT, TEXT("bound"));
+	const FString Conf    = Str(FT, TEXT("bound_confidence"));
+	const double BudgetMs = Num(Budget, TEXT("budget_ms"), 16.67);
+	const double TargetFps= Num(Budget, TEXT("target_fps"), 60.0);
+	const bool bMeets     = Budget.IsValid() && Budget->GetBoolField(TEXT("meets_target"));
+	const bool bPIE       = FT->GetBoolField(TEXT("pie_running"));
+
+	const bool bHasTrace = Trace.IsValid() && Num(Trace, TEXT("frame_count")) > 0.0;
+	const double MaxFrameMs = Num(Trace, TEXT("max_frame_ms"));
+	const double P95Ms      = Num(Trace, TEXT("p95_frame_ms"));
+	const int32  FrameCount = (int32)Num(Trace, TEXT("frame_count"));
+	const double AvgFps     = Num(Trace, TEXT("avg_fps"));
+	const double DurationS  = Num(Trace, TEXT("duration_seconds"));
+	const bool bHasLogs  = Logs.IsValid();
+	const int32 PsoHitches = (int32)Num(Logs, TEXT("pso_hitches"));
+	const int32 LogErrors  = (int32)Num(Logs, TEXT("errors"));
+	const int32 LogWarnings= (int32)Num(Logs, TEXT("warnings"));
+
+	// --- Build the "fix in this order" list from the data ---------------------------------------------
+	TArray<FPerfFix> Fixes;
+	if (bHasTrace && MaxFrameMs > 250.0)
+	{
+		Fixes.Add({
+			FString::Printf(TEXT("Startup / load hitch — %s ms peak frame"), *FString::FormatAsNumber((int64)MaxFrameMs)),
+			TEXT("A representative (cold-cache) run pays load, PSO and shader-compilation costs the editor's warm caches hide. This is almost always the single biggest stall a player feels."),
+			TEXT("# Ship a bundled PSO cache + keep precaching on (default):\nr.PSOPrecache.GlobalShaders 1\n# Then async-stream the opening level so the first frame isn't a hard stall."),
+			PerformanceDocs::PsoPrecache, TEXT("PSO Precaching — UE 5.8 docs") });
+	}
+	if (Bound == TEXT("GameThread"))
+	{
+		Fixes.Add({ TEXT("Game-thread bound — CPU logic cost"),
+			TEXT("Tick / Blueprint / AI / animation dominate the frame. Dropping resolution or GPU cost will not help a game-thread-bound frame."),
+			TEXT("stat dumpframe -ms=0.5 -root=gamethread\n# or capture with Unreal Insights, then cut the worst scopes:\n# throttle Tick, reduce ticking actors & AI, trim Blueprint tick logic."),
+			PerformanceDocs::StatCommands, TEXT("Stat Commands — UE 5.8 docs") });
+	}
+	else if (Bound == TEXT("RenderThread"))
+	{
+		Fixes.Add({ TEXT("Render-thread bound — scene setup cost"),
+			TEXT("Too many draw calls / primitives, or many dynamic shadow-casting lights, saturate render-thread scene setup."),
+			TEXT("stat scenerendering\n# Levers: merge/instance meshes, enable Nanite, cut dynamic lights & per-light shadows."),
+			PerformanceDocs::Profiling, TEXT("Performance Profiling — UE 5.8 docs") });
+	}
+	else if (Bound == TEXT("RHIThread"))
+	{
+		Fixes.Add({ TEXT("RHI-thread bound — GPU command submission"),
+			TEXT("The thread submitting GPU commands is the bottleneck, distinct from render-thread scene setup — usually too many draw calls / state changes."),
+			TEXT("stat rhi\nstat scenerendering\n# Levers: cut draw calls via merging / instancing / HISM, enable Nanite, reduce material & state permutations."),
+			PerformanceDocs::Profiling, TEXT("Performance Profiling — UE 5.8 docs") });
+	}
+	else if (Bound == TEXT("GPU"))
+	{
+		Fixes.Add({ TEXT("GPU bound — render cost"),
+			TEXT("The GPU is the bottleneck. Confirm with the resolution test: r.ScreenPercentage 50 should noticeably raise FPS if truly GPU-bound."),
+			TEXT("ProfileGPU\n# Levers: Virtual Shadow Maps, Lumen GI/reflections, translucency, post-process, ScreenPercentage."),
+			PerformanceDocs::Insights, TEXT("Unreal Insights — UE 5.8 docs") });
+	}
+	if (bHasLogs && PsoHitches > 0)
+	{
+		Fixes.Add({ FString::Printf(TEXT("%d PSO hitch%s — pipeline-state cache misses"), PsoHitches, PsoHitches == 1 ? TEXT("") : TEXT("es")),
+			TEXT("A PSO stalls the first time a shader/state combo is drawn. Gathering a bundled cache from a representative playthrough removes them."),
+			TEXT("# Enable PSO logging in a build, play a representative pass, then bundle the cache:\nr.ShaderPipelineCache.Enabled 1\nr.PSOPrecache.Components 1"),
+			PerformanceDocs::PsoCaches, TEXT("Optimizing Rendering with PSO Caches — UE 5.8 docs") });
+	}
+
+	// --- Compose the HTML -----------------------------------------------------------------------------
+	auto ConfClass = [](const FString& C) -> const TCHAR*
+	{ return C == TEXT("clear") ? TEXT("good") : (C == TEXT("none") ? TEXT("crit") : TEXT("warn")); };
+
+	FString H;
+	H.Reserve(16 * 1024);
+	H += FString::Printf(TEXT("<title>%s</title>"), *PerfHtmlEscape(Title));
+	H += PerfReportCss;
+	H += TEXT("<div class=\"wrap\"><div class=\"sheet\">");
+	H += FString::Printf(TEXT("<p class=\"eyebrow\">VibeUE Performance &middot; %s &middot; %s</p>"),
+		*PerfHtmlEscape(FApp::GetProjectName()), bPIE ? TEXT("PIE frame") : TEXT("Editor frame"));
+	H += FString::Printf(TEXT("<h1>%s</h1>"), *PerfHtmlEscape(Title));
+	H += FString::Printf(TEXT("<p class=\"lede\">Frame verdict and, where a capture is available, the representative frame stats — with a data-driven fix order. Generated %s.</p>"),
+		*PerfHtmlEscape(FDateTime::Now().ToString(TEXT("%Y-%m-%d %H:%M"))));
+
+	// Headline tiles: with a representative capture, frame them as the in-process-vs-representative contrast
+	// (warm reading vs the cold worst frame + p95); without one, fall back to the single-run KPIs.
+	H += TEXT("<div class=\"tiles\">");
+	if (bHasTrace)
+	{
+		const double Ratio = FrameMs > 0.0 ? (P95Ms / FrameMs) : 0.0;
+		H += FString::Printf(TEXT("<div class=\"tile warn\"><p class=\"k\">In-process (warm)</p><p class=\"v\">%.1f<small>ms</small></p><p class=\"s\">%.0f fps &middot; %s &middot; budget %s</p></div>"),
+			FrameMs, Fps, *PerfHtmlEscape(Bound.IsEmpty() ? TEXT("—") : Bound), bMeets ? TEXT("PASS") : TEXT("FAIL"));
+		H += FString::Printf(TEXT("<div class=\"tile crit\"><p class=\"k\">Worst frame (cold)</p><p class=\"v\">%s<small>ms</small></p><p class=\"s\">The frame-0 stall the warm reading hid.</p></div>"),
+			*FString::FormatAsNumber((int64)MaxFrameMs));
+		H += FString::Printf(TEXT("<div class=\"tile %s\"><p class=\"k\">Steady-state (p95)</p><p class=\"v\">%.0f<small>ms</small></p><p class=\"s\">~%.0f&times; the %.1f ms in-process frame.</p></div>"),
+			P95Ms > BudgetMs ? TEXT("crit") : TEXT("good"), P95Ms, Ratio, FrameMs);
+	}
+	else
+	{
+		H += FString::Printf(TEXT("<div class=\"tile %s\"><p class=\"k\">Frame</p><p class=\"v\">%.1f<small>ms</small></p><p class=\"s\">%.0f fps live</p></div>"),
+			FrameMs > BudgetMs ? TEXT("crit") : TEXT("good"), FrameMs, Fps);
+		H += FString::Printf(TEXT("<div class=\"tile %s\"><p class=\"k\">Bound</p><p class=\"v\" style=\"font-size:22px\">%s</p><p class=\"s\">%s confidence</p></div>"),
+			ConfClass(Conf), *PerfHtmlEscape(Bound.IsEmpty() ? TEXT("—") : Bound), *PerfHtmlEscape(Conf));
+		H += FString::Printf(TEXT("<div class=\"tile %s\"><p class=\"k\">Budget @ %.0f fps</p><p class=\"v\" style=\"font-size:22px\">%s</p><p class=\"s\">%.2f ms/frame budget</p></div>"),
+			bMeets ? TEXT("good") : TEXT("crit"), TargetFps, bMeets ? TEXT("PASS") : TEXT("FAIL"), BudgetMs);
+	}
+	H += TEXT("</div>");
+
+	// The full in-process vs representative matrix — only when a capture supplies the cold column. Numbers
+	// are live; the descriptive cells are the fixed teaching layer (the nature of warm-vs-cold doesn't change
+	// run to run).
+	if (bHasTrace)
+	{
+		const TCHAR* SteadyRec =
+			  Bound == TEXT("GameThread")   ? TEXT("Frame is <b>game-thread bound</b> &rarr; drill <code>stat dumpframe -root=gamethread</code> (Tick / BP / AI / anim)")
+			: Bound == TEXT("RenderThread") ? TEXT("Frame is <b>render-thread bound</b> &rarr; <code>stat scenerendering</code>; merge/instance meshes, cut dynamic lights")
+			: Bound == TEXT("RHIThread")    ? TEXT("Frame is <b>RHI-thread bound</b> &rarr; <code>stat rhi</code>; cut draw calls via instancing / HISM / Nanite")
+			: Bound == TEXT("GPU")          ? TEXT("Frame is <b>GPU bound</b> &rarr; <code>ProfileGPU</code>; shadows, Lumen, translucency, ScreenPercentage")
+			:                                 TEXT("Profile the bottleneck thread with Unreal Insights");
+
+		H += TEXT("<h2>In-process vs Representative</h2><div class=\"card table-scroll\"><table style=\"min-width:720px\">");
+		H += TEXT("<thead><tr><th>Dimension</th><th>In-process — warm</th><th>Representative — cold</th><th class=\"rec\">Where to improve</th></tr></thead><tbody>");
+		H += TEXT("<tr><td class=\"dim\">Process &amp; caches<small>environment</small></td><td class=\"warm\">Editor/PIE process, <b>warm</b> shader/PSO caches, on-demand cooked data</td><td class=\"cold\">Separate process, <b>cold</b> caches — like a shipping build</td><td class=\"rec-cell\">Trust the representative numbers for anything absolute; in-process is for logic checks</td></tr>");
+		H += FString::Printf(TEXT("<tr><td class=\"dim\">Startup hitch<small>the fixture</small></td><td class=\"warm\"><span class=\"tag hidden\">invisible</span></td><td class=\"cold\"><b>%s ms</b> @ frame 0 <span class=\"tag caught\">caught</span></td><td class=\"rec-cell\"><b>Biggest lever.</b> Load / PSO / shader-comp bound at boot — ship a PSO precache, warm the shader pipeline, async-stream the first level</td></tr>"),
+			*FString::FormatAsNumber((int64)MaxFrameMs));
+		H += FString::Printf(TEXT("<tr><td class=\"dim\">PSO hitches<small>pipeline stalls</small></td><td class=\"warm\">Not surfaced</td><td class=\"cold\"><b>%d</b> from <code>-logPSO</code>%s</td><td class=\"rec-cell\">Bundle a gathered PSO cache with the build — folds into the startup fix</td></tr>"),
+			PsoHitches, PsoHitches > 0 ? TEXT(" <span class=\"tag warn\">hitch</span>") : TEXT(""));
+		H += FString::Printf(TEXT("<tr class=\"bound\"><td class=\"dim\">Steady-state frame<small>hot path</small></td><td class=\"warm\"><b>%.1f ms</b> &middot; %s &middot; %.0f fps</td><td class=\"cold\"><b>p95 %.0f ms</b> &middot; avg <b>%.1f fps</b> &middot; %d frames</td><td class=\"rec-cell\">%s</td></tr>"),
+			FrameMs, *PerfHtmlEscape(Bound.IsEmpty() ? TEXT("—") : Bound), Fps, P95Ms, AvgFps, FrameCount, SteadyRec);
+		H += FString::Printf(TEXT("<tr><td class=\"dim\">Render thread<small>attribution</small></td><td class=\"warm\">Reads <b>%.1f ms</b> in-process</td><td class=\"cold\">Captured per-frame in the trace</td><td class=\"rec-cell\">Use a representative trace for render / RHI attribution — in-process render time is not shipping-accurate</td></tr>"),
+			RenderMs);
+		H += TEXT("<tr><td class=\"dim\">Bound verdict<small>CPU vs GPU</small></td><td class=\"warm\">Live — <code>FrameTiming</code> / <code>ForceHitch</code> self-measure</td><td class=\"cold\">Read via trace + <code>Analyse</code></td><td class=\"rec-cell\">In-process for the fast verdict + hitch self-validation; representative for <i>where</i> the ms goes</td></tr>");
+		H += TEXT("<tr><td class=\"dim\">Best use<small>role</small></td><td class=\"warm\">Quick sanity + verdict/hitch <b>logic</b> checks</td><td class=\"cold\"><b>Real stall identification</b> &amp; regression capture</td><td class=\"rec-cell\">Keep both — they answer different questions</td></tr>");
+		H += TEXT("</tbody></table></div>");
+	}
+
+	// Per-thread table
+	H += TEXT("<h2>Thread breakdown &middot; in-process frame</h2><div class=\"card table-scroll\"><table><thead><tr><th>Thread</th><th>ms</th><th>vs budget</th></tr></thead><tbody>");
+	struct FRow { const TCHAR* Name; double Ms; bool bShow; };
+	const FRow Rows[] = {
+		{ TEXT("Game"),   GameMs,   true },
+		{ TEXT("Render"), RenderMs, true },
+		{ TEXT("RHI"),    RhiMs,    RhiMs > 0.0 },
+		{ TEXT("GPU"),    GpuMs,    GpuMs > 0.0 },
+	};
+	for (const FRow& Rw : Rows)
+	{
+		if (!Rw.bShow) continue;
+		const bool bOver = Rw.Ms > BudgetMs;
+		const bool bIsBound = Bound.StartsWith(Rw.Name);
+		H += FString::Printf(TEXT("<tr%s><td class=\"th-name\">%s%s</td><td class=\"num\">%.2f</td><td>%s</td></tr>"),
+			bIsBound ? TEXT(" class=\"bound\"") : TEXT(""),
+			Rw.Name, bIsBound ? TEXT(" ◀") : TEXT(""),
+			Rw.Ms,
+			bOver ? TEXT("<span class=\"pill crit\">over</span>") : TEXT("<span class=\"pill good\">ok</span>"));
+	}
+	H += TEXT("</tbody></table></div>");
+
+	// Capture summary (trace worst frames + log health), when present
+	if (bHasTrace)
+	{
+		H += FString::Printf(TEXT("<h2>Representative capture &middot; %.0fs &middot; avg %.1f fps</h2>"), DurationS, AvgFps);
+		const TArray<TSharedPtr<FJsonValue>>* Worst = nullptr;
+		if (Trace->TryGetArrayField(TEXT("worst_frames"), Worst) && Worst)
+		{
+			H += TEXT("<div class=\"card\"><ul class=\"worst\">");
+			int32 Shown = 0;
+			for (const TSharedPtr<FJsonValue>& V : *Worst)
+			{
+				const TSharedPtr<FJsonObject> WO = V->AsObject();
+				if (!WO.IsValid()) continue;
+				H += FString::Printf(TEXT("<li><span class=\"fm\">frame %d</span><span>%s ms</span></li>"),
+					(int32)WO->GetNumberField(TEXT("frame")), *FString::FormatAsNumber((int64)WO->GetNumberField(TEXT("ms"))));
+				if (++Shown >= 6) break;
+			}
+			H += TEXT("</ul></div>");
+		}
+		if (bHasLogs)
+		{
+			H += FString::Printf(TEXT("<p class=\"lede\" style=\"margin-top:14px\">Log: %s errors, %s warnings, <b style=\"color:var(--ink)\">%d PSO hitch%s</b>.</p>"),
+				*FString::FormatAsNumber(LogErrors), *FString::FormatAsNumber(LogWarnings), PsoHitches, PsoHitches == 1 ? TEXT("") : TEXT("es"));
+		}
+	}
+	else
+	{
+		H += TEXT("<p class=\"lede\" style=\"margin-top:8px\">No capture analysed — run <b>StartStandalone</b> (or StartTrace → workload → StopTrace), then Report again for frame-level worst-case detail.</p>");
+	}
+
+	// Fix list
+	if (Fixes.Num() > 0)
+	{
+		H += TEXT("<h2>Fix in this order</h2><div class=\"fixes\">");
+		for (const FPerfFix& Fx : Fixes)
+		{
+			H += TEXT("<div class=\"fix\"><div>");
+			H += FString::Printf(TEXT("<p class=\"ft\">%s</p><p class=\"fw\">%s</p>"), *PerfHtmlEscape(Fx.Title), *PerfHtmlEscape(Fx.Why));
+			H += FString::Printf(TEXT("<p class=\"how-l\">How to fix</p><pre>%s</pre>"), *PerfHtmlEscape(Fx.How));
+			H += FString::Printf(TEXT("<a class=\"doc\" href=\"%s\">%s &rarr;</a>"), *Fx.DocUrl, *PerfHtmlEscape(Fx.DocLabel));
+			H += TEXT("</div></div>");
+		}
+		H += TEXT("</div>");
+		H += TEXT("<div class=\"guide\"><b>Want a walkthrough?</b> Ask your assistant to guide you through any fix above — it can run the commands, read the results back, and validate the change with ForceHitch.</div>");
+	}
+
+	H += FString::Printf(TEXT("<footer><span><b>Project:</b> %s</span>"), *PerfHtmlEscape(FApp::GetProjectName()));
+	if (bHasTrace) { H += FString::Printf(TEXT("<span><b>Capture:</b> %d frames / %.0fs</span>"), FrameCount, DurationS); }
+	H += FString::Printf(TEXT("<span><b>Generated:</b> %s</span><span><b>Tool:</b> VibeUE Performance — FrameTiming + Analyse</span></footer>"),
+		*PerfHtmlEscape(FDateTime::Now().ToString(TEXT("%Y-%m-%d %H:%M:%S"))));
+	H += TEXT("</div></div>");
+
+	// --- Write the self-contained file ----------------------------------------------------------------
+	const FString Dir = ProjectSavedDirAbs() / TEXT("VibeUE") / TEXT("Performance");
+	IPlatformFile::GetPlatformPhysical().CreateDirectoryTree(*Dir);
+	const FString Path = Dir / FString::Printf(TEXT("report_%s.html"), *FDateTime::Now().ToString(TEXT("%Y%m%d_%H%M%S")));
+	if (!FFileHelper::SaveStringToFile(H, *Path, FFileHelper::EEncodingOptions::ForceUTF8))
+	{
+		return ErrJson(TEXT("REPORT_WRITE_FAILED"), FString::Printf(TEXT("Could not write report to %s"), *Path));
+	}
+
+	TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+	R->SetStringField(TEXT("report_file"), Path);
+	R->SetNumberField(TEXT("fix_count"), Fixes.Num());
+	R->SetBoolField(TEXT("included_capture"), bHasTrace);
+	R->SetStringField(TEXT("bound"), Bound);
+	R->SetStringField(TEXT("hint"), FString::Printf(
+		TEXT("Self-contained HTML written. Open it in any browser or screenshot it to share: %s"), *Path));
 	return OkJson(R);
 }
 
@@ -537,11 +1170,20 @@ FString UPerformanceService::StartStandalone(const FString& Name, const FString&
 	const FString ChannelSet = Channels.IsEmpty() ? FString(DefaultTraceChannels()) : Channels;
 	FString TracePath = BuildTraceFilePath(TraceName);
 	GLastTraceFilePath = TracePath + TEXT(".utrace");
-	GLastLogFilePath   = ProjectSavedDirAbs() / TEXT("Logs") / (FApp::GetProjectName() + FString(TEXT(".log")));
+
+	// Give the standalone process its own timestamped log via -abslog, rather than sharing the
+	// project's default <Project>.log. That file is held open by the running editor, so LoadFileToString
+	// fails on it (surfacing as a misleading LOG_NOT_FOUND) and a "newest log in the folder" guess picks
+	// the editor's live log instead of the standalone's. A dedicated, unique path is unlocked and exact.
+	FString LogDir = ProjectSavedDirAbs() / TEXT("Logs");
+	IPlatformFile::GetPlatformPhysical().CreateDirectoryTree(*LogDir);
+	FString StandaloneLogPath = LogDir / FString::Printf(TEXT("%s_%s.log"),
+		*TraceName, *FDateTime::Now().ToString(TEXT("%Y%m%d_%H%M%S")));
+	GLastLogFilePath = StandaloneLogPath;
 
 	FString ExtraArgs = FString::Printf(
-		TEXT("-tracehost=127.0.0.1 -trace=%s -tracefile=\"%s\""),
-		*ChannelSet, *TracePath);
+		TEXT("-tracehost=127.0.0.1 -trace=%s -tracefile=\"%s\" -abslog=\"%s\""),
+		*ChannelSet, *TracePath, *StandaloneLogPath);
 
 	FRequestPlaySessionParams P;
 	P.SessionDestination = EPlaySessionDestinationType::NewProcess;
@@ -597,25 +1239,9 @@ FString UPerformanceService::StopStandalone()
 	FString UTSTrace = FindLatestUTSTrace();
 	if (!UTSTrace.IsEmpty()) GLastTraceFilePath = UTSTrace;
 
-	{
-		FString LogDir = ProjectSavedDirAbs() / TEXT("Logs");
-		FString NewestLog;
-		FDateTime NewestTime = FDateTime::MinValue();
-		IFileManager::Get().IterateDirectory(*LogDir, [&](const TCHAR* Path, bool bDir) -> bool
-		{
-			if (!bDir && FPaths::GetExtension(Path).Equals(TEXT("log"), ESearchCase::IgnoreCase))
-			{
-				FString Fname = FPaths::GetCleanFilename(Path);
-				if (!Fname.Contains(TEXT("backup")) && !Fname.Contains(TEXT("cef")))
-				{
-					FDateTime T = IFileManager::Get().GetTimeStamp(Path);
-					if (T > NewestTime) { NewestTime = T; NewestLog = Path; }
-				}
-			}
-			return true;
-		});
-		if (!NewestLog.IsEmpty()) GLastLogFilePath = NewestLog;
-	}
+	// GLastLogFilePath was set to a dedicated timestamped file in StartStandalone (-abslog), so it is
+	// already the standalone's own log — no need to guess the newest log in the folder (which would
+	// pick the editor's live, locked log).
 
 	TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
 	R->SetStringField(TEXT("status"),     TEXT("standalone stop requested"));
@@ -632,5 +1258,35 @@ FString UPerformanceService::GetStandaloneStatus()
 	R->SetBoolField(TEXT("running"), GStandaloneRunning);
 	R->SetStringField(TEXT("last_trace_file"), GLastTraceFilePath);
 	R->SetStringField(TEXT("last_log_file"),   GLastLogFilePath);
+	return OkJson(R);
+}
+
+FString UPerformanceService::StartPIE()
+{
+	if (!GEditor) return ErrJson(TEXT("NO_EDITOR"), TEXT("GEditor not available."));
+	if (IsPIERunning()) return ErrJson(TEXT("ALREADY_RUNNING"), TEXT("PIE is already running. Call StopPIE first."));
+
+	FRequestPlaySessionParams P;
+	P.SessionDestination = EPlaySessionDestinationType::InProcess;   // in-process, unlike StartStandalone's NewProcess
+	P.WorldType          = EPlaySessionWorldType::PlayInEditor;
+	GEditor->RequestPlaySession(P);
+
+	TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+	R->SetStringField(TEXT("status"), TEXT("PIE start requested"));
+	R->SetStringField(TEXT("note"),   TEXT("PIE starts on the next editor tick — call FrameTiming on a FOLLOWING frame (pie_running flips true). Because PIE is IN-PROCESS, ForceHitch game/render stalls now land and FrameTiming reads the live game world."));
+	R->SetStringField(TEXT("caveat"), TEXT("PIE is NOT representative for real stall identification — it reuses the editor's warm shader/PSO caches and on-demand cooked data, hiding costs a standalone/shipping build pays. For trustworthy stall numbers use StartStandalone."));
+	R->SetStringField(TEXT("hint"),   TEXT("StartTrace before your workload if you want a capture, then StopPIE and Analyse."));
+	return OkJson(R);
+}
+
+FString UPerformanceService::StopPIE()
+{
+	if (!GEditor) return ErrJson(TEXT("NO_EDITOR"), TEXT("GEditor not available."));
+	if (!IsPIERunning()) return ErrJson(TEXT("NOT_RUNNING"), TEXT("PIE is not running."));
+	GEditor->RequestEndPlayMap();
+
+	TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+	R->SetStringField(TEXT("status"), TEXT("PIE end requested"));
+	R->SetStringField(TEXT("hint"),   TEXT("PIE tears down on the next tick. If you were tracing, StopTrace then Analyse."));
 	return OkJson(R);
 }

--- a/Source/VibeUE/Private/PythonAPI/UPerformanceTriageSkill.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UPerformanceTriageSkill.cpp
@@ -1,0 +1,45 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#include "PythonAPI/UPerformanceTriageSkill.h"
+
+UPerformanceTriageSkill::UPerformanceTriageSkill()
+{
+	// Shown in ListSkills — keep it one line so the assistant can decide whether to open the skill.
+	Description = TEXT(
+		"Frame-rate triage & validation: determine whether the game is CPU (game/render) or GPU bound "
+		"BEFORE optimising, gate against an FPS budget, capture Unreal Insights traces, and validate the "
+		"verdict with deliberately forced hitches.");
+
+	// Read via GetSkills -> GetDetails(). This is the strategy the per-tool descriptions can't carry.
+	Instructions = FString(
+		TEXT("VibeUE's performance tools answer 'am I CPU- or GPU-bound?' and drive Insights traces. All tools return a JSON string.\n")
+		TEXT("\n")
+		TEXT("# Golden rule\n")
+		TEXT("ALWAYS call frame_timing FIRST. Optimising the GPU is wasted effort if the frame is game- or render-thread bound, and vice-versa. Never start a trace or suggest a fix before you know the `bound` thread.\n")
+		TEXT("\n")
+		TEXT("# 1. Triage: frame_timing(target_fps=60)\n")
+		TEXT("Read these fields:\n")
+		TEXT("- `bound`: GameThread | RenderThread | RHIThread | GPU — the bottleneck thread.\n")
+		TEXT("- `bound_confidence`: clear | moderate | marginal | none. Trust `clear`; be cautious below it.\n")
+		TEXT("- `contested` / `contested_with`: when true the top two threads are within ~10% — frame-to-frame noise can flip the winner. Treat BOTH as bottlenecks; take several readings or trace both.\n")
+		TEXT("- `gpu_ms == 0`: GPU timing was unavailable, so a CPU verdict is UNCONFIRMED. Confirm with the resolution test: `r.ScreenPercentage 50` should noticeably raise FPS if truly GPU-bound.\n")
+		TEXT("- `budget`: per-thread headroom + PASS/FAIL against target_fps. Gate CI/perf checks on `budget.meets_target`; read each thread's `over_budget` to see which one blew the budget.\n")
+		TEXT("- `pie_running`: if false you are reading the EDITOR viewport, NOT the game. Start PIE (start_pie, or use start_standalone) and park in a representative/worst spot before trusting numbers.\n")
+		TEXT("\n")
+		TEXT("# 2. Act on the verdict\n")
+		TEXT("- bound == GPU: NOW profile the GPU. start_trace(channels 'frame,gpu,cpu') -> reproduce -> stop_trace -> analyse; or 'ProfileGPU'. Levers: shadows (Virtual Shadow Maps), Lumen, translucency, post-process, ScreenPercentage.\n")
+		TEXT("- bound == RenderThread: too many draw calls / primitives or dynamic shadow-casting lights. Check 'stat scenerendering'. Levers: merge/instance meshes, Nanite, cut dynamic lights. Dropping r.ScreenPercentage will NOT help.\n")
+		TEXT("- bound == RHIThread: GPU command submission is the bottleneck. Check 'stat rhi'. Levers: cut draw calls via instancing / HISM / Nanite, reduce material & state permutations. Dropping r.ScreenPercentage will NOT help.\n")
+		TEXT("- bound == GameThread: Tick / Blueprint / AI / animation cost. Run 'stat dumpframe -ms=0.5 -root=gamethread' on the PIE world. Levers: throttle Tick, fewer ticking actors/AI, cut expensive BP tick. Dropping r.ScreenPercentage will NOT help.\n")
+		TEXT("\n")
+		TEXT("# 3. Capture a trace for detail\n")
+		TEXT("start_trace -> reproduce the workload -> stop_trace -> analyse('both'). Use bookmark / region_start / region_end to mark points of interest. For a representative reading prefer start_standalone (a separate game process) over the bare editor. Render a shareable HTML printout with report().\n")
+		TEXT("\n")
+		TEXT("# 4. Validate the verdict (force_hitch)\n")
+		TEXT("force_hitch deliberately stalls a KNOWN thread so you can confirm frame_timing reports it correctly. The CPU paths (game/render/both) self-measure and return `observed_peak_*_ms` + `verdict_matched_expect` in the SAME response — validate from that, do NOT follow up with frame_timing (that read races the stall and misses it). The gpu path is async, so for it read frame_timing on a following frame and compare against `expect`:\n")
+		TEXT("- force_hitch('game', 250)   -> expect bound == GameThread\n")
+		TEXT("- force_hitch('render', 250) -> expect bound == RenderThread\n")
+		TEXT("- force_hitch('both', 250)   -> expect contested == true\n")
+		TEXT("- force_hitch('gpu')         -> expect bound == GPU (scene-dependent; supersamples via r.ScreenPercentage, auto-restored)\n")
+		TEXT("Use frames>1 to sustain the hitch and reproduce jitter rather than a single spike.\n"));
+}

--- a/Source/VibeUE/Public/PythonAPI/UPerformanceService.h
+++ b/Source/VibeUE/Public/PythonAPI/UPerformanceService.h
@@ -16,7 +16,7 @@
  *
  * Recommended flow: FrameTiming() FIRST (CPU vs GPU bound verdict) → StartTrace → reproduce the
  * workload → StopTrace → Analyse. For a representative reading, profile under PIE or a standalone
- * session, not the bare editor viewport. Methods return a JSON string (typed result structs TBD).
+ * session, not the bare editor viewport. Methods return a JSON string.
  */
 UCLASS(BlueprintType)
 class VIBEUE_API UPerformanceService : public UToolsetDefinition
@@ -28,9 +28,58 @@ public:
 	 * Report Game/Render/GPU/RHI thread ms + a CPU-vs-GPU bound verdict and hint for the most recently
 	 * rendered frame (the same data as the on-screen "stat unit"). RUN THIS FIRST in any frame-rate
 	 * investigation — optimising the GPU does nothing if the frame is game- or render-thread bound.
+	 *
+	 * The verdict is robust: when the top two threads are within a small margin it reports the frame as
+	 * "contested" with a confidence level rather than declaring a false winner, and it flags when GPU
+	 * timing is unavailable (gpu_ms == 0) so you don't trust a CPU verdict that GPU could overturn.
+	 *
+	 * Also reports a per-thread budget breakdown against a target frame rate: each thread's headroom
+	 * against the per-frame budget and a pass/fail gate, so the same call that triages can also guard.
+	 * @param TargetFPS Frame-rate budget to gate against (e.g. 60, 120). Defaults to 60.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Performance")
-	static FString FrameTiming();
+	static FString FrameTiming(float TargetFPS = 60.0f);
+
+	/**
+	 * TEST/VALIDATION HELPER — deliberately induce a frame hitch on a chosen thread to verify that
+	 * FrameTiming's verdict, budget gate and contested detection fire correctly against a KNOWN ground truth.
+	 *
+	 *   Thread = "game"   -> stall the game thread   `Milliseconds` ms/frame  (expect bound=GameThread)
+	 *   Thread = "render" -> stall the render thread `Milliseconds` ms/frame  (expect bound=RenderThread)
+	 *   Thread = "both"   -> stall game AND render by the same amount         (expect contested=true)
+	 *   Thread = "gpu"    -> supersample via r.ScreenPercentage to force GPU cost, auto-restored after
+	 *                        `Frames` frames (scene-dependent best-effort; `Milliseconds` is ignored).
+	 *
+	 * The CPU paths (game/render/both) are SELF-MEASURING and race-free: the stall is applied
+	 * synchronously inside the call and timed directly, so the response carries `observed_peak_game_ms` /
+	 * `observed_peak_render_ms` and a `verdict_matched_expect` bool. Validate from THIS single response —
+	 * do NOT follow up with FrameTiming, whose read runs on the game thread the stall blocks and reliably
+	 * lands on a clean frame. The gpu path is async (cost persists across frames), so for it alone read
+	 * FrameTiming on a following frame and confirm `expect`. Total CPU blocking is capped (~10 s) for safety.
+	 *
+	 * @param Thread       "game" (default), "render", "both", or "gpu".
+	 * @param Milliseconds Stall size per frame for the CPU threads. Clamped to [1, 5000]. Ignored for gpu.
+	 * @param Frames       Consecutive frames to sustain the hitch. Clamped to [1, 600]; CPU frames further
+	 *                     capped so total synchronous stall stays under ~10 s. Use >1 to simulate jitter.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Performance")
+	static FString ForceHitch(const FString& Thread = TEXT("game"), float Milliseconds = 250.0f, int32 Frames = 1);
+
+	/**
+	 * Render a self-contained HTML performance report from the current verdict and the most recent capture,
+	 * and write it to <Project>/Saved/VibeUE/Performance/report_<timestamp>.html — a shareable "printout" you
+	 * can open in any browser, screenshot, or hand to the team. Pulls the live FrameTiming verdict + budget and
+	 * (when a trace/log is available) the Analyse frame stats, worst frames and PSO hitches, then builds a
+	 * data-driven "fix in this order" list — each fix carries the concrete stat/console commands to run and
+	 * a link to the matching Unreal Engine docs. No external assets (CSS is inlined), so the file is portable.
+	 *
+	 * @param Title  Heading for the report. Defaults to "VibeUE Performance Report".
+	 * @param Source "trace", "logs", or "both" (default) — which capture to summarise, same as Analyse.
+	 * @param File   Optional trace/log override; empty uses the last trace started/stopped.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Performance")
+	static FString Report(const FString& Title = TEXT("VibeUE Performance Report"),
+	                      const FString& Source = TEXT("both"), const FString& File = TEXT(""));
 
 	/**
 	 * Start an Unreal Insights trace to file.
@@ -83,4 +132,23 @@ public:
 	/** Report whether a standalone session is running and which trace/log it is writing. */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Performance")
 	static FString GetStandaloneStatus();
+
+	/**
+	 * Start Play-In-Editor IN-PROCESS (inside the editor's own process) so FrameTiming and ForceHitch
+	 * read the live PIE game world. This is what makes the in-process CPU-hitch validation land:
+	 * ForceHitch's game/render stalls only take effect when a game world is actually ticking.
+	 *
+	 * PREFER StartStandalone for real stall identification. PIE is NOT representative — it shares the
+	 * editor's already-warm shader/PSO caches and on-demand cooked data, so it hides costs a standalone
+	 * or shipping build actually pays. Use PIE for quick in-process checks and for validating the
+	 * verdict/hitch logic against a live world; use Standalone when the numbers have to be trusted.
+	 *
+	 * PIE starts on the next editor tick, so read FrameTiming on a FOLLOWING frame (pie_running flips true).
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Performance")
+	static FString StartPIE();
+
+	/** Stop the in-process Play-In-Editor session started with StartPIE. Tears down on the next tick. */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Performance")
+	static FString StopPIE();
 };

--- a/Source/VibeUE/Public/PythonAPI/UPerformanceTriageSkill.h
+++ b/Source/VibeUE/Public/PythonAPI/UPerformanceTriageSkill.h
@@ -1,0 +1,26 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "ToolsetRegistry/AgentSkill.h"
+#include "UPerformanceTriageSkill.generated.h"
+
+/**
+ * Native AgentSkill that teaches the AI assistant HOW to use VibeUE's performance tools — the strategy
+ * layer on top of the per-tool descriptions on UPerformanceService. Ships with the plugin: because
+ * ToolsetRegistry discovers skills by scanning UAgentSkill subclasses (native classes included) and the
+ * default allow/block lists are empty, this is auto-registered on plugin load with zero project setup. It
+ * shows up in ListSkills and the assistant reads its Instructions via GetSkills.
+ *
+ * Description/Instructions are set on the CDO in the constructor, which is exactly what the read path
+ * (UAgentSkillToolset::ListSkills / GetSkills) inspects.
+ */
+UCLASS()
+class UPerformanceTriageSkill : public UAgentSkill
+{
+	GENERATED_BODY()
+
+public:
+	UPerformanceTriageSkill();
+};


### PR DESCRIPTION
Grows `UPerformanceService` from a frame-timing/trace-capture wrapper into a full CPU-vs-GPU triage toolset (15 `AICallable` tools). The goal is that an AI assistant can answer *"why is this project slow, and what do I fix first?"* without a human reading Insights by hand — and that its answer is **provably correct**, not a plausible guess.

## What's new

**`FrameTiming(TargetFPS = 60)` — an honest verdict, not a coin flip.**
The old version picked whichever thread had the biggest number. That silently lies on frames where two threads are within noise of each other. It now reports a `confidence` level, marks the frame `contested` when the top two threads tie inside a margin rather than declaring a false winner, treats **RHIThread as a distinct bottleneck** (it was previously invisible), and flags when GPU timing is unavailable (`gpu_ms == 0`) so a CPU verdict that GPU could overturn isn't taken at face value. The same call also returns a **per-thread budget gate** against `TargetFPS` — headroom and pass/fail per thread — so the tool that triages can also guard in CI.

**`ForceHitch(Thread, Milliseconds, Frames)` — ground truth for the verdict.**
Deliberately stalls a known thread (`game` / `render` / `both` / `rhi` / `gpu`) so the verdict can be checked against something we *know* the answer to. The CPU/RHI paths are self-measuring and race-free: the stall is applied synchronously inside the call and timed there, so the response carries `observed_peak_game_ms` / `observed_peak_render_ms` and a `verdict_matched_expect` bool in one shot. That matters — a follow-up `FrameTiming` would read on the very game thread the stall blocks and reliably land on a clean frame, which is exactly the trap this API is shaped to avoid. Total synchronous blocking is capped at ~10 s; `Milliseconds` clamps to [1, 5000] and `Frames` to [1, 600].

**`Report(Title, Source, File)` — a shareable printout.**
Renders a self-contained HTML report (CSS inlined, no external assets) to `Saved/VibeUE/Performance/report_<timestamp>.html`: live verdict + budget, capture summary, worst frames, PSO hitches, and a data-driven *"fix in this order"* list where each entry carries the concrete `stat`/console commands to run and a link to the matching UE docs. Open it in a browser, screenshot it, hand it to the team.

**`StartPIE()` / `StopPIE()` — in-process PIE.**
`ForceHitch`'s game/render stalls only take effect when a game world is actually ticking, so validating the logic needs a live world inside the editor's own process. The tool descriptions are explicit that **PIE is not representative** for real stall identification — it shares the editor's warm shader/PSO caches and on-demand cooked data — and steer toward `StartStandalone` when the numbers have to be trusted.

## Structure

Pure verdict/budget logic lives in `PerformanceVerdict.h` — header-only and free of engine globals — so `FrameTiming` and the automation tests exercise **one** implementation rather than a test copy that can drift from the shipping path.

`UPerformanceTriageSkill` is a native `UAgentSkill` carrying the triage playbook (run `FrameTiming` first; optimising the GPU does nothing on a game-thread-bound frame). Because `ToolsetRegistry` discovers skills by scanning `UAgentSkill` subclasses and the default allow/block lists are empty, it auto-registers on plugin load with zero project setup.

## Test gate

Three independent passes, all green.

1. **Strict clean build** (warnings-as-errors, UE 5.8) on two separate projects.
2. **14/14 headless automation tests** — `VibeUE.Performance.*`, added in `PerformanceServiceTests.cpp`. These cover the verdict logic directly: contested ties, confidence bands, the `gpu_ms == 0` unavailability flag, RHIThread selection, and the budget gate at several target frame rates.
3. **Full live systems test** on a clean FAB-style install in a second project, editor running, driven over MCP: **15/15 tools exercised, 4/4 ground-truth hitch verdicts correct, 0 failures.** This included the live **RHIThread** path, which `-nullrhi` structurally cannot prove — a real RHI thread (`rhi_threading: true`) with a 251 ms induced stall, correctly attributed. Also covered PIE, standalone and trace lifecycles end-to-end, HTML report generation, and a broad surface smoke of the rest of the service.

The reason for pass 3 is that the interesting failure modes here — races between the stall and the read, RHIThread attribution, PIE world liveness — are precisely the ones a headless test cannot observe. The automation tests guard the logic; the live run guards the plumbing.

## Compatibility

`FrameTiming()` gains a defaulted `TargetFPS` parameter, so existing call sites are unaffected. Everything else is additive. Six files, +1360/−40, no changes outside `PythonAPI/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
