### PR TITLE
Add Linux editor build support

### DIFF
--- a/BuildAndLaunchGame.sh
+++ b/BuildAndLaunchGame.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Build and launch an Unreal Engine project on Linux. This script may live anywhere in the project tree.
+set -euo pipefail
+
+mode="Development"
+engine_root="${UE_ENGINE_ROOT:-}"
+clean=false
+skip_build=false
+strict_rebuild=false
+
+usage() {
+    cat <<'EOF'
+Usage: BuildAndLaunchGame.sh [options]
+
+Options:
+  --engine PATH        Unreal Engine root. Defaults to $UE_ENGINE_ROOT.
+  --mode NAME          Build configuration (default: Development).
+  --clean              Remove project and plugin build artifacts before building.
+  --strict-rebuild     Remove this plugin's build artifacts before building.
+  --skip-build         Launch without building.
+  -h, --help           Show this help.
+EOF
+}
+
+while (($#)); do
+    case "$1" in
+        --engine) engine_root="$2"; shift 2 ;;
+        --mode) mode="$2"; shift 2 ;;
+        --clean) clean=true; shift ;;
+        --strict-rebuild) strict_rebuild=true; shift ;;
+        --skip-build) skip_build=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+search_dir="$script_dir"
+project_path=""
+while [[ "$search_dir" != "/" ]]; do
+    shopt -s nullglob
+    projects=("$search_dir"/*.uproject)
+    shopt -u nullglob
+    if ((${#projects[@]})); then
+        project_path="${projects[0]}"
+        break
+    fi
+    search_dir="$(dirname -- "$search_dir")"
+done
+
+if [[ -z "$project_path" ]]; then
+    echo "ERROR: No .uproject file found above $script_dir" >&2
+    exit 1
+fi
+
+if [[ -z "$engine_root" ]]; then
+    echo "ERROR: Set UE_ENGINE_ROOT or pass --engine /path/to/UE5." >&2
+    exit 1
+fi
+
+engine_root="$(cd -- "$engine_root" && pwd -P)"
+build_script="$engine_root/Engine/Build/BatchFiles/Linux/Build.sh"
+editor_bin="$engine_root/Engine/Binaries/Linux/UnrealEditor"
+if [[ ! -x "$build_script" || ! -x "$editor_bin" ]]; then
+    echo "ERROR: $engine_root does not contain executable Linux Build.sh and UnrealEditor binaries." >&2
+    exit 1
+fi
+
+project_root="$(dirname -- "$project_path")"
+project_name="$(basename -- "${project_path%.uproject}")"
+
+stop_editor() {
+    local pids
+    pids="$(pgrep -f -- "UnrealEditor.*$project_path" || true)"
+    [[ -z "$pids" ]] && return
+
+    echo "Stopping the running editor for $project_name..."
+    kill $pids 2>/dev/null || true
+    for _ in {1..15}; do
+        sleep 1
+        pids="$(pgrep -f -- "UnrealEditor.*$project_path" || true)"
+        [[ -z "$pids" ]] && return
+    done
+    echo "Editor did not exit gracefully; terminating it."
+    kill -KILL $pids 2>/dev/null || true
+}
+
+remove_artifacts() {
+    local path
+    for path in "$@"; do
+        [[ -e "$path" ]] && rm -rf -- "$path"
+    done
+}
+
+echo "=== $project_name Linux Build and Launch ==="
+echo "Project: $project_path"
+echo "Engine:  $engine_root"
+echo "Mode:    $mode"
+
+stop_editor
+
+if [[ "$clean" == true ]]; then
+    remove_artifacts "$project_root/Binaries" "$project_root/Intermediate"
+    while IFS= read -r -d '' plugin_dir; do
+        remove_artifacts "$plugin_dir/Binaries" "$plugin_dir/Intermediate"
+    done < <(find "$project_root/Plugins" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
+elif [[ "$strict_rebuild" == true ]]; then
+    remove_artifacts "$script_dir/Binaries" "$script_dir/Intermediate"
+fi
+
+if [[ "$skip_build" == false ]]; then
+    "$build_script" "${project_name}Editor" Linux "$mode" "$project_path" -waitmutex
+fi
+
+exec "$editor_bin" "$project_path"

--- a/Content/samples/AGENTS.md.sample
+++ b/Content/samples/AGENTS.md.sample
@@ -186,6 +186,8 @@ When asked to rebuild / relaunch / test, use the project script — not manual `
 - `./Plugins/VibeUE/BuildAndLaunchGame.ps1` (stops the editor, builds, relaunches).
 - `-StrictRebuild` for a full plugin recompile under warnings-as-errors; `-Clean` to wipe artifacts;
   `-SkipBuild` to relaunch only.
+- On Linux: `./Plugins/VibeUE/BuildAndLaunchGame.sh --engine /path/to/UE5`.
+  Use `--strict-rebuild`, `--clean`, or `--skip-build` for the corresponding operations.
 
 ---
 

--- a/FAB-Checklist.md
+++ b/FAB-Checklist.md
@@ -46,7 +46,7 @@ _Last verified: 2026-06-21 against the `5-8` branch (UE 5.8)._
 
 ### .uplugin Configuration
 - [x] `EngineVersion` = **"5.8.0"**
-- [x] `WhitelistPlatforms` = Win64 (matches Supported Target Platforms)
+- [x] `WhitelistPlatforms` = Win64 + Linux (matches supported target platforms)
 - [x] `FabURL` set with Listing ID
 - [x] `DocsURL`, `SupportURL`, `CreatedByURL` populated (vibeue.com) — confirm `/support` resolves
 - [x] `Resources/Icon128.png` present (128×128) — placeholder lettermark; swap for final art if desired
@@ -76,7 +76,7 @@ _Last verified: 2026-06-21 against the `5-8` branch (UE 5.8)._
 ### ✅ Passing
 - All shipped text accurate and in English (descriptions + .uplugin updated for 5.8)
 - Plugin file structure correct; no unused assets (orphan header removed)
-- Engine version 5.8 supported; platform Win64
+- Engine version 5.8 supported; platforms Win64 and Linux
 - Documentation accessible (README.md + Resources/ + AGENTS.md.sample)
 - No offensive content; no redistributed Epic/Megascans content
 - EngineVersion + WhitelistPlatforms + FabURL configured

--- a/FAB-DESCRIPTION.md
+++ b/FAB-DESCRIPTION.md
@@ -41,4 +41,4 @@ VibeUE works without a key. A free API key (grab one at vibeue.com/login, set it
 • Free API key: https://www.vibeue.com/login
 
 
-Requirements: Win64 · Unreal Engine 5.8+ · Unreal's native MCP stack enabled (Unreal MCP, Toolset Registry, Editor Tools). VibeUE auto-enables the engine plugins its services need: Python Script Plugin, EditorScriptingUtilities, Enhanced Input, Niagara, MetaSound, MeshModelingToolset, ModelViewViewModel, StateTree, GameplayTagsEditor, plus ToolsetRegistry and ModelContextProtocol.
+Requirements: Win64 or Linux · Unreal Engine 5.8+ · Unreal's native MCP stack enabled (Unreal MCP, Toolset Registry, Editor Tools). VibeUE auto-enables the engine plugins its services need: Python Script Plugin, EditorScriptingUtilities, Enhanced Input, Niagara, MetaSound, MeshModelingToolset, ModelViewViewModel, StateTree, GameplayTagsEditor, plus ToolsetRegistry and ModelContextProtocol.

--- a/FAB_Tech_Details.md
+++ b/FAB_Tech_Details.md
@@ -1,7 +1,7 @@
 MCP Expansion + AI Editor Toolset for Unreal Engine 5.8+. Plugs into UE5.8's native MCP server, ToolsetRegistry, and AgentSkill system. 
 
 
-Module — VibeUE (Editor type), 105 C++ source files. Platform: Win64. Engine: UE 5.8+.
+Module — VibeUE (Editor type), 105 C++ source files. Platforms: Win64, Linux. Engine: UE 5.8+.
 
 
 Prerequisites — enable Unreal's native MCP stack and start the MCP server, then point your MCP agent at the endpoint.

--- a/README.md
+++ b/README.md
@@ -126,10 +126,15 @@ Epic's guide: **[Unreal MCP in the Unreal Editor](https://dev.epicgames.com/docu
 cd /path/to/YourProject/Plugins
 git clone https://github.com/kevinpbuckley/VibeUE.git
 ```
-Build with the project script (don't run `Build.bat` directly):
+Build with the project script:
 ```
 Plugins/VibeUE/BuildAndLaunchGame.ps1                  # builds + launches the editor
 Plugins/VibeUE/BuildAndLaunchGame.ps1 -StrictRebuild   # full recompile (warnings-as-errors)
+```
+On Linux, use:
+```bash
+Plugins/VibeUE/BuildAndLaunchGame.sh --engine /path/to/UE5
+Plugins/VibeUE/BuildAndLaunchGame.sh --engine /path/to/UE5 --strict-rebuild
 ```
 Then **Edit → Plugins** → enable **VibeUE** and restart. Its services, tools, and skills now register
 onto the same endpoint, alongside the engine's own.

--- a/Resources/BUILD_PLUGIN.md
+++ b/Resources/BUILD_PLUGIN.md
@@ -101,18 +101,15 @@ To verify the plugin works after building:
 
 ## Platform Support
 
-Currently, the build script supports:
-- ✅ Windows (Win64)
+Build and launch scripts are available for Windows and Linux:
+- ✅ Windows (Win64): `BuildAndLaunchGame.ps1`
+- ✅ Linux: `BuildAndLaunchGame.sh --engine /path/to/UE5`
 - ⏳ Mac (coming soon)
-- ⏳ Linux (coming soon)
 
-For Mac/Linux, you can manually build using:
+For manual Linux builds, use:
 ```bash
-# Navigate to UE installation
-cd /Path/To/UE_5.7
-
-# Build the plugin
-Engine/Build/BatchFiles/Mac/Build.sh MyProjectEditor Mac Development /Path/To/MyProject.uproject -waitmutex
+/Path/To/UE5/Engine/Build/BatchFiles/Linux/Build.sh \
+  MyProjectEditor Linux Development /Path/To/MyProject.uproject -waitmutex
 ```
 
 ## Integration with IDEs

--- a/Source/VibeUE/Private/PythonAPI/UMapBlockoutService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UMapBlockoutService.cpp
@@ -234,7 +234,7 @@ FMapBlockoutLandcoverGrid UMapBlockoutService::LoadLandcoverGridJson(const FStri
 	}
 
 	const int32 N = Out.GridN;
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : Root->Values)
+	for (const auto& Pair : Root->Values)
 	{
 		if (Pair.Key == TEXT("N") || Pair.Key == TEXT("lo") || Pair.Key == TEXT("hi") || Pair.Key == TEXT("landscape")) { continue; }
 		const TArray<TSharedPtr<FJsonValue>>* Rows = nullptr;

--- a/VibeUE.uplugin
+++ b/VibeUE.uplugin
@@ -22,7 +22,8 @@
 			"Type": "Editor",
 			"LoadingPhase": "Default",
 			"WhitelistPlatforms": [
-				"Win64"
+				"Win64",
+				"Linux"
 			]
 		}
 	],
@@ -72,4 +73,4 @@
 			"Enabled": true
 		}
 	]
-} 
+}


### PR DESCRIPTION
# Add Linux Editor Build Support

## Summary

This PR adds Linux as a supported editor platform and provides a Linux-native build and launch script for project installs of VibeUE.

## Changes

- Add `Linux` alongside `Win64` in the plugin's supported-platform declaration.
- Add `BuildAndLaunchGame.sh`, which finds the enclosing `.uproject`, invokes Unreal's Linux `Build.sh`, and launches `UnrealEditor`.
- Require an explicit `--engine /path/to/UE5` argument or `UE_ENGINE_ROOT` environment variable for the Linux script.
- Document Linux build, rebuild, and manual build commands.
- Correct a Clang warnings-as-errors range-loop diagnostic in `UMapBlockoutService.cpp`.

## Behavior

The Linux script stops an already-running editor for the same project before building. `--clean` removes build artifacts only when explicitly requested; `--strict-rebuild` removes only VibeUE artifacts; and `--skip-build` launches without compiling.

Windows support remains unchanged.

## Validation

- `bash -n BuildAndLaunchGame.sh` passes.
- `VibeUE.uplugin` parses as JSON.
- `RidgeLineEditor Linux Development` built successfully with UE 5.8.
- The build produced `Plugins/VibeUE/Binaries/Linux/libUnrealEditor-VibeUE.so`.