### PR TITLE
fix: raise bOverride_ companion when setting UMG override values (#508)

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
@@ -755,6 +755,41 @@ namespace
 		return Property->ImportText_Direct(*PropertyValue, ValuePtr, Object, PPF_None) != nullptr;
 	}
 
+	// UMG "optional override" values (USizeBox::WidthOverride/HeightOverride/MinDesiredWidth/…,
+	// UImage aspect-ratio overrides, etc.) are inert unless their companion bOverride_<Name> bool
+	// is also set — that bool is the "checkbox" the UMG designer ticks for you. Writing only the
+	// value field silently no-ops: the layout engine keeps ignoring it (e.g. a SizeBox width that
+	// never clamps, so the box fills its parent). Whenever we set such a value directly on an
+	// object, raise the matching bOverride_ companion so the intent actually applies. (issue #508)
+	void RaiseOverrideCompanionIfPresent(UObject* Object, const FProperty* ValueProperty)
+	{
+		if (!Object || !ValueProperty)
+		{
+			return;
+		}
+
+		// Only direct object members carry a bOverride_ companion; struct-nested fields
+		// (e.g. WidgetStyle.Normal.TintColor) don't, and GetOwnerClass() is null for those.
+		UClass* OwnerClass = ValueProperty->GetOwnerClass();
+		if (!OwnerClass || !Object->GetClass()->IsChildOf(OwnerClass))
+		{
+			return;
+		}
+
+		const FString CompanionName = FString(TEXT("bOverride_")) + ValueProperty->GetName();
+		FBoolProperty* OverrideFlag = FindFProperty<FBoolProperty>(Object->GetClass(), *CompanionName);
+		if (!OverrideFlag)
+		{
+			return;
+		}
+
+		void* FlagPtr = OverrideFlag->ContainerPtrToValuePtr<void>(Object);
+		if (!OverrideFlag->GetPropertyValue(FlagPtr))
+		{
+			OverrideFlag->SetPropertyValue(FlagPtr, true);
+		}
+	}
+
 	FString GetLastPathSegment(const FString& PropertyPath)
 	{
 		FString Left;
@@ -1880,6 +1915,10 @@ bool UWidgetService::SetProperty(
 		UE_LOG(LogTemp, Warning, TEXT("UWidgetService::SetProperty: Failed to parse value '%s' for property '%s'"), *PropertyValue, *PropertyName);
 		return false;
 	}
+
+	// An override value alone is ignored unless its bOverride_ companion is set — flip it so the
+	// value takes effect (e.g. SizeBox WidthOverride actually clamps instead of no-op'ing).
+	RaiseOverrideCompanionIfPresent(Resolved.TargetObject, Resolved.Property);
 
 	Resolved.TargetObject->Modify();
 	// If we wrote to the widget's slot (layout/alignment/z-order), the change is structural —


### PR DESCRIPTION
## What

Fixes #508 — `WidgetService.SetProperty` wrote UMG optional-override *values* but never set the paired `bOverride_<Name>` flag, so the layout engine silently ignored them. Most visibly, `USizeBox::WidthOverride`/`HeightOverride` did nothing: the box fell back to parent size and filled the surface, so wrapped content (a VerticalBox "card") spread instead of sizing to a compact, centered panel. The call returned `true` the whole time — it read as "the AI can't lay out," but the layout intent was correct; one dropped flag broke the chain.

## Fix

After a successful `ImportText_Direct` in `UWidgetService::SetProperty`, if the target object's class has an `FBoolProperty` named `bOverride_<PropertyName>`, set it `true` — the same thing the UMG designer does when you tick the override checkbox. Restricted to direct object members (leaf `GetOwnerClass() != nullptr`) so struct-nested fields like `WidgetStyle.Normal.TintColor` are unaffected.

Covers the whole `bOverride_` family generically (SizeBox `WidthOverride`/`HeightOverride`/`MinDesiredWidth`/`MaxDesiredWidth`/`MinDesiredHeight`/`MaxDesiredHeight`/aspect-ratio, and any other override-gated member).

## Testing

Built `InvasionEditor` (UE 5.8) clean and verified live: setting `WidthOverride` on a SizeBox now clamps the box, so the card sizes and centers correctly instead of filling the surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
