### PR TITLE
Re-register MCP tools after ModelContextProtocol.RefreshTools

### DIFF
--- a/Source/VibeUE/Private/Module.cpp
+++ b/Source/VibeUE/Private/Module.cpp
@@ -13,6 +13,7 @@
 #include "ToolsetRegistry/UToolsetRegistry.h"
 #include "ToolsetRegistry/ToolsetDefinition.h"
 #include "Core/VibeUEMCPToolBridge.h"
+#include "IModelContextProtocolModule.h"
 #include "UObject/UObjectHash.h"
 #include "UObject/UObjectIterator.h"
 #include "Utils/VibeUEPaths.h"
@@ -379,10 +380,37 @@ void FModule::RegisterToolsets()
 
 	// Dynamic FToolRegistry tools -> Epic's MCP endpoint (independent of ToolsetRegistry).
 	VibeUEMCPToolBridge::RegisterAll();
+
+	// ModelContextProtocol.RefreshTools drops every registered MCP tool and broadcasts
+	// OnRefreshTools for providers to re-add themselves (Epic's editor module does this for
+	// ToolsetRegistry adapters, so the service toolsets above survive on their own). Without
+	// this subscription the bridged tools stay gone until the next editor restart.
+	if (IModelContextProtocolModule* MCPModule = IModelContextProtocolModule::Get();
+		MCPModule && !OnRefreshToolsHandle.IsValid())
+	{
+		OnRefreshToolsHandle = MCPModule->OnRefreshTools().AddRaw(this, &FModule::HandleMCPRefreshTools);
+	}
+}
+
+void FModule::HandleMCPRefreshTools()
+{
+	// RefreshTools already emptied the MCP module's tool list; UnregisterAll() only clears
+	// the bridge's now-stale tracking list so RegisterAll() starts from a clean slate.
+	VibeUEMCPToolBridge::UnregisterAll();
+	VibeUEMCPToolBridge::RegisterAll();
 }
 
 void FModule::UnregisterToolsets()
 {
+	if (OnRefreshToolsHandle.IsValid())
+	{
+		if (IModelContextProtocolModule* MCPModule = IModelContextProtocolModule::Get())
+		{
+			MCPModule->OnRefreshTools().Remove(OnRefreshToolsHandle);
+		}
+		OnRefreshToolsHandle.Reset();
+	}
+
 	VibeUEMCPToolBridge::UnregisterAll();
 
 	if (UToolsetRegistry::IsAvailable())

--- a/Source/VibeUE/Public/Module.h
+++ b/Source/VibeUE/Public/Module.h
@@ -31,7 +31,12 @@ public:
 	}
 
 private:
+	/** Re-adds the bridged VibeUE tools after ModelContextProtocol.RefreshTools drops every registered MCP tool */
+	void HandleMCPRefreshTools();
+
 	// False when running as a commandlet (cook, etc.) — services are skipped to
 	// avoid keeping UnrealEditor-Cmd.exe alive after the commandlet finishes.
 	bool bServicesInitialized = false;
-}; 
+
+	FDelegateHandle OnRefreshToolsHandle;
+};


### PR DESCRIPTION
## Problem

Epic's `ModelContextProtocol.RefreshTools` console command resets the MCP module's tool list (`Tools.Reset()`) and broadcasts `OnRefreshTools` so tool providers can re-add themselves — the `IModelContextProtocolModule::AddTool` docs say "Tool providers *should* listen for OnRefreshTools to re-add tools", and Epic's own `ModelContextProtocolEditor` module does exactly that for its ToolsetRegistry adapters.

VibeUE never subscribed. So after anyone runs `ModelContextProtocol.RefreshTools`, every bridged native tool (`execute_python_code`, `discover_python_module/class/function`, `list_python_subsystems`, `deep_research`, `terrain_data`) vanishes from the endpoint until a full editor restart — while Epic's toolset tools come back, which makes the breakage easy to misdiagnose.

## Fix

- `FModule::RegisterToolsets()` subscribes a `HandleMCPRefreshTools` handler to `IModelContextProtocolModule::OnRefreshTools()` (guarded by the stored `FDelegateHandle` so it only binds once).
- The handler runs `VibeUEMCPToolBridge::UnregisterAll()` — which only clears the bridge's now-stale tracking list, since the module already dropped the tools — then `RegisterAll()`.
- `UnregisterToolsets()` removes the delegate before unregistering, so nothing dangles across module shutdown.

The service toolsets registered with `UToolsetRegistry` need no handling of their own: `RefreshTools` only clears the MCP tool list, and Epic's editor module rebuilds toolset adapters from the still-populated registry.

## Verification (UE 5.8, Win64 Development editor)

1. Built with `BuildAndLaunchGame.ps1` — clean under the module's warnings-as-errors settings.
2. Connected an MCP client to `http://127.0.0.1:8000/mcp`, confirmed `execute_python_code` responds.
3. Ran `ModelContextProtocol.RefreshTools` (via `unreal.SystemLibrary.execute_console_command`).
4. `execute_python_code` still responds, and the log shows the bridge re-exposing all tools:

```
[2026.07.13-15.02.30:942][  0]LogToolRegistry: Display: VibeUE: exposed 7 tool(s) on Epic's MCP endpoint (0 internal/testing tools skipped).
[2026.07.13-15.03.50:554][232]LogToolRegistry: Display: VibeUE: exposed 7 tool(s) on Epic's MCP endpoint (0 internal/testing tools skipped).
```

(first line = editor startup, second = immediately after RefreshTools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)