### PR TITLE
Add macOS editor build support

### DIFF
--- a/BuildAndLaunchGame.sh
+++ b/BuildAndLaunchGame.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build and launch an Unreal Engine project on Linux. This script may live anywhere in the project tree.
+# Build and launch an Unreal Engine project on Linux or macOS. This script may live anywhere in the project tree.
 set -euo pipefail
 
 mode="Development"
@@ -59,10 +59,24 @@ if [[ -z "$engine_root" ]]; then
 fi
 
 engine_root="$(cd -- "$engine_root" && pwd -P)"
-build_script="$engine_root/Engine/Build/BatchFiles/Linux/Build.sh"
-editor_bin="$engine_root/Engine/Binaries/Linux/UnrealEditor"
+case "$(uname -s)" in
+    Linux)
+        platform="Linux"
+        build_script="$engine_root/Engine/Build/BatchFiles/Linux/Build.sh"
+        editor_bin="$engine_root/Engine/Binaries/Linux/UnrealEditor"
+        ;;
+    Darwin)
+        platform="Mac"
+        build_script="$engine_root/Engine/Build/BatchFiles/Mac/Build.sh"
+        editor_bin="$engine_root/Engine/Binaries/Mac/UnrealEditor.app/Contents/MacOS/UnrealEditor"
+        ;;
+    *)
+        echo "ERROR: BuildAndLaunchGame.sh supports Linux and macOS only." >&2
+        exit 1
+        ;;
+esac
 if [[ ! -x "$build_script" || ! -x "$editor_bin" ]]; then
-    echo "ERROR: $engine_root does not contain executable Linux Build.sh and UnrealEditor binaries." >&2
+    echo "ERROR: $engine_root does not contain executable $platform Build.sh and UnrealEditor binaries." >&2
     exit 1
 fi
 
@@ -71,18 +85,22 @@ project_name="$(basename -- "${project_path%.uproject}")"
 
 stop_editor() {
     local pids
-    pids="$(pgrep -f -- "UnrealEditor.*$project_path" || true)"
+    pids="$(pgrep -f "UnrealEditor.*$project_path" || true)"
     [[ -z "$pids" ]] && return
 
     echo "Stopping the running editor for $project_name..."
-    kill $pids 2>/dev/null || true
+    while IFS= read -r pid; do
+        [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true
+    done <<< "$pids"
     for _ in {1..15}; do
         sleep 1
-        pids="$(pgrep -f -- "UnrealEditor.*$project_path" || true)"
+        pids="$(pgrep -f "UnrealEditor.*$project_path" || true)"
         [[ -z "$pids" ]] && return
     done
     echo "Editor did not exit gracefully; terminating it."
-    kill -KILL $pids 2>/dev/null || true
+    while IFS= read -r pid; do
+        [[ -n "$pid" ]] && kill -KILL "$pid" 2>/dev/null || true
+    done <<< "$pids"
 }
 
 remove_artifacts() {
@@ -92,7 +110,7 @@ remove_artifacts() {
     done
 }
 
-echo "=== $project_name Linux Build and Launch ==="
+echo "=== $project_name $platform Build and Launch ==="
 echo "Project: $project_path"
 echo "Engine:  $engine_root"
 echo "Mode:    $mode"
@@ -109,7 +127,7 @@ elif [[ "$strict_rebuild" == true ]]; then
 fi
 
 if [[ "$skip_build" == false ]]; then
-    "$build_script" "${project_name}Editor" Linux "$mode" "$project_path" -waitmutex
+    "$build_script" "${project_name}Editor" "$platform" "$mode" "$project_path" -waitmutex
 fi
 
 exec "$editor_bin" "$project_path"

--- a/Content/samples/AGENTS.md.sample
+++ b/Content/samples/AGENTS.md.sample
@@ -186,7 +186,7 @@ When asked to rebuild / relaunch / test, use the project script — not manual `
 - `./Plugins/VibeUE/BuildAndLaunchGame.ps1` (stops the editor, builds, relaunches).
 - `-StrictRebuild` for a full plugin recompile under warnings-as-errors; `-Clean` to wipe artifacts;
   `-SkipBuild` to relaunch only.
-- On Linux: `./Plugins/VibeUE/BuildAndLaunchGame.sh --engine /path/to/UE5`.
+- On Linux or macOS: `./Plugins/VibeUE/BuildAndLaunchGame.sh --engine /path/to/UE5`.
   Use `--strict-rebuild`, `--clean`, or `--skip-build` for the corresponding operations.
 
 ---

--- a/FAB-Checklist.md
+++ b/FAB-Checklist.md
@@ -46,7 +46,7 @@ _Last verified: 2026-06-21 against the `5-8` branch (UE 5.8)._
 
 ### .uplugin Configuration
 - [x] `EngineVersion` = **"5.8.0"**
-- [x] `WhitelistPlatforms` = Win64 + Linux (matches supported target platforms)
+- [x] `WhitelistPlatforms` = Win64 + Linux + Mac (matches supported target platforms)
 - [x] `FabURL` set with Listing ID
 - [x] `DocsURL`, `SupportURL`, `CreatedByURL` populated (vibeue.com) — confirm `/support` resolves
 - [x] `Resources/Icon128.png` present (128×128) — placeholder lettermark; swap for final art if desired
@@ -76,7 +76,7 @@ _Last verified: 2026-06-21 against the `5-8` branch (UE 5.8)._
 ### ✅ Passing
 - All shipped text accurate and in English (descriptions + .uplugin updated for 5.8)
 - Plugin file structure correct; no unused assets (orphan header removed)
-- Engine version 5.8 supported; platforms Win64 and Linux
+- Engine version 5.8 supported; platforms Win64, Linux, and Mac
 - Documentation accessible (README.md + Resources/ + AGENTS.md.sample)
 - No offensive content; no redistributed Epic/Megascans content
 - EngineVersion + WhitelistPlatforms + FabURL configured

--- a/FAB-DESCRIPTION.md
+++ b/FAB-DESCRIPTION.md
@@ -41,4 +41,4 @@ VibeUE works without a key. A free API key (grab one at vibeue.com/login, set it
 • Free API key: https://www.vibeue.com/login
 
 
-Requirements: Win64 or Linux · Unreal Engine 5.8+ · Unreal's native MCP stack enabled (Unreal MCP, Toolset Registry, Editor Tools). VibeUE auto-enables the engine plugins its services need: Python Script Plugin, EditorScriptingUtilities, Enhanced Input, Niagara, MetaSound, MeshModelingToolset, ModelViewViewModel, StateTree, GameplayTagsEditor, plus ToolsetRegistry and ModelContextProtocol.
+Requirements: Win64, Linux, or macOS · Unreal Engine 5.8+ · Unreal's native MCP stack enabled (Unreal MCP, Toolset Registry, Editor Tools). VibeUE auto-enables the engine plugins its services need: Python Script Plugin, EditorScriptingUtilities, Enhanced Input, Niagara, MetaSound, MeshModelingToolset, ModelViewViewModel, StateTree, GameplayTagsEditor, plus ToolsetRegistry and ModelContextProtocol.

--- a/FAB_Tech_Details.md
+++ b/FAB_Tech_Details.md
@@ -1,7 +1,7 @@
 MCP Expansion + AI Editor Toolset for Unreal Engine 5.8+. Plugs into UE5.8's native MCP server, ToolsetRegistry, and AgentSkill system. 
 
 
-Module — VibeUE (Editor type), 105 C++ source files. Platforms: Win64, Linux. Engine: UE 5.8+.
+Module — VibeUE (Editor type), 105 C++ source files. Platforms: Win64, Linux, Mac. Engine: UE 5.8+.
 
 
 Prerequisites — enable Unreal's native MCP stack and start the MCP server, then point your MCP agent at the endpoint.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Build with the project script:
 Plugins/VibeUE/BuildAndLaunchGame.ps1                  # builds + launches the editor
 Plugins/VibeUE/BuildAndLaunchGame.ps1 -StrictRebuild   # full recompile (warnings-as-errors)
 ```
-On Linux, use:
+On Linux or macOS, use the platform-detecting shell script:
 ```bash
 Plugins/VibeUE/BuildAndLaunchGame.sh --engine /path/to/UE5
 Plugins/VibeUE/BuildAndLaunchGame.sh --engine /path/to/UE5 --strict-rebuild

--- a/Resources/BUILD_PLUGIN.md
+++ b/Resources/BUILD_PLUGIN.md
@@ -101,15 +101,21 @@ To verify the plugin works after building:
 
 ## Platform Support
 
-Build and launch scripts are available for Windows and Linux:
+Build and launch scripts are available for Windows, Linux, and macOS:
 - ✅ Windows (Win64): `BuildAndLaunchGame.ps1`
 - ✅ Linux: `BuildAndLaunchGame.sh --engine /path/to/UE5`
-- ⏳ Mac (coming soon)
+- ✅ macOS: `BuildAndLaunchGame.sh --engine /path/to/UE5`
 
 For manual Linux builds, use:
 ```bash
 /Path/To/UE5/Engine/Build/BatchFiles/Linux/Build.sh \
   MyProjectEditor Linux Development /Path/To/MyProject.uproject -waitmutex
+```
+
+For manual macOS builds, use:
+```bash
+/Path/To/UE5/Engine/Build/BatchFiles/Mac/Build.sh \
+  MyProjectEditor Mac Development /Path/To/MyProject.uproject -waitmutex
 ```
 
 ## Integration with IDEs

--- a/VibeUE.uplugin
+++ b/VibeUE.uplugin
@@ -23,7 +23,8 @@
 			"LoadingPhase": "Default",
 			"WhitelistPlatforms": [
 				"Win64",
-				"Linux"
+				"Linux",
+				"Mac"
 			]
 		}
 	],


### PR DESCRIPTION
# Add macOS Editor Build Support

## Summary

This PR adds macOS as a supported editor platform and extends the existing Unix build and launch script to support both Linux and macOS project installs of VibeUE. I've been using this for about two weeks successfully, it's working well. Thanks for the project!

## Changes

- Add `Mac` alongside `Win64` and `Linux` in the plugin’s supported-platform declaration.
- Update `BuildAndLaunchGame.sh` to detect Linux or macOS automatically.
- Use Unreal’s platform-specific build script and editor executable:
  - Linux: `Engine/Build/BatchFiles/Linux/Build.sh`
  - macOS: `Engine/Build/BatchFiles/Mac/Build.sh`
- Preserve the existing `--engine`, `--clean`, `--strict-rebuild`, and `--skip-build` options.
- Make editor-process termination portable and ShellCheck-clean.
- Document macOS installation, build, and manual build commands.
- Update the FAB platform metadata and sample agent guidance.

## Behavior

The shell script selects the appropriate Unreal target platform from the host operating system. On macOS it builds the `Mac` editor target and launches the executable inside `UnrealEditor.app`.

The script still stops an already-running editor for the same project before building. `--clean` removes build artifacts only when explicitly requested, `--strict-rebuild` removes only VibeUE artifacts, and `--skip-build` launches without compiling.

Windows and Linux support remain unchanged.

## Validation

- `bash -n BuildAndLaunchGame.sh` passes.
- `shellcheck BuildAndLaunchGame.sh` passes.
- `VibeUE.uplugin` parses as JSON.
- `AgenticSimEditor Mac Development` built successfully with Unreal Engine 5.8.
- The build produced `libUnrealEditor-VibeUE.dylib`.
- `git diff --check` passes.