### PR TITLE
FabService: make list_library engine_version a real filter

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/UFabService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UFabService.cpp
@@ -200,7 +200,11 @@ FString UFabService::ListLibrary(const FString& NameFilter, const FString& TypeF
 		return LibErr;
 	}
 
-	const FString EngineVer = EngineVersion.IsEmpty() ? CurrentEngineVersion() : EngineVersion;
+	// "all"/"any" disables the engine-version filter; anything else (or empty = current engine) excludes
+	// assets that don't support that version.
+	const bool bAnyEngine = EngineVersion.Equals(TEXT("all"), ESearchCase::IgnoreCase)
+		|| EngineVersion.Equals(TEXT("any"), ESearchCase::IgnoreCase);
+	const FString EngineVer = (EngineVersion.IsEmpty() || bAnyEngine) ? CurrentEngineVersion() : EngineVersion;
 	const FString NameLower = NameFilter.ToLower();
 	const FString TypeLower = TypeFilter.ToLower();
 
@@ -222,6 +226,10 @@ FString UFabService::ListLibrary(const FString& NameFilter, const FString& TypeF
 				continue;
 			}
 		}
+		if (!bAnyEngine && !A.SupportsEngine(EngineVer))
+		{
+			continue;
+		}
 		Filtered.Add(&A);
 	}
 
@@ -236,9 +244,10 @@ FString UFabService::ListLibrary(const FString& NameFilter, const FString& TypeF
 	{
 		Results.Add(MakeShared<FJsonValueObject>(CompactAsset(*Filtered[i], EngineVer)));
 	}
-	for (const FFabLibraryAsset* A : Filtered)
+	// total_compatible counts the WHOLE owned library against EngineVer, independent of the filters.
+	for (const FFabLibraryAsset& A : GLibraryCache)
 	{
-		if (A->SupportsEngine(EngineVer))
+		if (A.SupportsEngine(EngineVer))
 		{
 			++CompatibleCount;
 		}

--- a/Source/VibeUE/Public/PythonAPI/UFabService.h
+++ b/Source/VibeUE/Public/PythonAPI/UFabService.h
@@ -41,7 +41,8 @@ public:
 	 * Refresh=true to re-fetch. Filters are applied locally.
 	 * @param NameFilter    Case-insensitive substring match on the title. Empty = all.
 	 * @param TypeFilter    Match on derived type / distribution method (e.g. "pack","plugin","quixel","model"). Empty = all.
-	 * @param EngineVersion Only assets supporting this engine (e.g. "5.8"). Empty = the current engine.
+	 * @param EngineVersion Only assets supporting this engine (e.g. "5.8"). Empty = the current engine;
+	 *                      "all" (or "any") = no engine filter, results carry a `compatible` flag instead.
 	 * @param Limit         Max items to return. @param Offset Items to skip (paging). @param Refresh Re-fetch the library.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Fab")


### PR DESCRIPTION
## Summary
- `list_library(engine_version=...)` now **excludes** owned assets that don't support the resolved engine version (empty still defaults to the current engine), matching what the header doc always claimed
- `engine_version="all"` (or `"any"`) opts out — full library returned with per-item `compatible` flags, the previous behavior
- `total_compatible` now counts the whole owned library against the target version regardless of name/type filters; `total_owned` / `total_matched` still expose what the filters hid
- Header doc updated to describe the `"all"`/`"any"` escape hatch

## Testing
- Full plugin rebuild via BuildAndLaunchGame.ps1 — succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)