### PR TITLE
Fix create_valley/mountain/plateau/crater

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/ULandscapeService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/ULandscapeService.cpp
@@ -4405,30 +4405,51 @@ namespace LandscapeServiceV3
 		TArray<uint16> HeightData;
 		HeightData.SetNumUninitialized(SzX * SzY);
 
+		// Read current height data (merged view across all edit layers)
 		{
 			FLandscapeEditDataInterface Edit(LInfo);
 			Edit.GetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0);
+		} // ~FLandscapeEditDataInterface: release read lock
 
-			for (int32 Y = 0; Y < SzY; Y++)
+		for (int32 Y = 0; Y < SzY; Y++)
+		{
+			for (int32 X = 0; X < SzX; X++)
 			{
-				for (int32 X = 0; X < SzX; X++)
-				{
-					float VertX = static_cast<float>(MinX + X);
-					float VertY = static_cast<float>(MinY + Y);
-					float Dist  = FMath::Sqrt(FMath::Square(VertX - LocalCX) + FMath::Square(VertY - LocalCY));
+				float VertX = static_cast<float>(MinX + X);
+				float VertY = static_cast<float>(MinY + Y);
+				float Dist  = FMath::Sqrt(FMath::Square(VertX - LocalCX) + FMath::Square(VertY - LocalCY));
 
-					if (Dist >= LocalR) continue;
+				if (Dist >= LocalR) continue;
 
-					int32 Idx = Y * SzX + X;
-					float WorldZ = RawToWorldZ(HeightData[Idx], LocXY.Z, ScaleV.Z);
-					float Delta  = DeltaFn(Dist * ScaleV.X, WorldZ); // pass world-unit dist
+				int32 Idx = Y * SzX + X;
+				float WorldZ = RawToWorldZ(HeightData[Idx], LocXY.Z, ScaleV.Z);
+				float Delta  = DeltaFn(Dist * ScaleV.X, WorldZ); // pass world-unit dist
 
-					HeightData[Idx] = WorldZToRaw(WorldZ + Delta, LocXY.Z, ScaleV.Z);
-				}
+				HeightData[Idx] = WorldZToRaw(WorldZ + Delta, LocXY.Z, ScaleV.Z);
 			}
-
-			Edit.SetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0, true);
 		}
+
+		// Write using edit-layer-aware path (matches SculptAtLocation/SetHeightInRegion/etc.) —
+		// writing via FLandscapeEditDataInterface::SetHeightData bypasses edit layers entirely,
+		// so a subsequent layer-content update (UpdateLandscapeAfterHeightEdit) recomputes the
+		// merged heightmap from the real per-layer data and silently discards this edit.
+		const FGuid EditLayerGuid = ResolveEditLayerGuid(Landscape);
+		{
+			FScopedSetLandscapeEditingLayer EditLayerScope(
+				Landscape,
+				EditLayerGuid,
+				[Landscape]()
+				{
+					if (Landscape)
+					{
+						Landscape->RequestLayersContentUpdate(ELandscapeLayerUpdateMode::Update_Heightmap_All);
+					}
+				});
+
+			FHeightmapAccessor<false> HeightmapAccessor(LInfo);
+			HeightmapAccessor.SetData(MinX, MinY, MaxX, MaxY, HeightData.GetData());
+			HeightmapAccessor.Flush();
+		} // ~FHeightmapAccessor: flushes and releases heightmap texture write lock
 
 		return true;
 	}


### PR DESCRIPTION
While working in a new Third-Person UE 5.8 project, Claude Code had trouble with `create_valley`.

It went and said it found a bug, fixed it and since then it worked.

So here's the completely AI-generated fix, I hope this actually helps and isn't some AI bullshit :) 

And this is what Claude Code says (especially note the scope I set it and the suggested follow-up):

--------------------

### Problem

`LandscapeService.create_valley` (and its siblings sharing the same helper — `create_mountain`, `create_plateau`, `create_crater`) can silently discard landscape height edits, including edits made by earlier calls to the same functions. Symptoms:

- Calling `create_valley` once appears to work, but a second call resets the entire landscape back to flat — not just the area near the new call's center.
- In the worst case, even the new call's own carve fails to show up.
- This reproduces deterministically, including in a freshly-restarted editor session with no other landscape operations beforehand — it isn't a fragile/stateful landscape issue, it's a straightforward code bug.

We hit this while procedurally carving a river channel for a gameplay project — building up a winding valley from a sequence of overlapping `create_valley` calls, exactly the workflow these functions are meant for.

### Root cause

`CreateValley`/`CreateMountain`/`CreatePlateau`/`CreateCrater` all route through a shared `ApplyRadialDelta` helper. That helper reads current heights correctly, but writes the result back via a raw `FLandscapeEditDataInterface::SetHeightData()` call with no edit-layer scope.

Compare this to the already-correct functions in the same file (`SetHeightInRegion`, `SculptAtLocation`, `FlattenAtLocation`, etc.), which wrap their writes in `FScopedSetLandscapeEditingLayer` + `FHeightmapAccessor<false>`. One of those functions even has a comment flagging this exact failure mode:

> "Using FLandscapeEditDataInterface::SetHeightData bypasses edit layers and causes a full layer resolve that zeroes out all weightmap data."

Without the edit-layer scope, the write never lands in the landscape's real per-layer storage — it only ever reaches the transient merged/composited heightmap. The next time anything forces a layer-content recompute (`UpdateLandscapeAfterHeightEdit` → `ForceUpdateLayersContent`, which these same functions call right after the broken write), the engine rebuilds the "true" merged heightmap from the actual layer stack and the edit vanishes. Since previous calls' edits were written the same broken way, they vanish too — which is why the apparent "blast radius" of a single `create_valley` call looks like it can reach arbitrarily far across the landscape.

### Fix

`ApplyRadialDelta` now uses the same edit-layer-aware write pattern as the working functions:

- Resolve the active edit layer via the existing ResolveEditLayerGuid helper.
- Write through `FScopedSetLandscapeEditingLayer` + `FHeightmapAccessor<false>` instead of `FLandscapeEditDataInterface::SetHeightData`.
- Keep the existing `FLandscapeEditDataInterface::GetHeightData` for the read — reading was never the problem.

This fixes all four functions that share the helper (`create_valley`, `create_mountain`, `create_plateau`, `create_crater`) with one change.

### Testing

Verified in a real project:
- Sequential `create_valley` calls now compose additively and correctly (each new carve blends with prior ones instead of resetting them).
- A distant, previously-carved point is unaffected by a new call elsewhere on the landscape.
- The fix survives a full editor process restart (i.e. it's actually persisted, not just correct in the live in-memory state).

### Not in scope

`create_ridge`, `apply_erosion`, `create_terraces`, and `blend_terrain_features` appear to have their own separate inline writes using the same raw `FLandscapeEditDataInterface::SetHeightData` pattern (not routed through `ApplyRadialDelta`), so they likely have the same bug — but that wasn't verified or fixed here, since it wasn't hit in practice. Worth a follow-up look.

