### PR TITLE
Add ordered insert/reorder support to WidgetService.AddComponent

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
@@ -1603,14 +1603,27 @@ FWidgetAddComponentResult UWidgetService::AddComponent(
 		ParentPanel = Cast<UPanelWidget>(WidgetBP->WidgetTree->RootWidget);
 	}
 
-	// Validate ChildIndex up front rather than silently falling back to append: -1 means append,
-	// [0, GetChildrenCount()] means insert at that position, anything else is an explicit error
-	if (ParentPanel && ChildIndex != -1 && (ChildIndex < 0 || ChildIndex > ParentPanel->GetChildrenCount()))
+	// Validate ChildIndex up front rather than silently falling back to append or to setting the root: -1 means
+	// append, [0, GetChildrenCount()] means insert at that position, anything else is an explicit error - this
+	// must fire even when ParentPanel is null (e.g. no root widget exists yet), since a non-default ChildIndex
+	// has nothing to insert into there and would otherwise silently be ignored by the set-as-root fallback below
+	if (ChildIndex != -1)
 	{
-		Result.ErrorMessage = FString::Printf(
-			TEXT("ChildIndex %d is out of range for parent '%s' (valid range: -1 to append, or 0-%d to insert)"),
-			ChildIndex, *ParentPanel->GetName(), ParentPanel->GetChildrenCount());
-		return Result;
+		if (!ParentPanel)
+		{
+			Result.ErrorMessage = FString::Printf(
+				TEXT("ChildIndex %d was specified, but there is no panel parent to insert into (ChildIndex requires an existing panel parent)"),
+				ChildIndex);
+			return Result;
+		}
+
+		if (ChildIndex < 0 || ChildIndex > ParentPanel->GetChildrenCount())
+		{
+			Result.ErrorMessage = FString::Printf(
+				TEXT("ChildIndex %d is out of range for parent '%s' (valid range: -1 to append, or 0-%d to insert)"),
+				ChildIndex, *ParentPanel->GetName(), ParentPanel->GetChildrenCount());
+			return Result;
+		}
 	}
 
 	// Create the new widget

--- a/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
@@ -1603,6 +1603,16 @@ FWidgetAddComponentResult UWidgetService::AddComponent(
 		ParentPanel = Cast<UPanelWidget>(WidgetBP->WidgetTree->RootWidget);
 	}
 
+	// Validate ChildIndex up front rather than silently falling back to append: -1 means append,
+	// [0, GetChildrenCount()] means insert at that position, anything else is an explicit error
+	if (ParentPanel && ChildIndex != -1 && (ChildIndex < 0 || ChildIndex > ParentPanel->GetChildrenCount()))
+	{
+		Result.ErrorMessage = FString::Printf(
+			TEXT("ChildIndex %d is out of range for parent '%s' (valid range: -1 to append, or 0-%d to insert)"),
+			ChildIndex, *ParentPanel->GetName(), ParentPanel->GetChildrenCount());
+		return Result;
+	}
+
 	// Create the new widget
 	UWidget* NewWidget = WidgetBP->WidgetTree->ConstructWidget<UWidget>(WidgetClass, FName(*ComponentName));
 	if (!NewWidget)
@@ -1620,11 +1630,10 @@ FWidgetAddComponentResult UWidgetService::AddComponent(
 		WidgetBP->WidgetVariableNameToGuidMap.Add(WidgetFName, FGuid::NewGuid());
 	}
 
-	// Add to parent or set as root
+	// Add to parent or set as root - ChildIndex was already validated above, so it's either -1 (append) or a valid index
 	if (ParentPanel)
 	{
-		const bool bInsertAtIndex = ChildIndex >= 0 && ChildIndex <= ParentPanel->GetChildrenCount();
-		UPanelSlot* Slot = bInsertAtIndex ? ParentPanel->InsertChildAt(ChildIndex, NewWidget) : ParentPanel->AddChild(NewWidget);
+		UPanelSlot* Slot = (ChildIndex >= 0) ? ParentPanel->InsertChildAt(ChildIndex, NewWidget) : ParentPanel->AddChild(NewWidget);
 		if (!Slot)
 		{
 			Result.ErrorMessage = TEXT("Failed to add widget to parent panel");

--- a/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
@@ -1542,7 +1542,8 @@ FWidgetAddComponentResult UWidgetService::AddComponent(
 	const FString& ComponentType,
 	const FString& ComponentName,
 	const FString& ParentName,
-	bool bIsVariable)
+	bool bIsVariable,
+	int32 ChildIndex)
 {
 	FWidgetAddComponentResult Result;
 	
@@ -1622,7 +1623,8 @@ FWidgetAddComponentResult UWidgetService::AddComponent(
 	// Add to parent or set as root
 	if (ParentPanel)
 	{
-		UPanelSlot* Slot = ParentPanel->AddChild(NewWidget);
+		const bool bInsertAtIndex = ChildIndex >= 0 && ChildIndex <= ParentPanel->GetChildrenCount();
+		UPanelSlot* Slot = bInsertAtIndex ? ParentPanel->InsertChildAt(ChildIndex, NewWidget) : ParentPanel->AddChild(NewWidget);
 		if (!Slot)
 		{
 			Result.ErrorMessage = TEXT("Failed to add widget to parent panel");
@@ -1665,6 +1667,41 @@ FWidgetAddComponentResult UWidgetService::AddComponent(
 	Result.bIsVariable = bIsVariable;
 
 	return Result;
+}
+
+bool UWidgetService::ReorderComponent(
+	const FString& WidgetPath,
+	const FString& ComponentName,
+	int32 NewIndex)
+{
+	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprint(WidgetPath);
+	if (!WidgetBP || !WidgetBP->WidgetTree)
+	{
+		return false;
+	}
+
+	UWidget* Widget = FindWidgetByName(WidgetBP, ComponentName);
+	if (!Widget)
+	{
+		return false;
+	}
+
+	UPanelWidget* ParentPanel = Widget->GetParent();
+	if (!ParentPanel)
+	{
+		return false;
+	}
+
+	if (NewIndex < 0 || NewIndex >= ParentPanel->GetChildrenCount())
+	{
+		return false;
+	}
+
+	WidgetBP->Modify();
+	ParentPanel->ShiftChild(NewIndex, Widget);
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WidgetBP);
+
+	return true;
 }
 
 FWidgetRemoveComponentResult UWidgetService::RemoveComponent(

--- a/Source/VibeUE/Public/PythonAPI/UWidgetService.h
+++ b/Source/VibeUE/Public/PythonAPI/UWidgetService.h
@@ -586,7 +586,9 @@ public:
 	 * @param ComponentName - Name for the new component
 	 * @param ParentName - Name of parent panel (empty for root)
 	 * @param bIsVariable - Whether to expose as a variable
-	 * @param ChildIndex - Position among the parent's children to insert at (0-based). -1 (default) appends at the end
+	 * @param ChildIndex - Position among the parent's children to insert at (0-based). -1 (default) appends at
+	 *        the end. Any other value must be within [0, parent's current child count] or the call fails with
+	 *        an error - it does not silently fall back to append
 	 * @return Result with success status and details
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Widgets")

--- a/Source/VibeUE/Public/PythonAPI/UWidgetService.h
+++ b/Source/VibeUE/Public/PythonAPI/UWidgetService.h
@@ -586,6 +586,7 @@ public:
 	 * @param ComponentName - Name for the new component
 	 * @param ParentName - Name of parent panel (empty for root)
 	 * @param bIsVariable - Whether to expose as a variable
+	 * @param ChildIndex - Position among the parent's children to insert at (0-based). -1 (default) appends at the end
 	 * @return Result with success status and details
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Widgets")
@@ -594,7 +595,23 @@ public:
 		const FString& ComponentType,
 		const FString& ComponentName,
 		const FString& ParentName = TEXT(""),
-		bool bIsVariable = true);
+		bool bIsVariable = true,
+		int32 ChildIndex = -1);
+
+	/**
+	 * Move an existing widget component to a new position among its current parent's children.
+	 * Maps to action="reorder_component"
+	 *
+	 * @param WidgetPath - Full path to the Widget Blueprint
+	 * @param ComponentName - Name of the component to move
+	 * @param NewIndex - New 0-based position among the parent's children
+	 * @return True if the widget was found, has a panel parent, and was moved
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Widgets")
+	static bool ReorderComponent(
+		const FString& WidgetPath,
+		const FString& ComponentName,
+		int32 NewIndex);
 
 	/**
 	 * Remove a widget component from a Widget Blueprint.


### PR DESCRIPTION
## Summary
- `AddComponent` previously only appended new children via `UPanelWidget::AddChild`, with no way to control where in the parent's child list a new widget lands.
- The engine's `UPanelWidget` already exposes `InsertChildAt`/`ShiftChild` natively — this wires them up.

## Changes
- `AddComponent` gains an optional `ChildIndex` parameter (Python: `child_index`, default `-1`), which preserves the existing append-only behavior when omitted, and uses `InsertChildAt` when `>= 0`.
- New `ReorderComponent(widget_path, component_name, new_index) -> bool` moves an already-placed widget to a new position among its current parent's children, via `ShiftChild`. Returns `false` gracefully for a missing widget, a widget with no panel parent, or an out-of-range index.

## Test plan
- [x] Created a throwaway `WidgetBlueprint` with a `VerticalBox` containing two `TextBlock`s, verified `add_component(..., child_index=0)` inserts at the front (`get_hierarchy` before/after)
- [x] Verified `reorder_component` moves an existing widget to a new index
- [x] Verified graceful `False` return for out-of-range index and nonexistent widget name
- [x] Verified default `add_component` call (no `child_index`) still appends, unchanged