### PR TITLE
Make the engine Fab plugin an optional dependency

### DIFF
--- a/Content/Skills/fab/SKILL.md
+++ b/Content/Skills/fab/SKILL.md
@@ -72,6 +72,9 @@ listing is currently free and provides a supported source format.
   same request blindly.
 
 Every method returns a JSON string with `success: true|false`. Errors include `error_code` and `error`.
+If every method returns `error_code: "UNSUPPORTED"`, the engine install VibeUE was built against lacks
+the engine Fab plugin (`Engine/Plugins/Fab`) and FabService was compiled out (issue #525) — the rest of
+VibeUE is unaffected. Report this to the user; do not retry.
 Discover exact signatures with `discover_python_class('unreal.FabService')`. Current methods:
 `auth_status`, `list_library`, `get_asset`, `search_free_catalog`, `import_asset`, `import_free_asset`,
 and `import_status`.

--- a/Source/VibeUE/Private/PythonAPI/Fab/FabAuthBridge.cpp
+++ b/Source/VibeUE/Private/PythonAPI/Fab/FabAuthBridge.cpp
@@ -1,5 +1,8 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
+// Compiled out when the engine install lacks the Fab plugin (issue #525) — see VibeUE.Build.cs.
+#if WITH_VIBEUE_FAB
+
 #include "FabAuthBridge.h"
 #include "FabEndpoints.h"
 
@@ -361,3 +364,5 @@ FString FVibeFabAuth::GetLastError()
 {
 	return GLastError;
 }
+
+#endif // WITH_VIBEUE_FAB

--- a/Source/VibeUE/Private/PythonAPI/Fab/FabCatalogClient.cpp
+++ b/Source/VibeUE/Private/PythonAPI/Fab/FabCatalogClient.cpp
@@ -1,5 +1,8 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
+// Compiled out when the engine install lacks the Fab plugin (issue #525) — see VibeUE.Build.cs.
+#if WITH_VIBEUE_FAB
+
 #include "FabCatalogClient.h"
 #include "FabEndpoints.h"
 
@@ -442,3 +445,5 @@ bool FVibeFabCatalog::ResolveFreeDownload(const FString& BaseUrl, const FString&
 	}
 	return true;
 }
+
+#endif // WITH_VIBEUE_FAB

--- a/Source/VibeUE/Private/PythonAPI/Fab/FabImportDriver.cpp
+++ b/Source/VibeUE/Private/PythonAPI/Fab/FabImportDriver.cpp
@@ -1,5 +1,8 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
+// Compiled out when the engine install lacks the Fab plugin (issue #525) — see VibeUE.Build.cs.
+#if WITH_VIBEUE_FAB
+
 #include "FabImportDriver.h"
 #include "FabManifestClient.h"
 
@@ -417,3 +420,5 @@ TSharedPtr<FFabImportProgress> FVibeFabImport::Get(const FString& AssetId)
 	}
 	return nullptr;
 }
+
+#endif // WITH_VIBEUE_FAB

--- a/Source/VibeUE/Private/PythonAPI/Fab/FabLibraryClient.cpp
+++ b/Source/VibeUE/Private/PythonAPI/Fab/FabLibraryClient.cpp
@@ -1,5 +1,8 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
+// Compiled out when the engine install lacks the Fab plugin (issue #525) — see VibeUE.Build.cs.
+#if WITH_VIBEUE_FAB
+
 #include "FabLibraryClient.h"
 #include "FabEndpoints.h"
 
@@ -320,3 +323,5 @@ bool FVibeFabLibrary::Fetch(const FString& BaseUrl, const FString& EpicAccountId
 
 	return true;
 }
+
+#endif // WITH_VIBEUE_FAB

--- a/Source/VibeUE/Private/PythonAPI/Fab/FabManifestClient.cpp
+++ b/Source/VibeUE/Private/PythonAPI/Fab/FabManifestClient.cpp
@@ -1,5 +1,8 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
+// Compiled out when the engine install lacks the Fab plugin (issue #525) — see VibeUE.Build.cs.
+#if WITH_VIBEUE_FAB
+
 #include "FabManifestClient.h"
 #include "FabEndpoints.h"
 
@@ -152,3 +155,5 @@ bool FVibeFabManifest::Fetch(const FString& BaseUrl, const FString& ArtifactId, 
 
 	return true;
 }
+
+#endif // WITH_VIBEUE_FAB

--- a/Source/VibeUE/Private/PythonAPI/FabServiceTests.cpp
+++ b/Source/VibeUE/Private/PythonAPI/FabServiceTests.cpp
@@ -6,7 +6,9 @@
 #include "PythonAPI/UFabService.h"
 #include "Json.h"
 
-#if WITH_AUTOMATION_TESTS
+// WITH_VIBEUE_FAB: the client implementations these tests link against are compiled out when the
+// engine install lacks the Fab plugin (issue #525) — see VibeUE.Build.cs.
+#if WITH_AUTOMATION_TESTS && WITH_VIBEUE_FAB
 
 // Pure discovery logic (engine-version compat, type routing, version rollup) is factored onto
 // FFabLibraryAsset so it can be verified headlessly, with no editor/auth/network. Test path prefix
@@ -130,4 +132,4 @@ bool FVibeFabFreeImportEulaGuardTest::RunTest(const FString&)
 	return true;
 }
 
-#endif // WITH_AUTOMATION_TESTS
+#endif // WITH_AUTOMATION_TESTS && WITH_VIBEUE_FAB

--- a/Source/VibeUE/Private/PythonAPI/UFabService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UFabService.cpp
@@ -1,6 +1,30 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
 #include "PythonAPI/UFabService.h"
+
+#if !WITH_VIBEUE_FAB
+
+// This engine install has no Fab plugin (Engine/Plugins/Fab), so VibeUE.Build.cs compiled FabService
+// out (issue #525). The UCLASS stays registered so the Python/toolset surface is stable; every method
+// reports the feature as unavailable instead.
+static FString FabUnavailableJson()
+{
+	return TEXT("{\"success\":false,\"error_code\":\"UNSUPPORTED\",")
+	       TEXT("\"error\":\"FabService is unavailable: this engine install does not include the Fab plugin ")
+	       TEXT("(Engine/Plugins/Fab), so VibeUE was compiled without Fab support. ")
+	       TEXT("Use an engine install that ships the Fab plugin and rebuild VibeUE to enable it.\"}");
+}
+
+FString UFabService::AuthStatus(float) { return FabUnavailableJson(); }
+FString UFabService::ListLibrary(const FString&, const FString&, const FString&, int32, int32, bool) { return FabUnavailableJson(); }
+FString UFabService::GetAsset(const FString&) { return FabUnavailableJson(); }
+FString UFabService::SearchFreeCatalog(const FString&, const FString&, const FString&, int32, const FString&) { return FabUnavailableJson(); }
+FString UFabService::ImportAsset(const FString&, const FString&, const FString&, const FString&) { return FabUnavailableJson(); }
+FString UFabService::ImportFreeAsset(const FString&, const FString&, const FString&, const FString&, bool) { return FabUnavailableJson(); }
+FString UFabService::ImportStatus(const FString&) { return FabUnavailableJson(); }
+
+#else // WITH_VIBEUE_FAB
+
 #include "Fab/FabAuthBridge.h"
 #include "Fab/FabLibraryClient.h"
 #include "Fab/FabManifestClient.h"
@@ -577,3 +601,5 @@ FString UFabService::ImportStatus(const FString& AssetId)
 	}
 	return OkJson(Obj);
 }
+
+#endif // WITH_VIBEUE_FAB

--- a/Source/VibeUE/VibeUE.Build.cs
+++ b/Source/VibeUE/VibeUE.Build.cs
@@ -1,5 +1,6 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
+using System.IO;
 using UnrealBuildTool;
 
 public class VibeUE : ModuleRules
@@ -22,7 +23,26 @@ public class VibeUE : ModuleRules
 		// reusing the login the editor/launcher already holds. EOSSDK provides the SDK headers and the
 		// WITH_EOS_SDK=1 define; EOSShared provides IEOSSDKManager. bRequiresPlatformSDK mirrors the
 		// engine Fab plugin's own Build.cs so the platform SDK is available.
-		bRequiresPlatformSDK = true;
+		//
+		// Some engine installs ship without the Fab plugin entirely (issue #525), so all of this is
+		// conditional on it existing: without it, WITH_VIBEUE_FAB=0 compiles FabService down to stubs
+		// that report the feature as unavailable, and the rest of VibeUE builds normally.
+		bool bFabPluginPresent = File.Exists(
+			Path.Combine(EngineDirectory, "Plugins", "Fab", "Fab.uplugin"));
+		PrivateDefinitions.Add("WITH_VIBEUE_FAB=" + (bFabPluginPresent ? "1" : "0"));
+		if (bFabPluginPresent)
+		{
+			bRequiresPlatformSDK = true;
+			PrivateDependencyModuleNames.AddRange(
+				new string[]
+				{
+					"EOSSDK",                 // FabService (#517): Epic Online Services SDK — headers + WITH_EOS_SDK=1 for Fab auth token
+					"EOSShared",              // FabService (#517): IEOSSDKManager (create/enumerate + auto-tick EOS platforms)
+					"Fab",                    // FabService (#517): reuse the engine Fab plugin's FAB_API downloader (FFabDownloadRequest / queue)
+					"FileUtilities",          // FabService: safely extract public free-asset ZIP downloads
+				}
+			);
+		}
 
 		// Ensure proper debug symbol generation for PDB files
 		if (Target.Configuration == UnrealTargetConfiguration.Debug || 
@@ -111,10 +131,6 @@ public class VibeUE : ModuleRules
 				"StaticMeshDescription",  // For FStaticMeshAttributes / FStaticMeshOperations / FUVMapParameters
 				"ToolsetRegistry",        // UE 5.8 native AI toolset registry — exposes services as AICallable tools on Epic's MCP endpoint
 				"ModelContextProtocol",   // UE 5.8 native MCP server — VibeUE's dynamic tools are bridged onto Epic's endpoint
-				"EOSSDK",                 // FabService (#517): Epic Online Services SDK — headers + WITH_EOS_SDK=1 for Fab auth token
-				"EOSShared",              // FabService (#517): IEOSSDKManager (create/enumerate + auto-tick EOS platforms)
-				"Fab",                    // FabService (#517): reuse the engine Fab plugin's FAB_API downloader (FFabDownloadRequest / queue)
-				"FileUtilities",          // FabService: safely extract public free-asset ZIP downloads
 			}
 		);
 

--- a/VibeUE.uplugin
+++ b/VibeUE.uplugin
@@ -75,11 +75,13 @@
 		},
 		{
 			"Name": "Fab",
-			"Enabled": true
+			"Enabled": true,
+			"Optional": true
 		},
 		{
 			"Name": "EOSShared",
-			"Enabled": true
+			"Enabled": true,
+			"Optional": true
 		}
 	]
 }


### PR DESCRIPTION
Fixes #525.

Some Launcher engine installs ship without `Engine/Plugins/Fab`. Because FabService (#517) referenced it unconditionally, those installs failed twice: `.uproject` load rejected the required-plugin reference, and after working around that, the module failed to link (`LNK1181` on `UnrealEditor-Fab.lib`). One optional feature was blocking the entire plugin — exactly as the issue describes.

## Changes

- **`VibeUE.Build.cs`**: detects `Engine/Plugins/Fab/Fab.uplugin` at UBT configure time and defines `WITH_VIBEUE_FAB=1/0`. `Fab`, `EOSSDK`, `EOSShared`, `FileUtilities`, and `bRequiresPlatformSDK = true` are only applied when Fab is present.
- **`VibeUE.uplugin`**: the `Fab` and `EOSShared` plugin references are now `"Optional": true`, fixing the load-time error.
- **Fab client implementations** (`FabAuthBridge`, `FabCatalogClient`, `FabImportDriver`, `FabLibraryClient`, `FabManifestClient`) and `FabServiceTests` compile out under `WITH_VIBEUE_FAB=0`.
- **`UFabService`** stays registered either way (UHT can't gate a UCLASS on a custom define, and this keeps the Python/toolset surface stable); without Fab every method returns `{"success": false, "error_code": "UNSUPPORTED", ...}` explaining that the engine install lacks the Fab plugin.
- **`fab` skill**: documents the `UNSUPPORTED` response so agents report the missing feature instead of retrying.

## Verification (UE 5.8.1)

- With detection temporarily forced to `false` (simulating an install without Fab): the full editor target compiles and links with no Fab/EOS modules.
- With detection restored: full build succeeds, editor launches, and live checks confirm the real implementation is active — `import_status` on an unknown id returns `NO_IMPORT` (stub would return `UNSUPPORTED`) and `auth_status` reaches the Fab library as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)