### PR TITLE
Landscape: route all height writers through the edit-layer system

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/ULandscapeService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/ULandscapeService.cpp
@@ -114,6 +114,36 @@ static FGuid ResolveEditLayerGuid(ALandscape* Landscape)
 	return LayerGuid;
 }
 
+/**
+ * Write a rectangle of uint16 heights through the edit-layer system (issue #524).
+ * FLandscapeEditDataInterface::SetHeightData bypasses edit layers: the heights reach the merged
+ * runtime heightmap but the per-layer data keeps its old values, so the next layer-content
+ * resolve (triggered by any layer-aware edit such as sculpt_at_location/flatten_at_location)
+ * rebuilds the heightmap from layer data and silently reverts the edit in unpredictable,
+ * component-sized chunks far from the later edit's brush. Every height writer must use this
+ * helper (or an equivalent FScopedSetLandscapeEditingLayer + FHeightmapAccessor block).
+ * Any FLandscapeEditDataInterface used to read the source heights must be destroyed first.
+ */
+static void WriteHeightsToEditLayer(ALandscape* Landscape, ULandscapeInfo* LandscapeInfo,
+	int32 MinX, int32 MinY, int32 MaxX, int32 MaxY, const uint16* HeightData)
+{
+	const FGuid EditLayerGuid = ResolveEditLayerGuid(Landscape);
+	FScopedSetLandscapeEditingLayer EditLayerScope(
+		Landscape,
+		EditLayerGuid,
+		[Landscape]()
+		{
+			if (Landscape)
+			{
+				Landscape->RequestLayersContentUpdate(ELandscapeLayerUpdateMode::Update_Heightmap_All);
+			}
+		});
+
+	FHeightmapAccessor<false> HeightmapAccessor(LandscapeInfo);
+	HeightmapAccessor.SetData(MinX, MinY, MaxX, MaxY, HeightData);
+	HeightmapAccessor.Flush();
+} // ~FHeightmapAccessor: flushes and releases heightmap texture write lock
+
 void ULandscapeService::UpdateLandscapeAfterHeightEdit(ALandscapeProxy* Landscape)
 {
 	if (!Landscape)
@@ -2063,9 +2093,8 @@ FLandscapeNoiseResult ULandscapeService::ApplyNoise(
 	TArray<uint16> HeightData;
 	HeightData.SetNumUninitialized(SizeX * SizeY);
 
-	// Scope the edit interface so its destructor flushes and releases the
-	// heightmap texture write lock before UpdateLandscapeAfterHeightEdit
-	// triggers UpdateMaterialInstances / texture compression.
+	// Read current height data (merged view across all edit layers); the write goes through
+	// WriteHeightsToEditLayer once the read interface has released its locks.
 	{
 		FLandscapeEditDataInterface LandscapeEdit(LandscapeInfo);
 		LandscapeEdit.GetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0);
@@ -2111,8 +2140,9 @@ FLandscapeNoiseResult ULandscapeService::ApplyNoise(
 		}
 	}
 
-		LandscapeEdit.SetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0, true);
-	} // ~FLandscapeEditDataInterface: flushes and releases heightmap texture write lock
+	} // ~FLandscapeEditDataInterface: release read lock
+
+	WriteHeightsToEditLayer(Landscape, LandscapeInfo, MinX, MinY, MaxX, MaxY, HeightData.GetData());
 
 	UpdateLandscapeAfterHeightEdit(Landscape);
 
@@ -4553,8 +4583,9 @@ FMeshProjectionResult ULandscapeService::ProjectMeshToLandscape(
 			}
 		}
 
-		Edit.SetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0, true);
 	}
+
+	WriteHeightsToEditLayer(Landscape, LInfo, MinX, MinY, MaxX, MaxY, HeightData.GetData());
 
 	UpdateLandscapeAfterHeightEdit(Landscape);
 
@@ -5182,8 +5213,9 @@ bool ULandscapeService::CreateRidge(
 			}
 		}
 
-		Edit.SetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0, true);
 	}
+
+	WriteHeightsToEditLayer(Landscape, LInfo, MinX, MinY, MaxX, MaxY, HeightData.GetData());
 
 	UpdateLandscapeAfterHeightEdit(Landscape);
 	return true;
@@ -5316,8 +5348,9 @@ bool ULandscapeService::ApplyErosion(
 			HeightData = MoveTemp(Temp);
 		}
 
-		Edit.SetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0, true);
 	}
+
+	WriteHeightsToEditLayer(Landscape, LInfo, MinX, MinY, MaxX, MaxY, HeightData.GetData());
 
 	UpdateLandscapeAfterHeightEdit(Landscape);
 	UE_LOG(LogTemp, Log, TEXT("ULandscapeService::ApplyErosion: %d passes applied at (%.0f,%.0f) r=%.0f"), Iterations/100, CenterX, CenterY, Radius);
@@ -5456,8 +5489,9 @@ bool ULandscapeService::CreateTerraces(
 			}
 		}
 
-		Edit.SetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0, true);
 	}
+
+	WriteHeightsToEditLayer(Landscape, LInfo, MinX, MinY, MaxX, MaxY, HeightData.GetData());
 
 	UpdateLandscapeAfterHeightEdit(Landscape);
 	return true;
@@ -5500,11 +5534,13 @@ bool ULandscapeService::BlendTerrainFeatures(
 
 	FScopedTransaction Transaction(NSLOCTEXT("LandscapeService", "BlendTerrainFeatures", "Blend Terrain"));
 
+	TArray<uint16> Smoothed;
+
 	{
 		FLandscapeEditDataInterface Edit(LInfo);
 		Edit.GetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0);
 
-		TArray<uint16> Smoothed = HeightData;
+		Smoothed = HeightData;
 
 		// 3x3 box average
 		for (int32 Y = 1; Y < SzY - 1; Y++)
@@ -5531,8 +5567,9 @@ bool ULandscapeService::BlendTerrainFeatures(
 			}
 		}
 
-		Edit.SetHeightData(MinX, MinY, MaxX, MaxY, Smoothed.GetData(), 0, true);
 	}
+
+	WriteHeightsToEditLayer(Landscape, LInfo, MinX, MinY, MaxX, MaxY, Smoothed.GetData());
 
 	UpdateLandscapeAfterHeightEdit(Landscape);
 	return true;


### PR DESCRIPTION
Fixes #524.

## Root cause

Not a brush-bounds bug — the region math in `sculpt_at_location`/`flatten_at_location` is correct. The reporter's build (default branch) had `create_mountain` & co. writing heights via `FLandscapeEditDataInterface::SetHeightData`, which **bypasses the edit-layer system**: heights reach the merged runtime heightmap while the per-layer data keeps its old values. The first layer-aware edit afterwards (one small flatten) triggers a layer-content resolve that rebuilds the heightmap **from layer data**, silently reverting the bypass-written terrain in unpredictable component-sized chunks far from the brush. That matches every observation in the issue: correct height at the brush point, distant peaks wiped inconsistently, `success: True` on every call.

`cc3e35c` already fixed exactly this for `create_mountain`/`valley`/`plateau`/`crater` (in `5-8`, not yet released) — but six writers still had the bypass, so e.g. `create_ridge` → `flatten_at_location` reproduced #524 on `5-8` too.

## Changes

- New shared `WriteHeightsToEditLayer` helper (`ResolveEditLayerGuid` + `FScopedSetLandscapeEditingLayer` + `FHeightmapAccessor`), with a comment explaining the failure mode so no new writer regresses this.
- Converted the six remaining bypass writers to read → compute → layer-aware write (read interface released before the write): `ApplyNoise`, `ProjectMeshToLandscape`, `CreateRidge`, `ApplyErosion`, `CreateTerraces`, `BlendTerrainFeatures`.
- Zero `SetHeightData` writers remain in `ULandscapeService.cpp`.

## Verification (UE 5.8.1, live editor)

Repro modeled on the issue: fresh landscape, `create_mountain` at one corner + `create_ridge` far away, then **one** `flatten_at_location(radius=1200)` elsewhere:
- Before fix semantics: ridge (bypass-written) would be wiped by the flatten's layer resolve.
- After: mountain peak (20000.0) and ridge height (15000.0) unchanged; whole-landscape `analyze_terrain` stats stable (avg 316.9 → 317.2, the flatten's own local effect).
- `apply_noise`/`apply_erosion`/`create_terraces`/`blend_terrain_features` all succeed and their edits persist through a subsequent `sculpt_at_location`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)