### PR TITLE
Blueprint SCS: stop writing inherited-parent linkage for same-SCS parents

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -725,6 +725,23 @@ TArray<FBlueprintComponentInfo> UBlueprintService::ListComponents(const FString&
 	USCS_Node* ActualRootNode = FindActualSceneRootNode(SCS);
 
 	const TArray<USCS_Node*>& AllNodes = SCS->GetAllNodes();
+
+	// Same-SCS attachment lives only in the parents' ChildNodes arrays (see AttachSameScsChild);
+	// ParentComponentOrVariableName names inherited/native parents only. Map each node to its
+	// same-SCS tree parent so AttachParent reports both kinds of attachment.
+	TMap<USCS_Node*, USCS_Node*> SameScsParent;
+	for (USCS_Node* Node : AllNodes)
+	{
+		if (!Node)
+		{
+			continue;
+		}
+		for (USCS_Node* ChildNode : Node->GetChildNodes())
+		{
+			SameScsParent.Add(ChildNode, Node);
+		}
+	}
+
 	for (USCS_Node* Node : AllNodes)
 	{
 		if (!Node)
@@ -744,6 +761,10 @@ TArray<FBlueprintComponentInfo> UBlueprintService::ListComponents(const FString&
 		if (Node->ParentComponentOrVariableName != NAME_None)
 		{
 			CompInfo.AttachParent = Node->ParentComponentOrVariableName.ToString();
+		}
+		else if (USCS_Node* const* TreeParent = SameScsParent.Find(Node))
+		{
+			CompInfo.AttachParent = (*TreeParent)->GetVariableName().ToString();
 		}
 
 		CompInfo.bIsRootComponent = (Node == ActualRootNode);
@@ -1000,6 +1021,26 @@ bool UBlueprintService::GetComponentInfo(const FString& ComponentType, FComponen
 	return true;
 }
 
+/**
+ * Attach Child under Parent within the SAME SimpleConstructionScript.
+ * ParentComponentOrVariableName (+ ParentComponentOwnerClassName / bIsParentComponentNative)
+ * is reserved for attachment to INHERITED (parent-class or native) components. When it names
+ * the node's own-SCS parent, the Blueprint compiles and behaves normally, but the engine's
+ * hierarchy fixup (FSceneHierarchyMapper::FixupParentage) fires the "possible cyclic linkage"
+ * ensure on package load — which BuildCookRun counts as an error after every package has
+ * already cooked (issues #371, #523). Same-SCS attachment is expressed by the parent's
+ * ChildNodes array alone; USCS_Node::SetParent must only be used for genuinely inherited
+ * parents. Clearing the fields here also heals nodes corrupted by earlier writes.
+ */
+static void AttachSameScsChild(USCS_Node* Parent, USCS_Node* Child)
+{
+	Parent->AddChildNode(Child);
+	Child->Modify();
+	Child->ParentComponentOrVariableName = NAME_None;
+	Child->ParentComponentOwnerClassName = NAME_None;
+	Child->bIsParentComponentNative = false;
+}
+
 bool UBlueprintService::AddComponent(
 	const FString& BlueprintPath,
 	const FString& ComponentType,
@@ -1079,10 +1120,9 @@ bool UBlueprintService::AddComponent(
 		
 		if (ParentNode)
 		{
-			ParentNode->AddChildNode(NewNode);
-			// CRITICAL: Call SetParent to properly set ParentComponentOrVariableName
-			// AddChildNode only manages the ChildNodes array, it does NOT set the parent reference
-			NewNode->SetParent(ParentNode);
+			// ParentNode comes from this Blueprint's own SCS (the lookup above), so this must
+			// NOT go through SetParent — see AttachSameScsChild (issue #523).
+			AttachSameScsChild(ParentNode, NewNode);
 		}
 		else
 		{
@@ -1182,7 +1222,7 @@ bool UBlueprintService::RemoveComponent(
 			NodeToRemove->RemoveChildNode(Child);
 			if (ParentNode)
 			{
-				ParentNode->AddChildNode(Child);
+				AttachSameScsChild(ParentNode, Child);
 			}
 			else
 			{
@@ -1549,18 +1589,10 @@ bool UBlueprintService::SetRootComponent(
 	NewRootNode->ParentComponentOwnerClassName = NAME_None;
 	NewRootNode->bIsParentComponentNative = false;
 
-	// Attach a node as a same-SCS child of the new root. ParentComponentOrVariableName
-	// is reserved for attachment to INHERITED (parent-class/native) components — the
-	// engine's hierarchy fixup fires the "possible cyclic linkage" ensure on load/cook
-	// when it names the node's own SCS parent (issue #371). Same-SCS attachment is the
-	// ChildNodes array alone, with the inherited-parent linkage cleared.
+	// Attach a node as a same-SCS child of the new root (issue #371) — see AttachSameScsChild.
 	auto AttachUnderNewRoot = [NewRootNode](USCS_Node* Child)
 	{
-		NewRootNode->AddChildNode(Child);
-		Child->Modify();
-		Child->ParentComponentOrVariableName = NAME_None;
-		Child->ParentComponentOwnerClassName = NAME_None;
-		Child->bIsParentComponentNative = false;
+		AttachSameScsChild(NewRootNode, Child);
 	};
 
 	// If there was a current root, we need to handle it
@@ -1830,12 +1862,9 @@ bool UBlueprintService::ReparentComponent(
 		SCS->RemoveNode(NodeToReparent);
 	}
 	
-	// Add to new parent
-	NewParent->AddChildNode(NodeToReparent);
-	
-	// CRITICAL: Call SetParent to properly set ParentComponentOrVariableName
-	// AddChildNode only manages the ChildNodes array, it does NOT set the parent reference
-	NodeToReparent->SetParent(NewParent);
+	// Add to new parent. NewParent comes from this Blueprint's own SCS (the lookup above),
+	// so this must NOT go through SetParent — see AttachSameScsChild (issue #523).
+	AttachSameScsChild(NewParent, NodeToReparent);
 	
 	// Mark blueprint as modified
 	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);


### PR DESCRIPTION
Fixes #523 (completes the #371 fix).

## Root cause

Exactly as Sergio diagnosed: `add_component(parent=...)` and `reparent_component` resolve the parent from the **same Blueprint's SCS** (the lookup only searches `SCS->GetAllNodes()`) yet still called `USCS_Node::SetParent`, which writes `ParentComponentOrVariableName` — a field reserved for attachment to **inherited/native** components. The Blueprint compiles `BS_UP_TO_DATE`, looks right in the SCS panel, and PIEs cleanly, but on package load the engine's hierarchy fixup fires the "possible cyclic linkage" ensure (`SimpleConstructionScript.cpp:540`), which `BuildCookRun` counts as an error after every package has already cooked.

## Changes

- New `AttachSameScsChild` helper — same-SCS attachment via the parent's `ChildNodes` array with `ParentComponentOrVariableName` / `ParentComponentOwnerClassName` / `bIsParentComponentNative` cleared (mirrors #371's `AttachUnderNewRoot`; clearing also heals nodes corrupted by earlier writes). The helper's comment documents the field semantics so no new writer regresses this.
- Converted **`AddComponent`**, **`ReparentComponent`**, the **`RemoveComponent`** child-rehoming path, and refactored `SetRootComponent`'s `AttachUnderNewRoot` lambda onto the helper. No `USCS_Node::SetParent` callers remain in the plugin.
- **`ListComponents`**: `AttachParent` is now derived from the SCS tree when `ParentComponentOrVariableName` is `None`. Previously it only read that field — which happened to work *because of* the bug being fixed; without this, correct Blueprints would report no attach parent.

## Verification (UE 5.8.1, live editor)

Issue repro: fresh Actor Blueprint → `add_component("Arm", parent="Hub")` → `reparent_component("Tip", "Arm")` → compile + save → force-reload the package from disk:
- Reload log window contains **no** `Reparenting the ...` warning and **no** cyclic-linkage ensure (37 log lines, zero matches).
- Hierarchy `Hub → Arm → Tip` intact and reported correctly by `list_components` both before and after the disk reload.

The two adjacent traps noted at the end of the issue (`attach_subobject` root-promotion deleting `DefaultSceneRoot`, and `reload_packages` silently saving dirty packages) are engine-side behaviors not touched by this PR and worth tracking separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)