### PR TITLE
Release: 5-8 to master — optional Fab dependency, landscape edit-layer integrity, SCS linkage fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ vibe_ue.log
 *.log
 
 # AI-related files
+.codebase-memory/
 .cursorrules
 .cursorignore
 /.cursor/

--- a/BuildAndLaunchGame.ps1
+++ b/BuildAndLaunchGame.ps1
@@ -266,7 +266,8 @@ if (Test-Path $agentConversationsPath) {
 # Launch Unreal Editor
 Write-Host "Launching Unreal Editor..." -ForegroundColor Yellow
 
-Start-Process -FilePath $editorExe -ArgumentList $projectPath
+$editorProcess = Start-Process -FilePath $editorExe -ArgumentList $projectPath -PassThru
+Write-Output "Editor-PID=$($editorProcess.Id)"
 
 Write-Host "=== Launch Complete ===" -ForegroundColor Green
 Write-Host "Unreal Editor is starting with $projectName" -ForegroundColor Green

--- a/BuildAndLaunchGame.ps1
+++ b/BuildAndLaunchGame.ps1
@@ -267,6 +267,20 @@ if (Test-Path $agentConversationsPath) {
 Write-Host "Launching Unreal Editor..." -ForegroundColor Yellow
 
 $editorProcess = Start-Process -FilePath $editorExe -ArgumentList $projectPath -PassThru
+
+# Windows recycles process IDs, so an Editor that crashed without running OnPreExit can leave a signal
+# file whose name matches the PID we just got. VibeUE also clears it in RegisterToolsets(), but that runs
+# late in startup - an agent watching from now would see the stale file first and call MCP too early.
+# The Editor takes tens of seconds to reach RegisterToolsets(), so deleting here cannot race its write.
+$signalsDir = Join-Path $projectRoot "Saved\VibeUE\Signals"
+if (Test-Path $signalsDir) {
+    Get-ChildItem -Path $signalsDir -Filter "editor-$($editorProcess.Id)-*.json*" -File -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue
+            Write-Host "Cleared stale readiness signal: $($_.Name)" -ForegroundColor Gray
+        }
+}
+
 Write-Output "Editor-PID=$($editorProcess.Id)"
 
 Write-Host "=== Launch Complete ===" -ForegroundColor Green

--- a/BuildAndLaunchGame.sh
+++ b/BuildAndLaunchGame.sh
@@ -130,4 +130,13 @@ if [[ "$skip_build" == false ]]; then
     "$build_script" "${project_name}Editor" "$platform" "$mode" "$project_path" -waitmutex
 fi
 
-exec "$editor_bin" "$project_path"
+"$editor_bin" "$project_path" &
+editor_pid=$!
+
+# Same stale-signal guard as BuildAndLaunchGame.ps1: a crashed Editor can leave a readiness signal
+# named for a PID the OS later reuses, and RegisterToolsets() only clears it late in startup.
+rm -f -- "$project_root/Saved/VibeUE/Signals/editor-$editor_pid-"*.json* 2>/dev/null || true
+
+echo "Editor-PID=$editor_pid"
+
+wait "$editor_pid"

--- a/Content/Skills/fab/SKILL.md
+++ b/Content/Skills/fab/SKILL.md
@@ -72,6 +72,9 @@ listing is currently free and provides a supported source format.
   same request blindly.
 
 Every method returns a JSON string with `success: true|false`. Errors include `error_code` and `error`.
+If every method returns `error_code: "UNSUPPORTED"`, the engine install VibeUE was built against lacks
+the engine Fab plugin (`Engine/Plugins/Fab`) and FabService was compiled out (issue #525) — the rest of
+VibeUE is unaffected. Report this to the user; do not retry.
 Discover exact signatures with `discover_python_class('unreal.FabService')`. Current methods:
 `auth_status`, `list_library`, `get_asset`, `search_free_catalog`, `import_asset`, `import_free_asset`,
 and `import_status`.

--- a/Content/Skills/umg-widgets/SKILL.md
+++ b/Content/Skills/umg-widgets/SKILL.md
@@ -58,9 +58,13 @@ Do **not** call `BlueprintEditorLibrary.get_blueprint_class()`, `unreal.create_w
 ### 🚨 Hierarchy: set the root first, parents before children
 
 ```python
-unreal.WidgetService.add_component(path, "CanvasPanel", "RootCanvas", "", True)   # root: set_as_root=True
+unreal.WidgetService.add_component(path, "CanvasPanel", "RootCanvas", "", True)   # empty parent -> becomes root
 unreal.WidgetService.add_component(path, "Button", "PlayButton", "RootCanvas", False)
 ```
+
+That 5th argument is `is_variable`, **not** `set_as_root` — a widget becomes the root because its parent
+name is empty, not because of that flag. A 6th argument, `child_index`, inserts at a position instead of
+appending; `reorder_component` moves an existing widget within its parent. See `reference.md` ▸ Child order.
 
 > ⚠️ **Widget names are unique per-blueprint, NOT per-parent.** UMG enforces one name across the
 > whole Widget Blueprint, so you can't add an `ItemLabel`/`ItemButton` under each of `Item1`,

--- a/Content/Skills/umg-widgets/reference.md
+++ b/Content/Skills/umg-widgets/reference.md
@@ -147,6 +147,28 @@ Returned by `spawn_widget_in_pie(widget_path, z_order=0)`. Pass the **whole hand
 `add_component()` returns **WidgetAddComponentResult**: `success`, `component_name`, `component_type`,
 `parent_name`, `is_variable`, `error_message`.
 
+## Child order
+
+Panels keep their children in an ordered list, and that order is what a VerticalBox, HorizontalBox or
+Overlay actually lays out. Two ways to control it:
+
+- `add_component(..., child_index=N)` — insert the new widget at position `N` instead of appending.
+  `child_index` defaults to `-1` (append). Valid values are `0` to the parent's current child count;
+  anything else **fails with an error rather than silently appending**, so check `success`.
+- `reorder_component(widget_path, name, new_index)` — move a widget that already exists to another
+  position **under its current parent**. Valid range is `0` to `child_count - 1`. Returns `False` (with
+  the reason in the log) for an unknown widget, a widget with no panel parent (i.e. the root), or an
+  out-of-range index. To move a widget to a *different* parent, use `reparent_widget` instead.
+
+```python
+# Insert a banner above everything already in the list
+unreal.WidgetService.add_component(path, "TextBlock", "Banner", "ButtonList", False, 0)
+# ...or move an existing widget to the front
+unreal.WidgetService.reorder_component(path, "PlayButton", 0)
+```
+
+`child_index` is positional argument 6 — `is_variable` comes before it, so pass both when inserting.
+
 `get_available_events()` returns **WidgetEventInfo** list: `event_name`, `event_type`, `description`.
 
 ## Common properties
@@ -164,10 +186,11 @@ Returned by `spawn_widget_in_pie(widget_path, z_order=0)`. Pass the **whole hand
 
 | Action | Signature notes |
 |--------|-----------------|
-| `add_component` | `(widget_path, type, name, parent, set_as_root)` → WidgetAddComponentResult |
+| `add_component` | `(widget_path, type, name, parent, is_variable, child_index)` → WidgetAddComponentResult |
 | `remove_component` | Remove a widget (and optionally its children) |
 | `rename_widget` | `(widget_path, old_name, new_name)` |
 | `reparent_widget` | `(widget_path, widget_name, new_parent_name)` — move a widget to a new parent panel |
+| `reorder_component` | `(widget_path, component_name, new_index)` → bool — move a widget within its **current** parent |
 | `bind_event` | `(widget_path, widget_name, event_name, function_name)` |
 | `get_hierarchy` / `list_components` | All widgets as `WidgetInfo` list |
 | `get_widget_snapshot` | Full hierarchy + slot + properties as `WidgetComponentSnapshot` list |

--- a/Content/Skills/vibeue/SKILL.md
+++ b/Content/Skills/vibeue/SKILL.md
@@ -9,12 +9,22 @@ extra Python services (`unreal.<Service>`) and skill packs on top of the engine'
 
 ## Wait for VibeUE readiness after launch
 
-When `BuildAndLaunchGame.ps1` starts the Editor on Windows, treat its `Editor-PID=<pid>` output as
-the process identity. Check once, then watch the filesystem for
-`<ProjectDir>/Saved/VibeUE/Signals/editor-<pid>-true.json` before using MCP. Wait at most 180 seconds,
-do not poll MCP while waiting, and fail if that Editor process exits or the timeout expires. Ignore
-signal files for other or dead PIDs. The signal only means `RegisterToolsets()` reached its end;
-Python, World, and level readiness remain separate checks.
+`BuildAndLaunchGame.ps1` / `.sh` print `Editor-PID=<pid>` — treat that as the process identity. Check
+once, then watch the filesystem for `<ProjectDir>/Saved/VibeUE/Signals/editor-<pid>-true.json` before
+using MCP. Wait at most 180 seconds, do not poll MCP while waiting, and fail if that Editor process
+exits or the timeout expires. Ignore signal files for other or dead PIDs. The signal only means
+`RegisterToolsets()` reached its end; Python, World, and level readiness remain separate checks.
+
+The file is JSON, written atomically, so it is complete the moment it appears:
+
+```json
+{"signal":"toolsets-registered","pid":21044,"createdUtc":"2026-08-03T17:04:11.921Z",
+ "sessionStartUtc":"2026-08-03T17:03:22.108Z","pluginVersion":"3.0"}
+```
+
+Process IDs get recycled. The launch scripts clear a matching stale signal right after starting the
+Editor, but if you launch it some other way, verify `sessionStartUtc` is later than the moment you
+started the process before trusting the signal.
 
 Skill packs (this file and its siblings) are loaded through the engine's `AgentSkillToolset`.
 Each skill carries exact API patterns and gotchas; **load the relevant skill before writing any

--- a/Content/Skills/vibeue/SKILL.md
+++ b/Content/Skills/vibeue/SKILL.md
@@ -7,6 +7,15 @@ VibeUE is an **extension on Unreal Engine's native MCP endpoint** (`http://local
 There is no separate VibeUE server, no API key, and no in-editor chat — VibeUE simply registers
 extra Python services (`unreal.<Service>`) and skill packs on top of the engine's own toolsets.
 
+## Wait for VibeUE readiness after launch
+
+When `BuildAndLaunchGame.ps1` starts the Editor on Windows, treat its `Editor-PID=<pid>` output as
+the process identity. Check once, then watch the filesystem for
+`<ProjectDir>/Saved/VibeUE/Signals/editor-<pid>-true.json` before using MCP. Wait at most 180 seconds,
+do not poll MCP while waiting, and fail if that Editor process exits or the timeout expires. Ignore
+signal files for other or dead PIDs. The signal only means `RegisterToolsets()` reached its end;
+Python, World, and level readiness remain separate checks.
+
 Skill packs (this file and its siblings) are loaded through the engine's `AgentSkillToolset`.
 Each skill carries exact API patterns and gotchas; **load the relevant skill before writing any
 code** in a domain, or you will guess wrong property names and spiral into discovery loops.

--- a/Content/samples/AGENTS.md.sample
+++ b/Content/samples/AGENTS.md.sample
@@ -189,6 +189,13 @@ When asked to rebuild / relaunch / test, use the project script — not manual `
 - On Linux or macOS: `./Plugins/VibeUE/BuildAndLaunchGame.sh --engine /path/to/UE5`.
   Use `--strict-rebuild`, `--clean`, or `--skip-build` for the corresponding operations.
 
+**Windows readiness gate (required after launch):**
+- Parse `Editor-PID=<pid>` from `BuildAndLaunchGame.ps1` output.
+- Check once, then watch `<ProjectDir>/Saved/VibeUE/Signals/editor-<pid>-true.json` using filesystem events.
+- Wait at most 180 seconds; do not poll MCP. Fail if that Editor process exits or the timeout expires.
+- Ignore signal files for other or dead PIDs. The signal only means `RegisterToolsets()` reached its end;
+  Python, World, and level readiness remain separate checks.
+
 ---
 
 ## 9. Critical rules (evergreen)

--- a/Content/samples/AGENTS.md.sample
+++ b/Content/samples/AGENTS.md.sample
@@ -189,12 +189,16 @@ When asked to rebuild / relaunch / test, use the project script — not manual `
 - On Linux or macOS: `./Plugins/VibeUE/BuildAndLaunchGame.sh --engine /path/to/UE5`.
   Use `--strict-rebuild`, `--clean`, or `--skip-build` for the corresponding operations.
 
-**Windows readiness gate (required after launch):**
-- Parse `Editor-PID=<pid>` from `BuildAndLaunchGame.ps1` output.
+**Readiness gate (required after launch, both platforms):**
+- Parse `Editor-PID=<pid>` from the launch script's output.
 - Check once, then watch `<ProjectDir>/Saved/VibeUE/Signals/editor-<pid>-true.json` using filesystem events.
 - Wait at most 180 seconds; do not poll MCP. Fail if that Editor process exits or the timeout expires.
 - Ignore signal files for other or dead PIDs. The signal only means `RegisterToolsets()` reached its end;
   Python, World, and level readiness remain separate checks.
+- The file is JSON (`signal`, `pid`, `createdUtc`, `sessionStartUtc`, `pluginVersion`) and is written
+  atomically, so it is complete as soon as it appears. PIDs get recycled: the launch scripts clear a
+  stale same-PID signal on start, but if you launch the Editor yourself, check that `sessionStartUtc`
+  is later than your launch time before trusting it.
 
 ---
 

--- a/Source/VibeUE/Private/Module.cpp
+++ b/Source/VibeUE/Private/Module.cpp
@@ -18,53 +18,11 @@
 #include "UObject/UObjectHash.h"
 #include "UObject/UObjectIterator.h"
 #include "Utils/VibeUEPaths.h"
+#include "Utils/VibeUEReadinessSignal.h"
 #include "Misc/Paths.h"
 #include "Misc/FileHelper.h"
 
 #define LOCTEXT_NAMESPACE "FModule"
-
-namespace
-{
-	FString GetToolsetsRegisteredSignalPath()
-	{
-		return FPaths::Combine(
-			FPaths::ProjectSavedDir(),
-			TEXT("VibeUE"),
-			TEXT("Signals"),
-			FString::Printf(TEXT("editor-%u-true.json"), FPlatformProcess::GetCurrentProcessId()));
-	}
-
-	void RemoveToolsetsRegisteredSignal()
-	{
-		IFileManager::Get().Delete(
-			*GetToolsetsRegisteredSignalPath(),
-			/*RequireExists=*/false,
-			/*EvenReadOnly=*/true,
-			/*Quiet=*/true);
-	}
-
-	void PublishToolsetsRegisteredSignal()
-	{
-		const FString SignalDirectory = FPaths::Combine(
-			FPaths::ProjectSavedDir(), TEXT("VibeUE"), TEXT("Signals"));
-		IFileManager& FileManager = IFileManager::Get();
-		if (!FileManager.DirectoryExists(*SignalDirectory)
-			&& !FileManager.MakeDirectory(*SignalDirectory, /*Tree=*/true))
-		{
-			UE_LOG(LogTemp, Error, TEXT("VibeUE: failed to create signal directory: %s"), *SignalDirectory);
-			return;
-		}
-
-		const FString SignalPath = GetToolsetsRegisteredSignalPath();
-		if (!FFileHelper::SaveStringToFile(FString(), *SignalPath))
-		{
-			UE_LOG(LogTemp, Error, TEXT("VibeUE: failed to create toolsets-registered signal: %s"), *SignalPath);
-			return;
-		}
-
-		UE_LOG(LogTemp, Display, TEXT("VibeUE: toolsets-registered signal created: %s"), *SignalPath);
-	}
-}
 
 // Console command to list all registered tools
 static void ListVibeUETools()
@@ -407,8 +365,9 @@ static void GatherVibeUEToolsetClasses(TArray<UClass*>& OutClasses)
 
 void FModule::RegisterToolsets()
 {
-	// A reused process ID must not inherit a stale signal from an unclean Editor exit.
-	RemoveToolsetsRegisteredSignal();
+	// A reused process ID must not inherit a stale signal from an unclean Editor exit. This runs late
+	// in startup, so BuildAndLaunchGame also clears the file right after launch — see the script.
+	FVibeUEReadinessSignal::Remove();
 
 	// Service layer -> Epic's ToolsetRegistry (AICallable tools).
 	if (UToolsetRegistry::IsAvailable())
@@ -440,7 +399,7 @@ void FModule::RegisterToolsets()
 	}
 
 	// Reaching the end of RegisterToolsets is the complete readiness contract.
-	PublishToolsetsRegisteredSignal();
+	FVibeUEReadinessSignal::Publish();
 }
 
 void FModule::HandleMCPRefreshTools()
@@ -477,7 +436,7 @@ void FModule::UnregisterToolsets()
 
 void FModule::ShutdownModule()
 {
-	RemoveToolsetsRegisteredSignal();
+	FVibeUEReadinessSignal::Remove();
 
 	if (!bServicesInitialized)
 	{
@@ -501,7 +460,7 @@ void FModule::ShutdownModule()
 void FModule::OnPreExit()
 {
 	UE_LOG(LogTemp, Display, TEXT("VibeUE OnPreExit - cleaning up Python services"));
-	RemoveToolsetsRegisteredSignal();
+	FVibeUEReadinessSignal::Remove();
 	
 	// Release all C++ Python service instances
 	// This is safe because we're just clearing our own pointers

--- a/Source/VibeUE/Private/Module.cpp
+++ b/Source/VibeUE/Private/Module.cpp
@@ -6,6 +6,7 @@
 #include "Editor.h"
 #include "Core/ToolRegistry.h"
 #include "HAL/IConsoleManager.h"
+#include "HAL/PlatformProcess.h"
 #include "HAL/PlatformFileManager.h"
 #include "HAL/FileManager.h"
 #include "Tools/PythonTools.h"
@@ -21,6 +22,49 @@
 #include "Misc/FileHelper.h"
 
 #define LOCTEXT_NAMESPACE "FModule"
+
+namespace
+{
+	FString GetToolsetsRegisteredSignalPath()
+	{
+		return FPaths::Combine(
+			FPaths::ProjectSavedDir(),
+			TEXT("VibeUE"),
+			TEXT("Signals"),
+			FString::Printf(TEXT("editor-%u-true.json"), FPlatformProcess::GetCurrentProcessId()));
+	}
+
+	void RemoveToolsetsRegisteredSignal()
+	{
+		IFileManager::Get().Delete(
+			*GetToolsetsRegisteredSignalPath(),
+			/*RequireExists=*/false,
+			/*EvenReadOnly=*/true,
+			/*Quiet=*/true);
+	}
+
+	void PublishToolsetsRegisteredSignal()
+	{
+		const FString SignalDirectory = FPaths::Combine(
+			FPaths::ProjectSavedDir(), TEXT("VibeUE"), TEXT("Signals"));
+		IFileManager& FileManager = IFileManager::Get();
+		if (!FileManager.DirectoryExists(*SignalDirectory)
+			&& !FileManager.MakeDirectory(*SignalDirectory, /*Tree=*/true))
+		{
+			UE_LOG(LogTemp, Error, TEXT("VibeUE: failed to create signal directory: %s"), *SignalDirectory);
+			return;
+		}
+
+		const FString SignalPath = GetToolsetsRegisteredSignalPath();
+		if (!FFileHelper::SaveStringToFile(FString(), *SignalPath))
+		{
+			UE_LOG(LogTemp, Error, TEXT("VibeUE: failed to create toolsets-registered signal: %s"), *SignalPath);
+			return;
+		}
+
+		UE_LOG(LogTemp, Display, TEXT("VibeUE: toolsets-registered signal created: %s"), *SignalPath);
+	}
+}
 
 // Console command to list all registered tools
 static void ListVibeUETools()
@@ -363,6 +407,9 @@ static void GatherVibeUEToolsetClasses(TArray<UClass*>& OutClasses)
 
 void FModule::RegisterToolsets()
 {
+	// A reused process ID must not inherit a stale signal from an unclean Editor exit.
+	RemoveToolsetsRegisteredSignal();
+
 	// Service layer -> Epic's ToolsetRegistry (AICallable tools).
 	if (UToolsetRegistry::IsAvailable())
 	{
@@ -391,6 +438,9 @@ void FModule::RegisterToolsets()
 	{
 		OnRefreshToolsHandle = MCPModule->OnRefreshTools().AddRaw(this, &FModule::HandleMCPRefreshTools);
 	}
+
+	// Reaching the end of RegisterToolsets is the complete readiness contract.
+	PublishToolsetsRegisteredSignal();
 }
 
 void FModule::HandleMCPRefreshTools()
@@ -427,6 +477,8 @@ void FModule::UnregisterToolsets()
 
 void FModule::ShutdownModule()
 {
+	RemoveToolsetsRegisteredSignal();
+
 	if (!bServicesInitialized)
 	{
 		UE_LOG(LogTemp, Display, TEXT("VibeUE Module has shut down"));
@@ -449,6 +501,7 @@ void FModule::ShutdownModule()
 void FModule::OnPreExit()
 {
 	UE_LOG(LogTemp, Display, TEXT("VibeUE OnPreExit - cleaning up Python services"));
+	RemoveToolsetsRegisteredSignal();
 	
 	// Release all C++ Python service instances
 	// This is safe because we're just clearing our own pointers

--- a/Source/VibeUE/Private/PythonAPI/Fab/FabAuthBridge.cpp
+++ b/Source/VibeUE/Private/PythonAPI/Fab/FabAuthBridge.cpp
@@ -1,5 +1,8 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
+// Compiled out when the engine install lacks the Fab plugin (issue #525) — see VibeUE.Build.cs.
+#if WITH_VIBEUE_FAB
+
 #include "FabAuthBridge.h"
 #include "FabEndpoints.h"
 
@@ -361,3 +364,5 @@ FString FVibeFabAuth::GetLastError()
 {
 	return GLastError;
 }
+
+#endif // WITH_VIBEUE_FAB

--- a/Source/VibeUE/Private/PythonAPI/Fab/FabCatalogClient.cpp
+++ b/Source/VibeUE/Private/PythonAPI/Fab/FabCatalogClient.cpp
@@ -1,5 +1,8 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
+// Compiled out when the engine install lacks the Fab plugin (issue #525) — see VibeUE.Build.cs.
+#if WITH_VIBEUE_FAB
+
 #include "FabCatalogClient.h"
 #include "FabEndpoints.h"
 
@@ -442,3 +445,5 @@ bool FVibeFabCatalog::ResolveFreeDownload(const FString& BaseUrl, const FString&
 	}
 	return true;
 }
+
+#endif // WITH_VIBEUE_FAB

--- a/Source/VibeUE/Private/PythonAPI/Fab/FabImportDriver.cpp
+++ b/Source/VibeUE/Private/PythonAPI/Fab/FabImportDriver.cpp
@@ -1,5 +1,8 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
+// Compiled out when the engine install lacks the Fab plugin (issue #525) — see VibeUE.Build.cs.
+#if WITH_VIBEUE_FAB
+
 #include "FabImportDriver.h"
 #include "FabManifestClient.h"
 
@@ -417,3 +420,5 @@ TSharedPtr<FFabImportProgress> FVibeFabImport::Get(const FString& AssetId)
 	}
 	return nullptr;
 }
+
+#endif // WITH_VIBEUE_FAB

--- a/Source/VibeUE/Private/PythonAPI/Fab/FabLibraryClient.cpp
+++ b/Source/VibeUE/Private/PythonAPI/Fab/FabLibraryClient.cpp
@@ -1,5 +1,8 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
+// Compiled out when the engine install lacks the Fab plugin (issue #525) — see VibeUE.Build.cs.
+#if WITH_VIBEUE_FAB
+
 #include "FabLibraryClient.h"
 #include "FabEndpoints.h"
 
@@ -320,3 +323,5 @@ bool FVibeFabLibrary::Fetch(const FString& BaseUrl, const FString& EpicAccountId
 
 	return true;
 }
+
+#endif // WITH_VIBEUE_FAB

--- a/Source/VibeUE/Private/PythonAPI/Fab/FabManifestClient.cpp
+++ b/Source/VibeUE/Private/PythonAPI/Fab/FabManifestClient.cpp
@@ -1,5 +1,8 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
+// Compiled out when the engine install lacks the Fab plugin (issue #525) — see VibeUE.Build.cs.
+#if WITH_VIBEUE_FAB
+
 #include "FabManifestClient.h"
 #include "FabEndpoints.h"
 
@@ -152,3 +155,5 @@ bool FVibeFabManifest::Fetch(const FString& BaseUrl, const FString& ArtifactId, 
 
 	return true;
 }
+
+#endif // WITH_VIBEUE_FAB

--- a/Source/VibeUE/Private/PythonAPI/FabServiceTests.cpp
+++ b/Source/VibeUE/Private/PythonAPI/FabServiceTests.cpp
@@ -6,7 +6,9 @@
 #include "PythonAPI/UFabService.h"
 #include "Json.h"
 
-#if WITH_AUTOMATION_TESTS
+// WITH_VIBEUE_FAB: the client implementations these tests link against are compiled out when the
+// engine install lacks the Fab plugin (issue #525) — see VibeUE.Build.cs.
+#if WITH_AUTOMATION_TESTS && WITH_VIBEUE_FAB
 
 // Pure discovery logic (engine-version compat, type routing, version rollup) is factored onto
 // FFabLibraryAsset so it can be verified headlessly, with no editor/auth/network. Test path prefix
@@ -130,4 +132,4 @@ bool FVibeFabFreeImportEulaGuardTest::RunTest(const FString&)
 	return true;
 }
 
-#endif // WITH_AUTOMATION_TESTS
+#endif // WITH_AUTOMATION_TESTS && WITH_VIBEUE_FAB

--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -725,6 +725,23 @@ TArray<FBlueprintComponentInfo> UBlueprintService::ListComponents(const FString&
 	USCS_Node* ActualRootNode = FindActualSceneRootNode(SCS);
 
 	const TArray<USCS_Node*>& AllNodes = SCS->GetAllNodes();
+
+	// Same-SCS attachment lives only in the parents' ChildNodes arrays (see AttachSameScsChild);
+	// ParentComponentOrVariableName names inherited/native parents only. Map each node to its
+	// same-SCS tree parent so AttachParent reports both kinds of attachment.
+	TMap<USCS_Node*, USCS_Node*> SameScsParent;
+	for (USCS_Node* Node : AllNodes)
+	{
+		if (!Node)
+		{
+			continue;
+		}
+		for (USCS_Node* ChildNode : Node->GetChildNodes())
+		{
+			SameScsParent.Add(ChildNode, Node);
+		}
+	}
+
 	for (USCS_Node* Node : AllNodes)
 	{
 		if (!Node)
@@ -744,6 +761,10 @@ TArray<FBlueprintComponentInfo> UBlueprintService::ListComponents(const FString&
 		if (Node->ParentComponentOrVariableName != NAME_None)
 		{
 			CompInfo.AttachParent = Node->ParentComponentOrVariableName.ToString();
+		}
+		else if (USCS_Node* const* TreeParent = SameScsParent.Find(Node))
+		{
+			CompInfo.AttachParent = (*TreeParent)->GetVariableName().ToString();
 		}
 
 		CompInfo.bIsRootComponent = (Node == ActualRootNode);
@@ -1000,6 +1021,26 @@ bool UBlueprintService::GetComponentInfo(const FString& ComponentType, FComponen
 	return true;
 }
 
+/**
+ * Attach Child under Parent within the SAME SimpleConstructionScript.
+ * ParentComponentOrVariableName (+ ParentComponentOwnerClassName / bIsParentComponentNative)
+ * is reserved for attachment to INHERITED (parent-class or native) components. When it names
+ * the node's own-SCS parent, the Blueprint compiles and behaves normally, but the engine's
+ * hierarchy fixup (FSceneHierarchyMapper::FixupParentage) fires the "possible cyclic linkage"
+ * ensure on package load — which BuildCookRun counts as an error after every package has
+ * already cooked (issues #371, #523). Same-SCS attachment is expressed by the parent's
+ * ChildNodes array alone; USCS_Node::SetParent must only be used for genuinely inherited
+ * parents. Clearing the fields here also heals nodes corrupted by earlier writes.
+ */
+static void AttachSameScsChild(USCS_Node* Parent, USCS_Node* Child)
+{
+	Parent->AddChildNode(Child);
+	Child->Modify();
+	Child->ParentComponentOrVariableName = NAME_None;
+	Child->ParentComponentOwnerClassName = NAME_None;
+	Child->bIsParentComponentNative = false;
+}
+
 bool UBlueprintService::AddComponent(
 	const FString& BlueprintPath,
 	const FString& ComponentType,
@@ -1079,10 +1120,9 @@ bool UBlueprintService::AddComponent(
 		
 		if (ParentNode)
 		{
-			ParentNode->AddChildNode(NewNode);
-			// CRITICAL: Call SetParent to properly set ParentComponentOrVariableName
-			// AddChildNode only manages the ChildNodes array, it does NOT set the parent reference
-			NewNode->SetParent(ParentNode);
+			// ParentNode comes from this Blueprint's own SCS (the lookup above), so this must
+			// NOT go through SetParent — see AttachSameScsChild (issue #523).
+			AttachSameScsChild(ParentNode, NewNode);
 		}
 		else
 		{
@@ -1182,7 +1222,7 @@ bool UBlueprintService::RemoveComponent(
 			NodeToRemove->RemoveChildNode(Child);
 			if (ParentNode)
 			{
-				ParentNode->AddChildNode(Child);
+				AttachSameScsChild(ParentNode, Child);
 			}
 			else
 			{
@@ -1549,18 +1589,10 @@ bool UBlueprintService::SetRootComponent(
 	NewRootNode->ParentComponentOwnerClassName = NAME_None;
 	NewRootNode->bIsParentComponentNative = false;
 
-	// Attach a node as a same-SCS child of the new root. ParentComponentOrVariableName
-	// is reserved for attachment to INHERITED (parent-class/native) components — the
-	// engine's hierarchy fixup fires the "possible cyclic linkage" ensure on load/cook
-	// when it names the node's own SCS parent (issue #371). Same-SCS attachment is the
-	// ChildNodes array alone, with the inherited-parent linkage cleared.
+	// Attach a node as a same-SCS child of the new root (issue #371) — see AttachSameScsChild.
 	auto AttachUnderNewRoot = [NewRootNode](USCS_Node* Child)
 	{
-		NewRootNode->AddChildNode(Child);
-		Child->Modify();
-		Child->ParentComponentOrVariableName = NAME_None;
-		Child->ParentComponentOwnerClassName = NAME_None;
-		Child->bIsParentComponentNative = false;
+		AttachSameScsChild(NewRootNode, Child);
 	};
 
 	// If there was a current root, we need to handle it
@@ -1830,12 +1862,9 @@ bool UBlueprintService::ReparentComponent(
 		SCS->RemoveNode(NodeToReparent);
 	}
 	
-	// Add to new parent
-	NewParent->AddChildNode(NodeToReparent);
-	
-	// CRITICAL: Call SetParent to properly set ParentComponentOrVariableName
-	// AddChildNode only manages the ChildNodes array, it does NOT set the parent reference
-	NodeToReparent->SetParent(NewParent);
+	// Add to new parent. NewParent comes from this Blueprint's own SCS (the lookup above),
+	// so this must NOT go through SetParent — see AttachSameScsChild (issue #523).
+	AttachSameScsChild(NewParent, NodeToReparent);
 	
 	// Mark blueprint as modified
 	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);

--- a/Source/VibeUE/Private/PythonAPI/UFabService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UFabService.cpp
@@ -200,7 +200,11 @@ FString UFabService::ListLibrary(const FString& NameFilter, const FString& TypeF
 		return LibErr;
 	}
 
-	const FString EngineVer = EngineVersion.IsEmpty() ? CurrentEngineVersion() : EngineVersion;
+	// "all"/"any" disables the engine-version filter; anything else (or empty = current engine) excludes
+	// assets that don't support that version.
+	const bool bAnyEngine = EngineVersion.Equals(TEXT("all"), ESearchCase::IgnoreCase)
+		|| EngineVersion.Equals(TEXT("any"), ESearchCase::IgnoreCase);
+	const FString EngineVer = (EngineVersion.IsEmpty() || bAnyEngine) ? CurrentEngineVersion() : EngineVersion;
 	const FString NameLower = NameFilter.ToLower();
 	const FString TypeLower = TypeFilter.ToLower();
 
@@ -222,6 +226,10 @@ FString UFabService::ListLibrary(const FString& NameFilter, const FString& TypeF
 				continue;
 			}
 		}
+		if (!bAnyEngine && !A.SupportsEngine(EngineVer))
+		{
+			continue;
+		}
 		Filtered.Add(&A);
 	}
 
@@ -236,9 +244,10 @@ FString UFabService::ListLibrary(const FString& NameFilter, const FString& TypeF
 	{
 		Results.Add(MakeShared<FJsonValueObject>(CompactAsset(*Filtered[i], EngineVer)));
 	}
-	for (const FFabLibraryAsset* A : Filtered)
+	// total_compatible counts the WHOLE owned library against EngineVer, independent of the filters.
+	for (const FFabLibraryAsset& A : GLibraryCache)
 	{
-		if (A->SupportsEngine(EngineVer))
+		if (A.SupportsEngine(EngineVer))
 		{
 			++CompatibleCount;
 		}

--- a/Source/VibeUE/Private/PythonAPI/UFabService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UFabService.cpp
@@ -1,6 +1,30 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
 #include "PythonAPI/UFabService.h"
+
+#if !WITH_VIBEUE_FAB
+
+// This engine install has no Fab plugin (Engine/Plugins/Fab), so VibeUE.Build.cs compiled FabService
+// out (issue #525). The UCLASS stays registered so the Python/toolset surface is stable; every method
+// reports the feature as unavailable instead.
+static FString FabUnavailableJson()
+{
+	return TEXT("{\"success\":false,\"error_code\":\"UNSUPPORTED\",")
+	       TEXT("\"error\":\"FabService is unavailable: this engine install does not include the Fab plugin ")
+	       TEXT("(Engine/Plugins/Fab), so VibeUE was compiled without Fab support. ")
+	       TEXT("Use an engine install that ships the Fab plugin and rebuild VibeUE to enable it.\"}");
+}
+
+FString UFabService::AuthStatus(float) { return FabUnavailableJson(); }
+FString UFabService::ListLibrary(const FString&, const FString&, const FString&, int32, int32, bool) { return FabUnavailableJson(); }
+FString UFabService::GetAsset(const FString&) { return FabUnavailableJson(); }
+FString UFabService::SearchFreeCatalog(const FString&, const FString&, const FString&, int32, const FString&) { return FabUnavailableJson(); }
+FString UFabService::ImportAsset(const FString&, const FString&, const FString&, const FString&) { return FabUnavailableJson(); }
+FString UFabService::ImportFreeAsset(const FString&, const FString&, const FString&, const FString&, bool) { return FabUnavailableJson(); }
+FString UFabService::ImportStatus(const FString&) { return FabUnavailableJson(); }
+
+#else // WITH_VIBEUE_FAB
+
 #include "Fab/FabAuthBridge.h"
 #include "Fab/FabLibraryClient.h"
 #include "Fab/FabManifestClient.h"
@@ -577,3 +601,5 @@ FString UFabService::ImportStatus(const FString& AssetId)
 	}
 	return OkJson(Obj);
 }
+
+#endif // WITH_VIBEUE_FAB

--- a/Source/VibeUE/Private/PythonAPI/ULandscapeService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/ULandscapeService.cpp
@@ -4405,30 +4405,51 @@ namespace LandscapeServiceV3
 		TArray<uint16> HeightData;
 		HeightData.SetNumUninitialized(SzX * SzY);
 
+		// Read current height data (merged view across all edit layers)
 		{
 			FLandscapeEditDataInterface Edit(LInfo);
 			Edit.GetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0);
+		} // ~FLandscapeEditDataInterface: release read lock
 
-			for (int32 Y = 0; Y < SzY; Y++)
+		for (int32 Y = 0; Y < SzY; Y++)
+		{
+			for (int32 X = 0; X < SzX; X++)
 			{
-				for (int32 X = 0; X < SzX; X++)
-				{
-					float VertX = static_cast<float>(MinX + X);
-					float VertY = static_cast<float>(MinY + Y);
-					float Dist  = FMath::Sqrt(FMath::Square(VertX - LocalCX) + FMath::Square(VertY - LocalCY));
+				float VertX = static_cast<float>(MinX + X);
+				float VertY = static_cast<float>(MinY + Y);
+				float Dist  = FMath::Sqrt(FMath::Square(VertX - LocalCX) + FMath::Square(VertY - LocalCY));
 
-					if (Dist >= LocalR) continue;
+				if (Dist >= LocalR) continue;
 
-					int32 Idx = Y * SzX + X;
-					float WorldZ = RawToWorldZ(HeightData[Idx], LocXY.Z, ScaleV.Z);
-					float Delta  = DeltaFn(Dist * ScaleV.X, WorldZ); // pass world-unit dist
+				int32 Idx = Y * SzX + X;
+				float WorldZ = RawToWorldZ(HeightData[Idx], LocXY.Z, ScaleV.Z);
+				float Delta  = DeltaFn(Dist * ScaleV.X, WorldZ); // pass world-unit dist
 
-					HeightData[Idx] = WorldZToRaw(WorldZ + Delta, LocXY.Z, ScaleV.Z);
-				}
+				HeightData[Idx] = WorldZToRaw(WorldZ + Delta, LocXY.Z, ScaleV.Z);
 			}
-
-			Edit.SetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0, true);
 		}
+
+		// Write using edit-layer-aware path (matches SculptAtLocation/SetHeightInRegion/etc.) —
+		// writing via FLandscapeEditDataInterface::SetHeightData bypasses edit layers entirely,
+		// so a subsequent layer-content update (UpdateLandscapeAfterHeightEdit) recomputes the
+		// merged heightmap from the real per-layer data and silently discards this edit.
+		const FGuid EditLayerGuid = ResolveEditLayerGuid(Landscape);
+		{
+			FScopedSetLandscapeEditingLayer EditLayerScope(
+				Landscape,
+				EditLayerGuid,
+				[Landscape]()
+				{
+					if (Landscape)
+					{
+						Landscape->RequestLayersContentUpdate(ELandscapeLayerUpdateMode::Update_Heightmap_All);
+					}
+				});
+
+			FHeightmapAccessor<false> HeightmapAccessor(LInfo);
+			HeightmapAccessor.SetData(MinX, MinY, MaxX, MaxY, HeightData.GetData());
+			HeightmapAccessor.Flush();
+		} // ~FHeightmapAccessor: flushes and releases heightmap texture write lock
 
 		return true;
 	}

--- a/Source/VibeUE/Private/PythonAPI/ULandscapeService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/ULandscapeService.cpp
@@ -114,6 +114,36 @@ static FGuid ResolveEditLayerGuid(ALandscape* Landscape)
 	return LayerGuid;
 }
 
+/**
+ * Write a rectangle of uint16 heights through the edit-layer system (issue #524).
+ * FLandscapeEditDataInterface::SetHeightData bypasses edit layers: the heights reach the merged
+ * runtime heightmap but the per-layer data keeps its old values, so the next layer-content
+ * resolve (triggered by any layer-aware edit such as sculpt_at_location/flatten_at_location)
+ * rebuilds the heightmap from layer data and silently reverts the edit in unpredictable,
+ * component-sized chunks far from the later edit's brush. Every height writer must use this
+ * helper (or an equivalent FScopedSetLandscapeEditingLayer + FHeightmapAccessor block).
+ * Any FLandscapeEditDataInterface used to read the source heights must be destroyed first.
+ */
+static void WriteHeightsToEditLayer(ALandscape* Landscape, ULandscapeInfo* LandscapeInfo,
+	int32 MinX, int32 MinY, int32 MaxX, int32 MaxY, const uint16* HeightData)
+{
+	const FGuid EditLayerGuid = ResolveEditLayerGuid(Landscape);
+	FScopedSetLandscapeEditingLayer EditLayerScope(
+		Landscape,
+		EditLayerGuid,
+		[Landscape]()
+		{
+			if (Landscape)
+			{
+				Landscape->RequestLayersContentUpdate(ELandscapeLayerUpdateMode::Update_Heightmap_All);
+			}
+		});
+
+	FHeightmapAccessor<false> HeightmapAccessor(LandscapeInfo);
+	HeightmapAccessor.SetData(MinX, MinY, MaxX, MaxY, HeightData);
+	HeightmapAccessor.Flush();
+} // ~FHeightmapAccessor: flushes and releases heightmap texture write lock
+
 void ULandscapeService::UpdateLandscapeAfterHeightEdit(ALandscapeProxy* Landscape)
 {
 	if (!Landscape)
@@ -2063,9 +2093,8 @@ FLandscapeNoiseResult ULandscapeService::ApplyNoise(
 	TArray<uint16> HeightData;
 	HeightData.SetNumUninitialized(SizeX * SizeY);
 
-	// Scope the edit interface so its destructor flushes and releases the
-	// heightmap texture write lock before UpdateLandscapeAfterHeightEdit
-	// triggers UpdateMaterialInstances / texture compression.
+	// Read current height data (merged view across all edit layers); the write goes through
+	// WriteHeightsToEditLayer once the read interface has released its locks.
 	{
 		FLandscapeEditDataInterface LandscapeEdit(LandscapeInfo);
 		LandscapeEdit.GetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0);
@@ -2111,8 +2140,9 @@ FLandscapeNoiseResult ULandscapeService::ApplyNoise(
 		}
 	}
 
-		LandscapeEdit.SetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0, true);
-	} // ~FLandscapeEditDataInterface: flushes and releases heightmap texture write lock
+	} // ~FLandscapeEditDataInterface: release read lock
+
+	WriteHeightsToEditLayer(Landscape, LandscapeInfo, MinX, MinY, MaxX, MaxY, HeightData.GetData());
 
 	UpdateLandscapeAfterHeightEdit(Landscape);
 
@@ -4553,8 +4583,9 @@ FMeshProjectionResult ULandscapeService::ProjectMeshToLandscape(
 			}
 		}
 
-		Edit.SetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0, true);
 	}
+
+	WriteHeightsToEditLayer(Landscape, LInfo, MinX, MinY, MaxX, MaxY, HeightData.GetData());
 
 	UpdateLandscapeAfterHeightEdit(Landscape);
 
@@ -5182,8 +5213,9 @@ bool ULandscapeService::CreateRidge(
 			}
 		}
 
-		Edit.SetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0, true);
 	}
+
+	WriteHeightsToEditLayer(Landscape, LInfo, MinX, MinY, MaxX, MaxY, HeightData.GetData());
 
 	UpdateLandscapeAfterHeightEdit(Landscape);
 	return true;
@@ -5316,8 +5348,9 @@ bool ULandscapeService::ApplyErosion(
 			HeightData = MoveTemp(Temp);
 		}
 
-		Edit.SetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0, true);
 	}
+
+	WriteHeightsToEditLayer(Landscape, LInfo, MinX, MinY, MaxX, MaxY, HeightData.GetData());
 
 	UpdateLandscapeAfterHeightEdit(Landscape);
 	UE_LOG(LogTemp, Log, TEXT("ULandscapeService::ApplyErosion: %d passes applied at (%.0f,%.0f) r=%.0f"), Iterations/100, CenterX, CenterY, Radius);
@@ -5456,8 +5489,9 @@ bool ULandscapeService::CreateTerraces(
 			}
 		}
 
-		Edit.SetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0, true);
 	}
+
+	WriteHeightsToEditLayer(Landscape, LInfo, MinX, MinY, MaxX, MaxY, HeightData.GetData());
 
 	UpdateLandscapeAfterHeightEdit(Landscape);
 	return true;
@@ -5500,11 +5534,13 @@ bool ULandscapeService::BlendTerrainFeatures(
 
 	FScopedTransaction Transaction(NSLOCTEXT("LandscapeService", "BlendTerrainFeatures", "Blend Terrain"));
 
+	TArray<uint16> Smoothed;
+
 	{
 		FLandscapeEditDataInterface Edit(LInfo);
 		Edit.GetHeightData(MinX, MinY, MaxX, MaxY, HeightData.GetData(), 0);
 
-		TArray<uint16> Smoothed = HeightData;
+		Smoothed = HeightData;
 
 		// 3x3 box average
 		for (int32 Y = 1; Y < SzY - 1; Y++)
@@ -5531,8 +5567,9 @@ bool ULandscapeService::BlendTerrainFeatures(
 			}
 		}
 
-		Edit.SetHeightData(MinX, MinY, MaxX, MaxY, Smoothed.GetData(), 0, true);
 	}
+
+	WriteHeightsToEditLayer(Landscape, LInfo, MinX, MinY, MaxX, MaxY, Smoothed.GetData());
 
 	UpdateLandscapeAfterHeightEdit(Landscape);
 	return true;

--- a/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
@@ -1603,14 +1603,27 @@ FWidgetAddComponentResult UWidgetService::AddComponent(
 		ParentPanel = Cast<UPanelWidget>(WidgetBP->WidgetTree->RootWidget);
 	}
 
-	// Validate ChildIndex up front rather than silently falling back to append: -1 means append,
-	// [0, GetChildrenCount()] means insert at that position, anything else is an explicit error
-	if (ParentPanel && ChildIndex != -1 && (ChildIndex < 0 || ChildIndex > ParentPanel->GetChildrenCount()))
+	// Validate ChildIndex up front rather than silently falling back to append or to setting the root: -1 means
+	// append, [0, GetChildrenCount()] means insert at that position, anything else is an explicit error - this
+	// must fire even when ParentPanel is null (e.g. no root widget exists yet), since a non-default ChildIndex
+	// has nothing to insert into there and would otherwise silently be ignored by the set-as-root fallback below
+	if (ChildIndex != -1)
 	{
-		Result.ErrorMessage = FString::Printf(
-			TEXT("ChildIndex %d is out of range for parent '%s' (valid range: -1 to append, or 0-%d to insert)"),
-			ChildIndex, *ParentPanel->GetName(), ParentPanel->GetChildrenCount());
-		return Result;
+		if (!ParentPanel)
+		{
+			Result.ErrorMessage = FString::Printf(
+				TEXT("ChildIndex %d was specified, but there is no panel parent to insert into (ChildIndex requires an existing panel parent)"),
+				ChildIndex);
+			return Result;
+		}
+
+		if (ChildIndex < 0 || ChildIndex > ParentPanel->GetChildrenCount())
+		{
+			Result.ErrorMessage = FString::Printf(
+				TEXT("ChildIndex %d is out of range for parent '%s' (valid range: -1 to append, or 0-%d to insert)"),
+				ChildIndex, *ParentPanel->GetName(), ParentPanel->GetChildrenCount());
+			return Result;
+		}
 	}
 
 	// Create the new widget

--- a/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
@@ -1699,30 +1699,39 @@ bool UWidgetService::ReorderComponent(
 	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprint(WidgetPath);
 	if (!WidgetBP || !WidgetBP->WidgetTree)
 	{
+		UE_LOG(LogTemp, Warning, TEXT("UWidgetService::ReorderComponent: Widget Blueprint '%s' not found"), *WidgetPath);
 		return false;
 	}
 
 	UWidget* Widget = FindWidgetByName(WidgetBP, ComponentName);
 	if (!Widget)
 	{
+		UE_LOG(LogTemp, Warning, TEXT("UWidgetService::ReorderComponent: Widget '%s' not found"), *ComponentName);
 		return false;
 	}
 
 	UPanelWidget* ParentPanel = Widget->GetParent();
 	if (!ParentPanel)
 	{
+		UE_LOG(LogTemp, Warning, TEXT("UWidgetService::ReorderComponent: '%s' has no panel parent (the root widget cannot be reordered)"), *ComponentName);
 		return false;
 	}
 
 	if (NewIndex < 0 || NewIndex >= ParentPanel->GetChildrenCount())
 	{
+		UE_LOG(LogTemp, Warning, TEXT("UWidgetService::ReorderComponent: NewIndex %d is out of range for parent '%s' (valid range: 0-%d)"),
+			NewIndex, *ParentPanel->GetName(), ParentPanel->GetChildrenCount() - 1);
 		return false;
 	}
 
 	WidgetBP->Modify();
+	// ShiftChild rewrites ParentPanel->Slots directly, so the panel is the object whose state changes.
+	ParentPanel->Modify();
 	ParentPanel->ShiftChild(NewIndex, Widget);
 	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WidgetBP);
 
+	UE_LOG(LogTemp, Log, TEXT("UWidgetService::ReorderComponent: Moved '%s' to index %d under '%s'"),
+		*ComponentName, NewIndex, *ParentPanel->GetName());
 	return true;
 }
 

--- a/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
@@ -1603,6 +1603,16 @@ FWidgetAddComponentResult UWidgetService::AddComponent(
 		ParentPanel = Cast<UPanelWidget>(WidgetBP->WidgetTree->RootWidget);
 	}
 
+	// Validate ChildIndex up front rather than silently falling back to append: -1 means append,
+	// [0, GetChildrenCount()] means insert at that position, anything else is an explicit error
+	if (ParentPanel && ChildIndex != -1 && (ChildIndex < 0 || ChildIndex > ParentPanel->GetChildrenCount()))
+	{
+		Result.ErrorMessage = FString::Printf(
+			TEXT("ChildIndex %d is out of range for parent '%s' (valid range: -1 to append, or 0-%d to insert)"),
+			ChildIndex, *ParentPanel->GetName(), ParentPanel->GetChildrenCount());
+		return Result;
+	}
+
 	// Create the new widget
 	UWidget* NewWidget = WidgetBP->WidgetTree->ConstructWidget<UWidget>(WidgetClass, FName(*ComponentName));
 	if (!NewWidget)
@@ -1620,11 +1630,10 @@ FWidgetAddComponentResult UWidgetService::AddComponent(
 		WidgetBP->WidgetVariableNameToGuidMap.Add(WidgetFName, FGuid::NewGuid());
 	}
 
-	// Add to parent or set as root
+	// Add to parent or set as root - ChildIndex was already validated above, so it's either -1 (append) or a valid index
 	if (ParentPanel)
 	{
-		const bool bInsertAtIndex = ChildIndex >= 0 && ChildIndex <= ParentPanel->GetChildrenCount();
-		UPanelSlot* Slot = bInsertAtIndex ? ParentPanel->InsertChildAt(ChildIndex, NewWidget) : ParentPanel->AddChild(NewWidget);
+		UPanelSlot* Slot = (ChildIndex >= 0) ? ParentPanel->InsertChildAt(ChildIndex, NewWidget) : ParentPanel->AddChild(NewWidget);
 		if (!Slot)
 		{
 			Result.ErrorMessage = TEXT("Failed to add widget to parent panel");

--- a/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UWidgetService.cpp
@@ -1542,7 +1542,8 @@ FWidgetAddComponentResult UWidgetService::AddComponent(
 	const FString& ComponentType,
 	const FString& ComponentName,
 	const FString& ParentName,
-	bool bIsVariable)
+	bool bIsVariable,
+	int32 ChildIndex)
 {
 	FWidgetAddComponentResult Result;
 	
@@ -1622,7 +1623,8 @@ FWidgetAddComponentResult UWidgetService::AddComponent(
 	// Add to parent or set as root
 	if (ParentPanel)
 	{
-		UPanelSlot* Slot = ParentPanel->AddChild(NewWidget);
+		const bool bInsertAtIndex = ChildIndex >= 0 && ChildIndex <= ParentPanel->GetChildrenCount();
+		UPanelSlot* Slot = bInsertAtIndex ? ParentPanel->InsertChildAt(ChildIndex, NewWidget) : ParentPanel->AddChild(NewWidget);
 		if (!Slot)
 		{
 			Result.ErrorMessage = TEXT("Failed to add widget to parent panel");
@@ -1665,6 +1667,41 @@ FWidgetAddComponentResult UWidgetService::AddComponent(
 	Result.bIsVariable = bIsVariable;
 
 	return Result;
+}
+
+bool UWidgetService::ReorderComponent(
+	const FString& WidgetPath,
+	const FString& ComponentName,
+	int32 NewIndex)
+{
+	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprint(WidgetPath);
+	if (!WidgetBP || !WidgetBP->WidgetTree)
+	{
+		return false;
+	}
+
+	UWidget* Widget = FindWidgetByName(WidgetBP, ComponentName);
+	if (!Widget)
+	{
+		return false;
+	}
+
+	UPanelWidget* ParentPanel = Widget->GetParent();
+	if (!ParentPanel)
+	{
+		return false;
+	}
+
+	if (NewIndex < 0 || NewIndex >= ParentPanel->GetChildrenCount())
+	{
+		return false;
+	}
+
+	WidgetBP->Modify();
+	ParentPanel->ShiftChild(NewIndex, Widget);
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WidgetBP);
+
+	return true;
 }
 
 FWidgetRemoveComponentResult UWidgetService::RemoveComponent(

--- a/Source/VibeUE/Private/Utils/VibeUEPaths.cpp
+++ b/Source/VibeUE/Private/Utils/VibeUEPaths.cpp
@@ -124,6 +124,22 @@ FString FVibeUEPaths::GetConfigDir()
 	return PluginDir / TEXT("Config");
 }
 
+FString FVibeUEPaths::GetSignalsDir()
+{
+	// Use Project/Saved/VibeUE/Signals
+	FString SignalsDir = FPaths::ProjectSavedDir() / TEXT("VibeUE") / TEXT("Signals");
+
+	// Ensure directory exists
+	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+	if (!PlatformFile.DirectoryExists(*SignalsDir) && !PlatformFile.CreateDirectoryTree(*SignalsDir))
+	{
+		UE_LOG(LogVibeUEPaths, Error, TEXT("Could not create VibeUE signals directory: %s"), *SignalsDir);
+		return FString();
+	}
+
+	return SignalsDir;
+}
+
 FString FVibeUEPaths::GetPluginVersionName()
 {
 	IPluginManager& PluginManager = IPluginManager::Get();

--- a/Source/VibeUE/Private/Utils/VibeUEReadinessSignal.cpp
+++ b/Source/VibeUE/Private/Utils/VibeUEReadinessSignal.cpp
@@ -1,0 +1,97 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#include "Utils/VibeUEReadinessSignal.h"
+#include "Utils/VibeUEPaths.h"
+#include "CoreGlobals.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformProcess.h"
+#include "HAL/PlatformTime.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogVibeUESignal, Log, All);
+
+FString FVibeUEReadinessSignal::GetSignalPathForPid(uint32 ProcessId)
+{
+	// Deliberately not FVibeUEPaths::GetSignalsDir() — that creates the directory, and callers such as
+	// Remove() must be able to name the file without touching the filesystem.
+	return FPaths::Combine(
+		FPaths::ProjectSavedDir(),
+		TEXT("VibeUE"),
+		TEXT("Signals"),
+		FString::Printf(TEXT("editor-%u-true.json"), ProcessId));
+}
+
+FString FVibeUEReadinessSignal::GetSignalPath()
+{
+	return GetSignalPathForPid(FPlatformProcess::GetCurrentProcessId());
+}
+
+FDateTime FVibeUEReadinessSignal::GetSessionStartUtc()
+{
+	// GStartTime is FPlatformTime::Seconds() sampled at engine start, so the delta from "now" gives
+	// this process's age. Wall-clock start time is what lets an agent reject a stale signal left by a
+	// crashed editor whose PID was reused.
+	const double SecondsSinceStart = FMath::Max(0.0, FPlatformTime::Seconds() - GStartTime);
+	return FDateTime::UtcNow() - FTimespan::FromSeconds(SecondsSinceStart);
+}
+
+FString FVibeUEReadinessSignal::BuildSignalJson(uint32 ProcessId, const FDateTime& SessionStartUtc, const FDateTime& CreatedUtc)
+{
+	const TSharedRef<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("signal"), TEXT("toolsets-registered"));
+	// JSON has no integer type distinct from double; a PID fits exactly in a double, and writing it as
+	// a number keeps `json.load(...)["pid"] == pid` working for agents.
+	Root->SetNumberField(TEXT("pid"), static_cast<double>(ProcessId));
+	Root->SetStringField(TEXT("createdUtc"), CreatedUtc.ToIso8601());
+	Root->SetStringField(TEXT("sessionStartUtc"), SessionStartUtc.ToIso8601());
+	Root->SetStringField(TEXT("pluginVersion"), FVibeUEPaths::GetPluginVersionName());
+
+	FString Payload;
+	const TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Payload);
+	FJsonSerializer::Serialize(Root, Writer);
+	return Payload;
+}
+
+bool FVibeUEReadinessSignal::Publish()
+{
+	const FString SignalsDir = FVibeUEPaths::GetSignalsDir();
+	if (SignalsDir.IsEmpty())
+	{
+		UE_LOG(LogVibeUESignal, Error, TEXT("VibeUE: failed to create signal directory under %s"), *FPaths::ProjectSavedDir());
+		return false;
+	}
+
+	const uint32 ProcessId = FPlatformProcess::GetCurrentProcessId();
+	const FString SignalPath = GetSignalPathForPid(ProcessId);
+	const FString TempPath = SignalPath + TEXT(".tmp");
+	const FString Payload = BuildSignalJson(ProcessId, GetSessionStartUtc(), FDateTime::UtcNow());
+
+	// Write-then-move: an agent watching for the create event must never read a partial file.
+	if (!FFileHelper::SaveStringToFile(Payload, *TempPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
+	{
+		UE_LOG(LogVibeUESignal, Error, TEXT("VibeUE: failed to stage readiness signal: %s"), *TempPath);
+		return false;
+	}
+
+	IFileManager& FileManager = IFileManager::Get();
+	if (!FileManager.Move(*SignalPath, *TempPath, /*Replace=*/true, /*EvenIfReadOnly=*/true))
+	{
+		UE_LOG(LogVibeUESignal, Error, TEXT("VibeUE: failed to publish readiness signal: %s"), *SignalPath);
+		FileManager.Delete(*TempPath, /*RequireExists=*/false, /*EvenReadOnly=*/true, /*Quiet=*/true);
+		return false;
+	}
+
+	UE_LOG(LogVibeUESignal, Display, TEXT("VibeUE: readiness signal published: %s"), *SignalPath);
+	return true;
+}
+
+void FVibeUEReadinessSignal::Remove()
+{
+	IFileManager& FileManager = IFileManager::Get();
+	const FString SignalPath = GetSignalPath();
+	FileManager.Delete(*SignalPath, /*RequireExists=*/false, /*EvenReadOnly=*/true, /*Quiet=*/true);
+	FileManager.Delete(*(SignalPath + TEXT(".tmp")), /*RequireExists=*/false, /*EvenReadOnly=*/true, /*Quiet=*/true);
+}

--- a/Source/VibeUE/Private/Utils/VibeUEReadinessSignalTests.cpp
+++ b/Source/VibeUE/Private/Utils/VibeUEReadinessSignalTests.cpp
@@ -1,0 +1,115 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#include "Misc/AutomationTest.h"
+#include "Utils/VibeUEReadinessSignal.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformProcess.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Json.h"
+
+#if WITH_AUTOMATION_TESTS
+
+// Covers the readiness signal added in PR #527: path/PID binding, payload shape, and the
+// publish/remove round trip against the real filesystem. Test path prefix VibeUE.Readiness.*.
+// The end-to-end contract (launch script -> Editor-PID -> file appears) is a manual/agent check.
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeReadinessSignalPathTest, "VibeUE.Readiness.SignalPath",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FVibeReadinessSignalPathTest::RunTest(const FString&)
+{
+	const uint32 CurrentPid = FPlatformProcess::GetCurrentProcessId();
+	const FString CurrentPath = FVibeUEReadinessSignal::GetSignalPath();
+
+	TestEqual(TEXT("GetSignalPath == GetSignalPathForPid(current pid)"),
+		CurrentPath, FVibeUEReadinessSignal::GetSignalPathForPid(CurrentPid));
+
+	TestEqual(TEXT("file name is editor-<pid>-true.json"),
+		FPaths::GetCleanFilename(CurrentPath), FString::Printf(TEXT("editor-%u-true.json"), CurrentPid));
+
+	TestEqual(TEXT("lives in Saved/VibeUE/Signals"),
+		FPaths::GetCleanFilename(FPaths::GetPath(CurrentPath)), TEXT("Signals"));
+
+	TestTrue(TEXT("path is under the project Saved dir"),
+		FPaths::IsUnderDirectory(CurrentPath, FPaths::ProjectSavedDir()));
+
+	// A different PID must never resolve to this process's signal — that binding is the whole point.
+	TestNotEqual(TEXT("a different pid yields a different path"),
+		CurrentPath, FVibeUEReadinessSignal::GetSignalPathForPid(CurrentPid + 1));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeReadinessSignalPayloadTest, "VibeUE.Readiness.SignalPayload",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FVibeReadinessSignalPayloadTest::RunTest(const FString&)
+{
+	const FDateTime SessionStart(2026, 8, 3, 10, 0, 0);
+	const FDateTime Created(2026, 8, 3, 10, 0, 42);
+	const FString Payload = FVibeUEReadinessSignal::BuildSignalJson(4242, SessionStart, Created);
+
+	// The file is named .json, so it has to parse as JSON — the original implementation wrote an
+	// empty file, which every consumer would have choked on.
+	TSharedPtr<FJsonObject> Root;
+	const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Payload);
+	if (!TestTrue(TEXT("payload parses as JSON"), FJsonSerializer::Deserialize(Reader, Root) && Root.IsValid()))
+	{
+		return false;
+	}
+
+	TestEqual(TEXT("signal name"), Root->GetStringField(TEXT("signal")), TEXT("toolsets-registered"));
+	TestEqual(TEXT("pid round trips as a number"), static_cast<uint32>(Root->GetNumberField(TEXT("pid"))), 4242u);
+	TestEqual(TEXT("createdUtc is ISO 8601"), Root->GetStringField(TEXT("createdUtc")), Created.ToIso8601());
+	// sessionStartUtc is what lets an agent reject a stale signal from a reused PID.
+	TestEqual(TEXT("sessionStartUtc is ISO 8601"), Root->GetStringField(TEXT("sessionStartUtc")), SessionStart.ToIso8601());
+	TestFalse(TEXT("pluginVersion is populated"), Root->GetStringField(TEXT("pluginVersion")).IsEmpty());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeReadinessSignalPublishRemoveTest, "VibeUE.Readiness.PublishAndRemove",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FVibeReadinessSignalPublishRemoveTest::RunTest(const FString&)
+{
+	IFileManager& FileManager = IFileManager::Get();
+	const FString SignalPath = FVibeUEReadinessSignal::GetSignalPath();
+
+	// RegisterToolsets already published this signal for the running editor, so restore it either way.
+	const bool bWasPublished = FileManager.FileExists(*SignalPath);
+
+	FVibeUEReadinessSignal::Remove();
+	TestFalse(TEXT("Remove() deletes the signal"), FileManager.FileExists(*SignalPath));
+	// Remove() on a missing file must be a no-op, not an error.
+	FVibeUEReadinessSignal::Remove();
+
+	TestTrue(TEXT("Publish() succeeds"), FVibeUEReadinessSignal::Publish());
+	TestTrue(TEXT("signal exists after Publish()"), FileManager.FileExists(*SignalPath));
+	TestFalse(TEXT("no .tmp staging file is left behind"), FileManager.FileExists(*(SignalPath + TEXT(".tmp"))));
+
+	FString OnDisk;
+	if (TestTrue(TEXT("published signal is readable"), FFileHelper::LoadFileToString(OnDisk, *SignalPath)))
+	{
+		TestFalse(TEXT("published signal is not empty"), OnDisk.IsEmpty());
+
+		TSharedPtr<FJsonObject> Root;
+		const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(OnDisk);
+		if (TestTrue(TEXT("published signal parses as JSON"), FJsonSerializer::Deserialize(Reader, Root) && Root.IsValid()))
+		{
+			TestEqual(TEXT("published pid is this process"),
+				static_cast<uint32>(Root->GetNumberField(TEXT("pid"))), FPlatformProcess::GetCurrentProcessId());
+		}
+	}
+
+	// Publishing twice must overwrite cleanly rather than fail on the existing file.
+	TestTrue(TEXT("Publish() is idempotent"), FVibeUEReadinessSignal::Publish());
+	TestTrue(TEXT("signal still exists after republish"), FileManager.FileExists(*SignalPath));
+
+	if (!bWasPublished)
+	{
+		FVibeUEReadinessSignal::Remove();
+	}
+
+	return true;
+}
+
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/VibeUE/Public/PythonAPI/UFabService.h
+++ b/Source/VibeUE/Public/PythonAPI/UFabService.h
@@ -41,7 +41,8 @@ public:
 	 * Refresh=true to re-fetch. Filters are applied locally.
 	 * @param NameFilter    Case-insensitive substring match on the title. Empty = all.
 	 * @param TypeFilter    Match on derived type / distribution method (e.g. "pack","plugin","quixel","model"). Empty = all.
-	 * @param EngineVersion Only assets supporting this engine (e.g. "5.8"). Empty = the current engine.
+	 * @param EngineVersion Only assets supporting this engine (e.g. "5.8"). Empty = the current engine;
+	 *                      "all" (or "any") = no engine filter, results carry a `compatible` flag instead.
 	 * @param Limit         Max items to return. @param Offset Items to skip (paging). @param Refresh Re-fetch the library.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Fab")

--- a/Source/VibeUE/Public/PythonAPI/UWidgetService.h
+++ b/Source/VibeUE/Public/PythonAPI/UWidgetService.h
@@ -586,7 +586,9 @@ public:
 	 * @param ComponentName - Name for the new component
 	 * @param ParentName - Name of parent panel (empty for root)
 	 * @param bIsVariable - Whether to expose as a variable
-	 * @param ChildIndex - Position among the parent's children to insert at (0-based). -1 (default) appends at the end
+	 * @param ChildIndex - Position among the parent's children to insert at (0-based). -1 (default) appends at
+	 *        the end. Any other value must be within [0, parent's current child count] or the call fails with
+	 *        an error - it does not silently fall back to append
 	 * @return Result with success status and details
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Widgets")

--- a/Source/VibeUE/Public/PythonAPI/UWidgetService.h
+++ b/Source/VibeUE/Public/PythonAPI/UWidgetService.h
@@ -586,6 +586,7 @@ public:
 	 * @param ComponentName - Name for the new component
 	 * @param ParentName - Name of parent panel (empty for root)
 	 * @param bIsVariable - Whether to expose as a variable
+	 * @param ChildIndex - Position among the parent's children to insert at (0-based). -1 (default) appends at the end
 	 * @return Result with success status and details
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Widgets")
@@ -594,7 +595,23 @@ public:
 		const FString& ComponentType,
 		const FString& ComponentName,
 		const FString& ParentName = TEXT(""),
-		bool bIsVariable = true);
+		bool bIsVariable = true,
+		int32 ChildIndex = -1);
+
+	/**
+	 * Move an existing widget component to a new position among its current parent's children.
+	 * Maps to action="reorder_component"
+	 *
+	 * @param WidgetPath - Full path to the Widget Blueprint
+	 * @param ComponentName - Name of the component to move
+	 * @param NewIndex - New 0-based position among the parent's children
+	 * @return True if the widget was found, has a panel parent, and was moved
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Widgets")
+	static bool ReorderComponent(
+		const FString& WidgetPath,
+		const FString& ComponentName,
+		int32 NewIndex);
 
 	/**
 	 * Remove a widget component from a Widget Blueprint.

--- a/Source/VibeUE/Public/Utils/VibeUEPaths.h
+++ b/Source/VibeUE/Public/Utils/VibeUEPaths.h
@@ -56,6 +56,14 @@ public:
 	static FString GetScreenshotsDir();
 
 	/**
+	 * Get the VibeUE Signals directory under Project/Saved (agent readiness signals).
+	 * Creates the directory if it doesn't exist.
+	 *
+	 * @return Absolute path to Project/Saved/VibeUE/Signals, or empty string if it could not be created
+	 */
+	static FString GetSignalsDir();
+
+	/**
 	 * Get the VibeUE plugin version name (e.g. "3.0").
 	 * Reads from the plugin descriptor via IPluginManager.
 	 *

--- a/Source/VibeUE/Public/Utils/VibeUEReadinessSignal.h
+++ b/Source/VibeUE/Public/Utils/VibeUEReadinessSignal.h
@@ -1,0 +1,43 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * Per-process readiness signal for MCP agents (PR #527).
+ *
+ * VibeUE writes Project/Saved/VibeUE/Signals/editor-<pid>-true.json when FModule::RegisterToolsets()
+ * reaches its end, and deletes it on module shutdown / editor pre-exit. Agents that launch the editor
+ * via BuildAndLaunchGame.ps1|sh read `Editor-PID=<pid>` from the script output and watch for that one
+ * file instead of polling MCP.
+ *
+ * The signal means only "toolset registration finished for THIS process". Python, World and level
+ * readiness remain separate checks.
+ *
+ * The file carries real JSON (pid, createdUtc, sessionStartUtc, pluginVersion) so a watcher can tell
+ * a fresh signal from one left behind by a crashed editor whose PID the OS later reused: compare
+ * `sessionStartUtc` against the time you launched the process. It is written to a .tmp sibling and
+ * moved into place, so a watcher never observes a half-written file.
+ */
+class VIBEUE_API FVibeUEReadinessSignal
+{
+public:
+	/** Signal file path for an arbitrary process id. Does not create anything. */
+	static FString GetSignalPathForPid(uint32 ProcessId);
+
+	/** Signal file path for the running editor process. */
+	static FString GetSignalPath();
+
+	/** Approximate UTC start time of this editor process, derived from GStartTime. */
+	static FDateTime GetSessionStartUtc();
+
+	/** Build the signal payload. Pure — split out so automation tests can verify it headlessly. */
+	static FString BuildSignalJson(uint32 ProcessId, const FDateTime& SessionStartUtc, const FDateTime& CreatedUtc);
+
+	/** Write the signal for this process. Returns false (and logs) if the directory or file write fails. */
+	static bool Publish();
+
+	/** Delete this process's signal. Safe to call when it does not exist. */
+	static void Remove();
+};

--- a/Source/VibeUE/VibeUE.Build.cs
+++ b/Source/VibeUE/VibeUE.Build.cs
@@ -1,5 +1,6 @@
 // Copyright Buckley Builds LLC 2026 All Rights Reserved.
 
+using System.IO;
 using UnrealBuildTool;
 
 public class VibeUE : ModuleRules
@@ -22,7 +23,26 @@ public class VibeUE : ModuleRules
 		// reusing the login the editor/launcher already holds. EOSSDK provides the SDK headers and the
 		// WITH_EOS_SDK=1 define; EOSShared provides IEOSSDKManager. bRequiresPlatformSDK mirrors the
 		// engine Fab plugin's own Build.cs so the platform SDK is available.
-		bRequiresPlatformSDK = true;
+		//
+		// Some engine installs ship without the Fab plugin entirely (issue #525), so all of this is
+		// conditional on it existing: without it, WITH_VIBEUE_FAB=0 compiles FabService down to stubs
+		// that report the feature as unavailable, and the rest of VibeUE builds normally.
+		bool bFabPluginPresent = File.Exists(
+			Path.Combine(EngineDirectory, "Plugins", "Fab", "Fab.uplugin"));
+		PrivateDefinitions.Add("WITH_VIBEUE_FAB=" + (bFabPluginPresent ? "1" : "0"));
+		if (bFabPluginPresent)
+		{
+			bRequiresPlatformSDK = true;
+			PrivateDependencyModuleNames.AddRange(
+				new string[]
+				{
+					"EOSSDK",                 // FabService (#517): Epic Online Services SDK — headers + WITH_EOS_SDK=1 for Fab auth token
+					"EOSShared",              // FabService (#517): IEOSSDKManager (create/enumerate + auto-tick EOS platforms)
+					"Fab",                    // FabService (#517): reuse the engine Fab plugin's FAB_API downloader (FFabDownloadRequest / queue)
+					"FileUtilities",          // FabService: safely extract public free-asset ZIP downloads
+				}
+			);
+		}
 
 		// Ensure proper debug symbol generation for PDB files
 		if (Target.Configuration == UnrealTargetConfiguration.Debug || 
@@ -111,10 +131,6 @@ public class VibeUE : ModuleRules
 				"StaticMeshDescription",  // For FStaticMeshAttributes / FStaticMeshOperations / FUVMapParameters
 				"ToolsetRegistry",        // UE 5.8 native AI toolset registry — exposes services as AICallable tools on Epic's MCP endpoint
 				"ModelContextProtocol",   // UE 5.8 native MCP server — VibeUE's dynamic tools are bridged onto Epic's endpoint
-				"EOSSDK",                 // FabService (#517): Epic Online Services SDK — headers + WITH_EOS_SDK=1 for Fab auth token
-				"EOSShared",              // FabService (#517): IEOSSDKManager (create/enumerate + auto-tick EOS platforms)
-				"Fab",                    // FabService (#517): reuse the engine Fab plugin's FAB_API downloader (FFabDownloadRequest / queue)
-				"FileUtilities",          // FabService: safely extract public free-asset ZIP downloads
 			}
 		);
 

--- a/VibeUE.uplugin
+++ b/VibeUE.uplugin
@@ -75,11 +75,13 @@
 		},
 		{
 			"Name": "Fab",
-			"Enabled": true
+			"Enabled": true,
+			"Optional": true
 		},
 		{
 			"Name": "EOSShared",
-			"Enabled": true
+			"Enabled": true,
+			"Optional": true
 		}
 	]
 }

--- a/test_prompts/landscape/terrain_feature_composition.md
+++ b/test_prompts/landscape/terrain_feature_composition.md
@@ -1,0 +1,117 @@
+never run more than one tool at a time
+
+# Terrain Feature Composition Tests (edit-layer write path)
+
+Regression coverage for PR #522: `create_valley`/`create_mountain`/`create_plateau`/`create_crater`
+were writing heights via a raw `FLandscapeEditDataInterface::SetHeightData` call with no edit-layer
+scope, so a later layer-content resolve could silently discard the edit — and, because earlier calls
+were written the same way, discard *their* edits too. The observable symptom was a second
+`create_valley` call resetting the whole landscape back to flat.
+
+The point of every check below is **composition and persistence**: an edit must still be there after
+another edit elsewhere, after a forced layer resolve, and after a reload from disk.
+
+Do all of this in a throwaway level — never on a project map that has a real landscape.
+
+---
+
+## Setup
+
+Create a new empty level at /Game/Dev/TerrainCompositionTest and make it the current level. In it,
+create a landscape labelled CompTest at the origin with scale 100,100,100 and 4x4 components of 63
+quads. Confirm it has at least one edit layer.
+
+---
+
+Sample the height at a few widely separated world XY points and confirm the landscape starts flat
+(height 0).
+
+---
+
+## Two valleys must compose, not overwrite
+
+Carve a valley at world (5000, 5000) with radius 3000 and depth 2000, noise off.
+
+---
+
+Read the height back at (5000, 5000). It must be about -2000.
+
+---
+
+Now carve a second valley at (20000, 20000), same radius and depth, noise off.
+
+---
+
+Read the height at BOTH centers. The first valley must still be about -2000 — if it has returned to 0,
+the edit-layer write path has regressed and this is the exact bug #522 fixed. The second must also be
+about -2000.
+
+---
+
+## Overlapping valleys accumulate
+
+Carve a third valley whose radius overlaps the first, centered a short distance away. Read the height
+at the overlap point and confirm it is deeper than either valley alone would make it — overlapping
+carves blend additively rather than replacing each other.
+
+---
+
+## The other radial features behave the same way
+
+Repeat the "two calls, check the first survives" pattern for each of create_mountain, create_plateau
+and create_crater, each at its own well-separated location. All four share one helper, so a regression
+in that helper breaks all of them.
+
+---
+
+After all of those, re-read every earlier feature's center point. Every one must still hold its value.
+Report the full list of positions and heights.
+
+---
+
+## Non-radial features must not wipe the radial ones
+
+These take a different write path (create_ridge, apply_erosion, create_terraces,
+blend_terrain_features, apply_noise, project_mesh_to_landscape). Create a ridge somewhere clear of the
+existing features.
+
+---
+
+Re-read the centers of the valleys, mountain, plateau and crater. They must all be unchanged. Then read
+the ridge's own midpoint and confirm it was raised.
+
+---
+
+## Forced layer resolve
+
+Force a full layer update on the landscape (`force_layers_full_update`), then re-read every feature
+center. Nothing may change — a full resolve rebuilds the merged heightmap from the real per-layer data,
+so anything that disappears here never actually reached layer storage.
+
+---
+
+## Paint layers survive height edits
+
+Add a paint layer to the landscape and paint it at full strength across a large rectangle. Confirm the
+weight reads back as 1.0 at several points.
+
+---
+
+Now carve another valley and create another ridge. Re-read those same weight samples: they must still
+be 1.0. A height write that triggers an unscoped full layer resolve can zero out weightmap data, so a
+weight that has dropped to 0 is a real failure.
+
+---
+
+## Persistence across a reload
+
+Save the level, then load a different level and load this one back again. Re-read every feature center
+and every weight sample. All values must match what they were before the save — in-memory correctness
+is not enough, the edits have to be in the saved layer data.
+
+---
+
+## Cleanup
+
+Delete the /Game/Dev/TerrainCompositionTest level and any layer info asset created for it, and switch
+back to whatever level was open before.

--- a/test_prompts/umg/widget_child_order.md
+++ b/test_prompts/umg/widget_child_order.md
@@ -1,0 +1,165 @@
+never run more than one tool at a time
+
+# Widget Child Order Tests (add_component child_index + reorder_component)
+
+Coverage for ordered insert (`add_component(..., child_index=N)`) and `reorder_component`, added in
+PR #526. Order is what a VerticalBox actually lays out, so every check is a hierarchy readback — do
+not trust a `True` return on its own. Run sequentially.
+
+---
+
+## Setup
+
+Create a widget blueprint called TestChildOrder in the Blueprints folder. If it already exists, delete
+it silently and create a new one. Give it a VerticalBox root named ListRoot, then add three TextBlocks
+under it named ItemA, ItemB, ItemC — in that order, with no child_index.
+
+---
+
+Read the hierarchy back. ListRoot's children must be exactly ItemA, ItemB, ItemC in that order. Report
+the order you actually see.
+
+---
+
+## Insert at the front
+
+Add a TextBlock named Banner under ListRoot at child_index 0.
+
+---
+
+Read the hierarchy back. The order must now be Banner, ItemA, ItemB, ItemC. If Banner landed at the
+end, child_index was ignored — report that as a failure.
+
+---
+
+## Insert in the middle
+
+Add a TextBlock named Middle under ListRoot at child_index 2.
+
+---
+
+Read the hierarchy back: Banner, ItemA, Middle, ItemB, ItemC.
+
+---
+
+## Insert at the end via an explicit index
+
+Add a TextBlock named Tail under ListRoot at a child_index equal to the current number of children
+(that boundary value is legal and means "append").
+
+---
+
+Read the hierarchy back: Tail must be last, and nothing else may have moved.
+
+---
+
+## Default is still append
+
+Add a TextBlock named Appended under ListRoot with no child_index argument at all.
+
+---
+
+Read the hierarchy back. Appended must be last — the default behaviour must not have changed.
+
+---
+
+## Out-of-range insert must fail loudly
+
+Try to add a TextBlock named TooFar under ListRoot at child_index 99.
+
+---
+
+This must fail with an error message naming the valid range — it must NOT silently append. Confirm
+TooFar does not exist in the hierarchy afterwards.
+
+---
+
+Try to add a TextBlock named Negative under ListRoot at child_index -5. Same expectation: an explicit
+error, and no widget created. (Only -1 means append.)
+
+---
+
+## Empty parent name means "the root panel", not "become the root"
+
+Add a TextBlock named IntoRoot with an empty parent name and child_index 0.
+
+---
+
+This must SUCCEED and land at index 0 of ListRoot — an empty parent name resolves to the existing root
+panel. It must not become a second root.
+
+---
+
+## child_index with genuinely no panel parent
+
+Create a second, completely empty widget blueprint (no root widget at all), then try to add a TextBlock
+to it with child_index 0. This must fail with an error explaining there is no panel parent to insert
+into, and must not create the widget. Delete that blueprint afterwards.
+
+---
+
+## Reorder an existing widget
+
+Move ItemC to index 0 with reorder_component.
+
+---
+
+Read the hierarchy back and confirm ItemC is first and every other widget kept its relative order.
+
+---
+
+Move ItemC back to the last index.
+
+---
+
+Read the hierarchy back and confirm it is last.
+
+---
+
+## Reorder edge cases
+
+Reorder a widget to the index it already occupies. This should succeed and change nothing.
+
+---
+
+Try reorder_component with an index equal to the child count (one past the end). It must return False,
+and the hierarchy must be unchanged.
+
+---
+
+Try reorder_component with index -1. It must return False — unlike add_component, -1 is not special
+here.
+
+---
+
+Try reorder_component on a widget name that does not exist. It must return False, not crash.
+
+---
+
+Try reorder_component on ListRoot itself (the root widget, which has no panel parent). It must return
+False, not crash, and the hierarchy must be unchanged.
+
+---
+
+## Reorder does not reparent
+
+Add a HorizontalBox named SideBox under ListRoot, and a TextBlock named Nested under SideBox. Now call
+reorder_component on Nested with index 0.
+
+---
+
+Read the hierarchy back. Nested must still be a child of SideBox — reorder_component only moves a
+widget within its current parent. Moving between parents is reparent_widget's job.
+
+---
+
+## Persistence
+
+Save and reload the widget blueprint, then read the hierarchy one more time. The child order must
+survive the round trip.
+
+---
+
+## Cleanup
+
+Delete the TestChildOrder widget blueprint.


### PR DESCRIPTION
Promotes the current `5-8` development branch to `master` (20 commits, 30 files). `master` was last cut 2026-07-21; several recent user reports (#523, #524, #525) were hit on builds from `master` that predate fixes already on `5-8`.

## Issues closed by this release

- Fixes #525 — VibeUE failed to compile on engine installs without the Fab plugin. The Fab/EOS dependency is now detected at configure time (`WITH_VIBEUE_FAB`), the uplugin references are `Optional`, and `FabService` degrades to a stub reporting `UNSUPPORTED`. (PR #528)
- Fixes #524 — sculpt/flatten appeared to destroy terrain far outside the brush radius. Root cause was height writers bypassing the edit-layer system, so the next layer-aware edit reverted their work during layer resolve. All remaining bypass writers (`ApplyNoise`, `ProjectMeshToLandscape`, `CreateRidge`, `ApplyErosion`, `CreateTerraces`, `BlendTerrainFeatures`) now write through a shared edit-layer-aware helper, completing the earlier `create_mountain`/`valley`/`plateau`/`crater` fix (cc3e35c). (PR #529)
- Fixes #523 — `add_component(parent=...)` / `reparent_component` wrote `ParentComponentOrVariableName` for same-SCS parents, tripping the engine's cyclic-linkage ensure on package load and failing cooks after all packages had cooked. All SCS attachment now goes through `AttachSameScsChild` (completes #371), and `ListComponents` derives `AttachParent` from the SCS tree instead of the corrupt field. (PR #530)

## Also included

- Widget child order: `WidgetService.AddComponent` gains ordered insert (`ChildIndex`) and reorder support, with out-of-range and no-panel-parent rejection instead of silent appends (PR #526)
- Editor readiness signal for MCP agents: JSON payload with stale-PID guard, tests, Linux parity (PR #527)
- `FabService.list_library`: `engine_version` is now a real filter
- Skill/doc updates (fab, umg-widgets, vibeue) and new test prompt packs (widget child order, terrain feature composition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)