### PR TITLE
Fix GameplayEffect tag persistence and clarify notify APIs

### DIFF
--- a/Content/Skills/animsequence/patterns.md
+++ b/Content/Skills/animsequence/patterns.md
@@ -215,7 +215,8 @@ if info:
 9. **Reference Pose**: `create_from_pose` uses skeleton's reference pose
 10. **Notify Class Paths**: `add_notify` and `add_notify_state` require FULL class paths:
    - Instant notify: `/Script/Engine.AnimNotify`
-   - State notify: `/Script/Engine.AnimNotifyState`
+   - State notify: a concrete subclass such as `/Script/Engine.AnimNotifyState_Trail` (the base
+     `/Script/Engine.AnimNotifyState` is abstract and is rejected)
    - Sound notify: `/Script/Engine.AnimNotify_PlaySound`
    - Custom: `/Script/YourModule.YourNotifyClass`
 11. **Bone Rotation Axes Are Non-Intuitive**: Roll/Pitch/Yaw do NOT map predictably to world-space movement. Each bone's local coordinate system is different. **Always discover axis mappings** using `get_reference_pose()` and `get_pose_at_time()` before creating rotation animations!
@@ -224,3 +225,6 @@ if info:
 14. **Search-result objects use `anim_path`/`anim_name`, NOT `package_name`**: `search_animations`, `find_animations_for_skeleton`, and `list_anim_sequences` return `AnimSequenceInfo` objects (fields: `anim_path`, `anim_name`, `enable_root_motion`, `frame_rate`, `frame_count`, `bone_track_count`, `curve_count`, `notify_count`, `rate_scale`, `additive_anim_type`, `skeleton_path`, `raw_size`, `compressed_size`). `package_name`/`package_path` only exist on `AssetDiscoveryService.search_assets` results. Also **filter out `None`** entries before reading fields.
 15. **Scope searches to a folder**: a project-wide wildcard (e.g. `*Run*` over all of `/Game`) can exceed the 30 s Python timeout. Pass a `search_path` folder to keep `search_animations`/`list_anim_sequences` fast.
 16. **Verify frame rate after creation**: `create_anim_sequence(frame_rate=...)` has been observed to come back at 30 FPS for a 60 FPS request — always read back `get_animation_frame_rate(anim_path)` and don't assume a non-30 rate stuck.
+17. **Montages use `AnimMontageService`**: `AnimSequenceService` accepts `AnimSequence` assets only.
+    Passing an `AnimMontage` returns the failure sentinel; call the corresponding
+    `unreal.AnimMontageService` method instead.

--- a/Content/Skills/blueprints/SKILL.md
+++ b/Content/Skills/blueprints/SKILL.md
@@ -223,6 +223,10 @@ Rules:
 - Property names are the **native C++ names**: `bReplicates`, `InitialLifeSpan`, `bCanBeDamaged` —
   the `b` prefix is NOT stripped here (a stripped name returns `None`).
 - Values read back as strings: compare `value == "True"`, not `value is True`.
+- On UE 5.3+, `set_property` maps the deprecated GameplayEffect CDO fields
+  `InheritableGameplayEffectTags` and `InheritableOwnedTagsContainer` to their Asset Tags and
+  Target Tags GameplayEffect Components. Writing only the legacy fields is otherwise erased by
+  `UGameplayEffect::PreSave`.
 
 ### ⚠️ Info Struct Fields (don't guess — these are the complete lists)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://www.vibeue.com/
 **VibeUE is the MCP Expansion + AI Editor Toolset for Unreal Engine 5.8+.** Unreal 5.8 added a
 built-in MCP server and AI toolsets; VibeUE is an **MCP Expansion** that plugs straight into them and
 adds a deep **AI Editor Toolset** — a library of editor capabilities — Blueprints, materials, landscape, foliage, animation, Niagara, UMG, audio, StateTree,
-gameplay tags, input, UVs, **performance/profiling**, and more — registered into the engine's own
+Behavior Trees & Blackboards, gameplay tags, input, UVs, **performance/profiling**, and more — registered into the engine's own
 `ToolsetRegistry` and `ModelContextProtocol` server, plus rich domain **skills** served through
 Unreal's native `AgentSkill` system. Any MCP-capable agent (Claude Code, Cursor, Copilot, …) drives
 your editor through Unreal's standard MCP endpoint.
@@ -45,6 +45,9 @@ VibeUE **complements** them — it focuses on the domains and depth the engine d
 - **UI** — UMG widgets with MVVM bindings, animation authoring, and preview/PIE validation.
 - **Higher-order Blueprint authoring** — timelines, event dispatchers, delegates, custom-event pins,
   comment boxes, and a batch `build_graph` builder.
+- **AI behavior authoring** — Behavior Tree node/decorator/service editing by structural path with
+  blackboard key binding, JSON tree round-trips, and validate/repair; full Blackboard asset + key
+  CRUD. Writes go through the editor EdGraph with PIE- and open-editor-aware refusal guards.
 - **Editor safety** — `TransactionService` wraps the editor's transaction buffer (undo / redo /
   checkpoints) so an agent can group and roll back its own edits — the engine's toolsets expose none.
 - **⚡ Performance & profiling** — VibeUE's standout: see the dedicated section below.
@@ -94,7 +97,7 @@ VibeUE plugs into three native UE 5.8+ systems:
 2. **MCP server** (`ModelContextProtocol`) — a small set of VibeUE utility tools are registered
    directly on the endpoint: `execute_python_code`, `discover_python_module`/`_class`/`_function`,
    `list_python_subsystems`, `deep_research`, `terrain_data`.
-3. **Skills** (`AgentSkillToolset`) — ~34 markdown skill packs register as native `UAgentSkill`s,
+3. **Skills** (`AgentSkillToolset`) — ~36 markdown skill packs register as native `UAgentSkill`s,
    discoverable via `ListSkills` and loaded lazily via `GetSkills`, alongside the engine's own skills.
 
 **Efficient usage (for agents):** `execute_python_code` is the workhorse — it batches a whole

--- a/Source/VibeUE/Private/PythonAPI/UAnimSequenceService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UAnimSequenceService.cpp
@@ -58,8 +58,14 @@ UAnimSequence* UAnimSequenceService::LoadAnimSequence(const FString& AnimPath)
 		}
 		else
 		{
-			UE_LOG(LogTemp, Warning, TEXT("UAnimSequenceService::LoadAnimSequence: Not an AnimSequence: %s (got %s)"), 
-				*AnimPath, *LoadedObject->GetClass()->GetName());
+			const bool bIsMontage = LoadedObject->GetClass()->GetName().Contains(TEXT("AnimMontage"));
+			UE_LOG(LogTemp, Warning,
+				TEXT("UAnimSequenceService::LoadAnimSequence: Not an AnimSequence: %s (got %s).%s"),
+				*AnimPath,
+				*LoadedObject->GetClass()->GetName(),
+				bIsMontage
+					? TEXT(" Montage assets must use unreal.AnimMontageService (for example, add_notify or add_notify_state).")
+					: TEXT(""));
 			return nullptr;
 		}
 	}

--- a/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UBlueprintService.cpp
@@ -54,6 +54,7 @@
 #include "GameFramework/Character.h"
 #include "GameFramework/PlayerController.h"
 #include "UObject/Package.h"
+#include "UObject/UnrealType.h"
 #include "UObject/UObjectIterator.h"
 #include "Factories/BlueprintFactory.h"
 #include "WidgetBlueprintFactory.h"      // For creating WidgetBlueprints (UBlueprintFactory can't)
@@ -86,6 +87,188 @@
 
 namespace
 {
+	class FScopedVibePropertyValue
+	{
+	public:
+		explicit FScopedVibePropertyValue(FProperty* InProperty)
+			: Property(InProperty)
+			, Data(InProperty ? FMemory::Malloc(InProperty->GetSize(), InProperty->GetMinAlignment()) : nullptr)
+		{
+			if (Data)
+			{
+				Property->InitializeValue(Data);
+			}
+		}
+
+		~FScopedVibePropertyValue()
+		{
+			if (Data)
+			{
+				Property->DestroyValue(Data);
+				FMemory::Free(Data);
+			}
+		}
+
+		FScopedVibePropertyValue(const FScopedVibePropertyValue&) = delete;
+		FScopedVibePropertyValue& operator=(const FScopedVibePropertyValue&) = delete;
+
+		explicit operator bool() const { return Data != nullptr; }
+		void* GetData() const { return Data; }
+
+	private:
+		FProperty* Property = nullptr;
+		void* Data = nullptr;
+	};
+
+	/** Parse into default-initialized storage, then replace the destination as one value. ImportText
+	 * otherwise merges compound members into their existing storage, so an explicit empty array or
+	 * tag container can leave old entries behind. */
+	static bool ImportPropertyValueReplacing(
+		FProperty* Property,
+		void* Destination,
+		UObject* Owner,
+		const FString& Text)
+	{
+		FScopedVibePropertyValue ParsedValue(Property);
+		if (!ParsedValue || !Property->ImportText_Direct(*Text, ParsedValue.GetData(), Owner, PPF_None))
+		{
+			return false;
+		}
+
+		Property->CopyCompleteValue(Destination, ParsedValue.GetData());
+		return true;
+	}
+
+	/**
+	 * UE 5.3+ keeps the two legacy GameplayEffect tag containers as read-only compatibility
+	 * mirrors. UGameplayEffect::PreSave clears them and rebuilds them from GEComponents, so a
+	 * successful ImportText on the legacy property alone is discarded during SaveAsset.
+	 *
+	 * Keep BlueprintService independent of the optional GameplayAbilities plugin by using
+	 * reflection. When the target really is a GameplayEffect, mirror the requested legacy value
+	 * into the modern component that owns it before the asset is saved.
+	 */
+	static bool TrySetGameplayEffectTagCompatibilityProperty(
+		UObject* CDO,
+		const FString& PropertyName,
+		const FString& PropertyValue,
+		bool& bOutHandled,
+		FString& InOutExpectedValue)
+	{
+		bOutHandled = false;
+
+		const TCHAR* ComponentClassPath = nullptr;
+		const TCHAR* ComponentPropertyName = nullptr;
+		if (PropertyName == TEXT("InheritableGameplayEffectTags"))
+		{
+			ComponentClassPath = TEXT("/Script/GameplayAbilities.AssetTagsGameplayEffectComponent");
+			ComponentPropertyName = TEXT("InheritableAssetTags");
+		}
+		else if (PropertyName == TEXT("InheritableOwnedTagsContainer"))
+		{
+			ComponentClassPath = TEXT("/Script/GameplayAbilities.TargetTagsGameplayEffectComponent");
+			ComponentPropertyName = TEXT("InheritableGrantedTagsContainer");
+		}
+		else
+		{
+			return true;
+		}
+
+		bool bIsGameplayEffect = false;
+		for (UClass* Class = CDO ? CDO->GetClass() : nullptr; Class; Class = Class->GetSuperClass())
+		{
+			if (Class->GetPathName() == TEXT("/Script/GameplayAbilities.GameplayEffect"))
+			{
+				bIsGameplayEffect = true;
+				break;
+			}
+		}
+		if (!bIsGameplayEffect)
+		{
+			return true;
+		}
+		bOutHandled = true;
+
+		UClass* ComponentClass = LoadObject<UClass>(nullptr, ComponentClassPath);
+		FArrayProperty* ComponentsProperty = FindFProperty<FArrayProperty>(CDO->GetClass(), TEXT("GEComponents"));
+		FObjectPropertyBase* ComponentObjectProperty = ComponentsProperty
+			? CastField<FObjectPropertyBase>(ComponentsProperty->Inner)
+			: nullptr;
+		FProperty* ComponentValueProperty = ComponentClass
+			? ComponentClass->FindPropertyByName(ComponentPropertyName)
+			: nullptr;
+		if (!ComponentClass || !ComponentsProperty || !ComponentObjectProperty || !ComponentValueProperty)
+		{
+			UE_LOG(LogTemp, Error,
+				TEXT("SetProperty: GameplayEffect compatibility mapping for '%s' is unavailable in this engine build"),
+				*PropertyName);
+			return false;
+		}
+
+		void* ComponentsAddress = ComponentsProperty->ContainerPtrToValuePtr<void>(CDO);
+		FScriptArrayHelper Components(ComponentsProperty, ComponentsAddress);
+		UObject* Component = nullptr;
+		int32 AddedComponentIndex = INDEX_NONE;
+		for (int32 Index = 0; Index < Components.Num(); ++Index)
+		{
+			UObject* Candidate = ComponentObjectProperty->GetObjectPropertyValue(Components.GetRawPtr(Index));
+			if (Candidate && Candidate->IsA(ComponentClass))
+			{
+				Component = Candidate;
+				break;
+			}
+		}
+
+		if (!Component)
+		{
+			CDO->Modify();
+			Component = NewObject<UObject>(
+				CDO,
+				ComponentClass,
+				NAME_None,
+				CDO->GetMaskedFlags(RF_PropagateToSubObjects) | RF_Transactional);
+			if (!Component)
+			{
+				UE_LOG(LogTemp, Error,
+					TEXT("SetProperty: Failed to create GameplayEffect component '%s' for '%s'"),
+					ComponentClassPath, *PropertyName);
+				return false;
+			}
+
+			AddedComponentIndex = Components.AddValue();
+			ComponentObjectProperty->SetObjectPropertyValue(Components.GetRawPtr(AddedComponentIndex), Component);
+			UE_LOG(LogTemp, Log,
+				TEXT("SetProperty: Added GameplayEffect component '%s' for legacy property '%s'"),
+				ComponentClassPath, *PropertyName);
+		}
+
+		Component->Modify();
+		void* ComponentValueAddress = ComponentValueProperty->ContainerPtrToValuePtr<void>(Component);
+		if (!ImportPropertyValueReplacing(
+			ComponentValueProperty, ComponentValueAddress, Component, PropertyValue))
+		{
+			if (AddedComponentIndex != INDEX_NONE)
+			{
+				Components.RemoveValues(AddedComponentIndex, 1);
+				Component->MarkAsGarbage();
+			}
+			UE_LOG(LogTemp, Error,
+				TEXT("SetProperty: Failed to parse '%s' for GameplayEffect component property '%s'"),
+				*PropertyValue, ComponentPropertyName);
+			return false;
+		}
+
+#if WITH_EDITOR
+		FPropertyChangedEvent ChangedEvent(ComponentValueProperty, EPropertyChangeType::ValueSet);
+		Component->PostEditChangeProperty(ChangedEvent);
+#endif
+		// The component recomputes CombinedTags from Added/Removed (and any parent), so this is the
+		// canonical value the legacy compatibility mirror must contain after save.
+		ComponentValueProperty->ExportTextItem_Direct(
+			InOutExpectedValue, ComponentValueAddress, nullptr, Component, PPF_None);
+		return true;
+	}
+
 	static UEdGraph* ResolveBlueprintGraph(UBlueprint* Blueprint, const FString& GraphName)
 	{
 		if (!Blueprint)
@@ -5770,17 +5953,69 @@ bool UBlueprintService::SetProperty(
 	// Import property value from string. ImportText returns null on parse failure —
 	// report it instead of saving an unchanged asset and claiming success (issue #352).
 	void* PropertyAddr = Property->ContainerPtrToValuePtr<void>(CDO);
-	if (!Property->ImportText_Direct(*PropertyValue, PropertyAddr, CDO, PPF_None))
+	FScopedVibePropertyValue OriginalValue(Property);
+	Property->CopyCompleteValue(OriginalValue.GetData(), PropertyAddr);
+
+	FScopedVibePropertyValue ParsedValue(Property);
+	if (!ParsedValue || !Property->ImportText_Direct(*PropertyValue, ParsedValue.GetData(), CDO, PPF_None))
 	{
 		UE_LOG(LogTemp, Error, TEXT("SetProperty: Failed to parse '%s' for property '%s' (%s) — value rejected by ImportText"),
 			*PropertyValue, *PropertyName, *Property->GetClass()->GetName());
 		return false;
 	}
 
-	FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
-	UEditorAssetLibrary::SaveAsset(BlueprintPath, false);
+	FString ExpectedValue;
+	Property->ExportTextItem_Direct(ExpectedValue, ParsedValue.GetData(), nullptr, CDO, PPF_None);
+	Property->CopyCompleteValue(PropertyAddr, ParsedValue.GetData());
 
-	UE_LOG(LogTemp, Log, TEXT("SetProperty: Set property '%s' = '%s'"), *PropertyName, *PropertyValue);
+	bool bHandledGameplayEffectCompatibilityProperty = false;
+	if (!TrySetGameplayEffectTagCompatibilityProperty(
+		CDO,
+		PropertyName,
+		PropertyValue,
+		bHandledGameplayEffectCompatibilityProperty,
+		ExpectedValue))
+	{
+		Property->CopyCompleteValue(PropertyAddr, OriginalValue.GetData());
+		return false;
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+	if (!UEditorAssetLibrary::SaveAsset(BlueprintPath, false))
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetProperty: Failed to save blueprint: %s"), *BlueprintPath);
+		return false;
+	}
+
+	// A successful parse is not a successful write when PreSave or another engine callback
+	// replaces the value. Re-read the persisted CDO and report that case instead of returning a
+	// false positive (issue #539).
+	UBlueprint* SavedBlueprint = LoadBlueprint(BlueprintPath);
+	UClass* SavedClass = SavedBlueprint ? SavedBlueprint->GeneratedClass : nullptr;
+	UObject* SavedCDO = SavedClass ? SavedClass->GetDefaultObject() : nullptr;
+	FProperty* SavedProperty = SavedClass ? SavedClass->FindPropertyByName(*PropertyName) : nullptr;
+	if (!SavedCDO || !SavedProperty)
+	{
+		UE_LOG(LogTemp, Error, TEXT("SetProperty: Could not verify saved property '%s' on '%s'"),
+			*PropertyName, *BlueprintPath);
+		return false;
+	}
+
+	FString ActualValue;
+	const void* SavedPropertyAddr = SavedProperty->ContainerPtrToValuePtr<void>(SavedCDO);
+	SavedProperty->ExportTextItem_Direct(ActualValue, SavedPropertyAddr, nullptr, SavedCDO, PPF_None);
+	if (ActualValue != ExpectedValue)
+	{
+		UE_LOG(LogTemp, Error,
+			TEXT("SetProperty: Property '%s' was written as '%s' but the asset saved '%s'. An engine callback rewrote the value."),
+			*PropertyName, *ExpectedValue, *ActualValue);
+		return false;
+	}
+
+	UE_LOG(LogTemp, Log, TEXT("SetProperty: Set property '%s' = '%s'%s"),
+		*PropertyName,
+		*ActualValue,
+		bHandledGameplayEffectCompatibilityProperty ? TEXT(" through its GameplayEffect component") : TEXT(""));
 	return true;
 }
 

--- a/Source/VibeUE/Public/PythonAPI/UAnimSequenceService.h
+++ b/Source/VibeUE/Public/PythonAPI/UAnimSequenceService.h
@@ -996,7 +996,7 @@ public:
 	/**
 	 * Add an instant notify (point in time).
 	 *
-	 * @param AnimPath - Full path to the animation asset (use package_name from AssetData, not package_path)
+	 * @param AnimPath - Full path to an AnimSequence asset (montages must use AnimMontageService)
 	 * @param NotifyClass - Full class path (e.g., "/Script/Engine.AnimNotify" or "/Script/Engine.AnimNotify_PlaySound")
 	 * @param TriggerTime - Time in seconds when notify triggers
 	 * @param NotifyName - Optional name for the notify
@@ -1012,8 +1012,8 @@ public:
 	/**
 	 * Add a notify state (duration-based).
 	 *
-	 * @param AnimPath - Full path to the animation asset (use package_name from AssetData, not package_path)
-	 * @param NotifyStateClass - Full class path (e.g., "/Script/Engine.AnimNotifyState")
+	 * @param AnimPath - Full path to an AnimSequence asset (montages must use AnimMontageService)
+	 * @param NotifyStateClass - Full path to a concrete class (e.g., "/Script/Engine.AnimNotifyState_Trail")
 	 * @param StartTime - Start time in seconds
 	 * @param Duration - Duration in seconds
 	 * @param NotifyName - Optional name for the notify

--- a/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
+++ b/Source/VibeUE/Public/PythonAPI/UBlueprintService.h
@@ -2826,6 +2826,10 @@ public:
 	 *
 	 * Example:
 	 *   unreal.BlueprintService.set_property("/Game/BP_Player", "Health", "150.0")
+	 *
+	 * UE 5.3+ GameplayEffect compatibility:
+	 *   InheritableGameplayEffectTags and InheritableOwnedTagsContainer are persisted through
+	 *   their AssetTags and TargetTags GameplayEffect Components, respectively.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Blueprints")
 	static bool SetProperty(


### PR DESCRIPTION
## Summary
- persist `BlueprintService.set_property` writes to the UE 5.3+ legacy GameplayEffect tag fields by updating their Asset Tags / Target Tags GameplayEffect Components through reflection
- parse property text into fresh storage, replace compound values atomically, and verify the value after `SaveAsset` so rewritten/no-op writes no longer report success
- clarify that `AnimSequenceService` accepts AnimSequence assets only, point montage callers to `AnimMontageService`, and document that notify states require a concrete class

## Issue review
- **#538:** not valid as stated. On UE 5.8, both `AnimSequenceService.add_notify` and `add_notify_state` return valid indices for an AnimSequence. The repro passes an AnimMontage to `AnimSequenceService`; the corresponding `AnimMontageService` methods succeed. This PR makes that service mismatch explicit in the runtime warning and docs.
- **#539:** valid. UE 5.8 `UGameplayEffect::PreSave` clears the deprecated containers and rebuilds them from GameplayEffect Components, which discarded the generic ImportText write while the service returned `True`.

## Validation
- strict warnings-as-errors rebuild: 77/77 compile/link actions succeeded
- post-fix incremental rebuilds succeeded after each refinement
- UE 5.8 editor repro verified both tag properties empty -> populated, populated -> empty, and populated again
- restarted the editor and verified both values and their two GameplayEffect Components persisted from disk
- verified invalid property text returns `False` without mutation and a normal `DurationPolicy` write still succeeds
- verified notify behavior: AnimSequence service on AnimSequence returned a valid index; AnimSequence service on AnimMontage returned `-1` with the new guidance; AnimMontage service on AnimMontage returned a valid index

Fixes #539
Refs #538