### PR TITLE
skills(gas): GAS routing skill from the live Proteus capability spike (#536)

### DIFF
--- a/Content/Skills/gas/SKILL.md
+++ b/Content/Skills/gas/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: gas
+display_name: Gameplay Ability System (GAS)
+description: Author and PIE-verify Gameplay Ability System content — abilities, attribute sets, gameplay effects, gameplay events, costs/cooldowns, cues — by composing Epic's GASToolsets/GameplayTagsToolset with Blueprint/Object tools and Python. Use when the user asks to add abilities, attributes, damage/buff effects, cooldowns, gameplay cues, or to inspect a live ASC.
+vibeue_classes:
+  - GameplayTagService
+  - BlueprintService
+unreal_classes:
+  - UAbilitySystemComponent
+  - UGameplayAbility
+  - UGameplayEffect
+  - UAttributeSet
+  - UAbilitySystemBlueprintLibrary
+keywords:
+  - gameplay ability system
+  - GAS
+  - ability system component
+  - ASC
+  - attribute set
+  - gameplay effect
+  - gameplay event
+  - gameplay cue
+  - cooldown
+  - cost
+---
+
+> 🧠 **Brains complement:** IF an `unreal-engine-skills-manager` tool (external MCP) exists in this session, call it with `{action: "load", skill: "gameplay-ability-system"}` for UE domain knowledge (ASC setup, attribute/effect/ability APIs, networking) — treat it as the rubric for any review / "best practices" question. If no such tool is available, skip this line entirely and proceed with this skill alone — do NOT attempt the call.
+
+# Gameplay Ability System Skill
+
+**Compose, do not duplicate.** Everything GAS needs already exists across Epic's engine toolsets,
+the generic Blueprint/Object tools, and Python. VibeUE adds no GAS wrapper service; this skill is
+the routing map plus the live-verified gotchas.
+
+## Ownership matrix — who does what
+
+| Operation | Owner |
+|---|---|
+| Inspect a live ASC (PIE): attributes, active tags, active effects, granted abilities | Epic **`GASToolsets.AbilitySystemInspectorToolset`** → `GetAttributeValues` / `GetActiveTags` / `GetActiveEffects` / `GetGrantedAbilities`. Input is `{"actor": {"refPath": "<actor path>"}}` — works on PIE actors, no selection needed |
+| Discover attribute set classes / attributes | Epic **`GASToolsets.AttributeSetToolset`** → `FindAttributeSetClasses` / `ListAttributes` |
+| Gameplay Cue notify assets + cue tags | Epic **`GASToolsets.GameplayCueToolset`** (list/get/create/execute-on-selected) |
+| Tag CRUD (add/remove/rename/list single tags) | Epic **`GameplayTagsToolset`** — see the `gameplay-tags` skill |
+| Bulk tag registration, hierarchy queries, existence checks | `unreal.GameplayTagService` (VibeUE delta — see `gameplay-tags`) |
+| Create GameplayAbility / GameplayEffect / AttributeSet **Blueprint** subclasses, CDO config | Epic `BlueprintTools` + `ObjectTools` (or native Python `BlueprintFactory` with the right `ParentClass`) |
+| Ability / cue Blueprint graphs | Epic `BlueprintTools` + `unreal.BlueprintService.build_graph` (see `blueprint-graphs`) |
+| GameplayEffect legacy tag containers (Asset/Target Tags) | `unreal.BlueprintService.set_property` — maps them onto the UE 5.3+ GE Components (VibeUE #539/#541) |
+| Runtime PIE testing | `EditorToolset.EditorAppToolset` StartPIE/StopPIE + Python on live actors (below) |
+| Native C++ attribute sets / effects / abilities | **Coding-agent handoff** — C++ patterns below are for that agent, not for editor tools |
+
+## Python exposure facts (live-verified, UE 5.8)
+
+- `UAbilitySystemBlueprintLibrary` is exposed as **`unreal.AbilitySystemLibrary`** (the
+  "BlueprintLibrary" name does not exist in Python).
+  `asc = unreal.AbilitySystemLibrary.get_ability_system_component(actor)`.
+- **`FGameplayTag` cannot be constructed from raw Python**: `unreal.GameplayTag(tag_name=...)` is
+  rejected, `TagName` is read-only via `set_editor_property`, and
+  `GameplayTagLibrary.make_literal_gameplay_tag` takes an FGameplayTag (circular). Consequence:
+  tag-parameter APIs (`asc.has_matching_gameplay_tag`, `send_gameplay_event_to_actor`) are
+  unusable from raw Python. Work around it:
+  - **reads** → Epic inspector `GetActiveTags` (returns tag names as strings);
+  - **event sending / tag checks** → call a project-side `BlueprintCallable` seam that owns the
+    tag (e.g. a controller method that sends the event), or hand off to C++.
+- `asc.get_owned_gameplay_tags()` is NOT exposed. Use the inspector.
+- ASC `BlueprintCallable`s that take a **class** work fine:
+  `asc.try_activate_ability_by_class(unreal.MyGA_Class)` — this is the reliable Python path to
+  drive abilities in PIE (it bypasses any component-level gates, which makes tests deterministic).
+- Multiple activations inside ONE `execute_python_code` call happen in the same frame — no
+  timers tick and no GE durations expire between them. Exploit this to hit caps/lockouts
+  deterministically instead of sleeping wall-clock time.
+
+## PIE verification recipe (one round-trip per step)
+
+```python
+import unreal, json
+world = unreal.get_editor_subsystem(unreal.UnrealEditorSubsystem).get_game_world()
+pawn = unreal.GameplayStatics.get_player_pawn(world, 0)
+ref = json.dumps({"actor": {"refPath": pawn.get_path_name()}})
+for tool in ["GetAttributeValues", "GetActiveTags", "GetActiveEffects", "GetGrantedAbilities"]:
+    r = unreal.ToolsetRegistry.execute_tool("GASToolsets.AbilitySystemInspectorToolset", tool, ref)
+    print(tool, r.get_value_as_json_string())
+# drive an ability and re-inspect IN THE SAME CALL for deterministic assertions
+asc = unreal.AbilitySystemLibrary.get_ability_system_component(pawn)
+asc.try_activate_ability_by_class(unreal.MyGA_Fire)
+```
+
+Damage through the classic funnel also exercises GE pipelines when the project routes
+`TakeDamage` into effects: `unreal.GameplayStatics.apply_damage(actor, 25.0, None, None, None)`.
+
+## C++ authoring gotchas (for the coding-agent handoff)
+
+- **Never call `UGameplayEffect::FindOrAddComponent`/`AddComponent` in a GE constructor** — they
+  `NewObject` with an empty name, which fatal-asserts at CDO construction and kills the editor on
+  module load. In constructors use
+  `CreateDefaultSubobject<UTargetTagsGameplayEffectComponent>(TEXT("TargetTags"))`, call
+  `SetAndApplyTargetTagChanges(...)`, then `GEComponents.Add(...)` (protected — do it inside the
+  class).
+- SetByCaller cost/cooldown GEs: `CommitAbility` alone applies a **0-magnitude** spec and logs a
+  warning. Override `ApplyCost`/`ApplyCooldown`, build the spec with
+  `MakeOutgoingGameplayEffectSpec`, `SetSetByCallerMagnitude(tag, value)`, then
+  `ApplyGameplayEffectSpecToOwner`.
+- `AbilityTags` is deprecated in 5.5+ — call `SetAssetTags(container)` in the constructor.
+- `NonInstanced` instancing is deprecated — default to `InstancedPerActor`.
+- `UAbilitySystemGlobals::Get().InitGlobalData()` must run once at startup (GameInstance::Init /
+  AssetManager) or target data and montage prediction fail silently.
+- Set `[/Script/GameplayAbilities.AbilitySystemGlobals]` `+GameplayCueNotifyPaths=/Game/GameplayCues`
+  in DefaultGame.ini, or the cue manager scans all of /Game/ (startup warning + cost).
+
+## Verification rules
+
+After authoring: compile (`unreal.BlueprintEditorLibrary.compile_blueprint`), then prove behavior
+in PIE with the inspector — a successful tool call is not evidence. Attribute deltas, active-tag
+presence, and effect duration/stack readouts are the evidence to report.

--- a/Content/Skills/gas/SKILL.md
+++ b/Content/Skills/gas/SKILL.md
@@ -54,12 +54,14 @@ the routing map plus the live-verified gotchas.
   `asc = unreal.AbilitySystemLibrary.get_ability_system_component(actor)`.
 - **`FGameplayTag` cannot be constructed from raw Python**: `unreal.GameplayTag(tag_name=...)` is
   rejected, `TagName` is read-only via `set_editor_property`, and
-  `GameplayTagLibrary.make_literal_gameplay_tag` takes an FGameplayTag (circular). Consequence:
-  tag-parameter APIs (`asc.has_matching_gameplay_tag`, `send_gameplay_event_to_actor`) are
-  unusable from raw Python. Work around it:
-  - **reads** → Epic inspector `GetActiveTags` (returns tag names as strings);
-  - **event sending / tag checks** → call a project-side `BlueprintCallable` seam that owns the
-    tag (e.g. a controller method that sends the event), or hand off to C++.
+  `GameplayTagLibrary.make_literal_gameplay_tag` takes an FGameplayTag (circular).
+  **Use VibeUE's escape hatch**: `unreal.GameplayTagService.request_tag("A.B.C")` returns the real
+  registered tag VALUE (invalid tag for unknown names — check with
+  `GameplayTagLibrary.is_gameplay_tag_valid`), and `request_tag_container([...])` batches into a
+  container. That unlocks every tag-typed API: `asc.has_matching_gameplay_tag`,
+  `send_gameplay_event_to_actor`, `assign_tag_set_by_caller_magnitude`, tag-keyed `TMap`
+  authoring, and tag queries. For pure READS the Epic inspector `GetActiveTags` also returns tag
+  names as strings without needing tag values.
 - `asc.get_owned_gameplay_tags()` is NOT exposed. Use the inspector.
 - ASC `BlueprintCallable`s that take a **class** work fine:
   `asc.try_activate_ability_by_class(unreal.MyGA_Class)` — this is the reliable Python path to

--- a/Content/Skills/vibeue/SKILL.md
+++ b/Content/Skills/vibeue/SKILL.md
@@ -79,7 +79,7 @@ when two areas seem to fit, the one that *excludes* your task is telling you whe
 | Functional area | Use for â€” **NOT** forâ€¦ | Load skill(s) |
 |---|---|---|
 | **Scene & actors** | place / move / arrange / organize / tag actors in a level â€” NOT gameplay logic (â†’ Blueprints), NOT world-scale terrain/foliage (â†’ Environment), NOT attaching a Niagara/particle component (â†’ VFX) | `level-actors` |
-| **Blueprints & gameplay logic** | author Blueprint classes & graphs, Enhanced Input, gameplay tags â€” NOT AI behavior (â†’ AI), NOT AnimBP graphs (â†’ Animation), NOT C++/source (coding-agent handoff) | `blueprints`, `blueprint-graphs`, `enhanced-input`, `gameplay-tags` |
+| **Blueprints & gameplay logic** | author Blueprint classes & graphs, Enhanced Input, gameplay tags, Gameplay Ability System (abilities/attributes/effects/cues) â€” NOT AI behavior (â†’ AI), NOT AnimBP graphs (â†’ Animation), NOT C++/source (coding-agent handoff) | `blueprints`, `blueprint-graphs`, `enhanced-input`, `gameplay-tags`, `gas` |
 | **AI** | author StateTree logic â€” states, tasks, transitions, event payloads, delegate bindings â€” NOT character body animation (â†’ Animation), NOT generic actor placement (â†’ Scene) | `state-trees` |
 | **Animation & rigging** | AnimBP state machines, AnimSequence keyframes, montages & AnimNotify wiring, bone/skeleton editing & retarget â€” NOT cinematic timelines (Epic Sequencer), NOT AI movement (â†’ AI), NOT authoring/adding sound assets â€” even a character's footstep sounds (â†’ Audio) | `animation-blueprint`, `animsequence`, `animation-editing`, `animation-montage`, `skeleton` |
 | **Materials & shading** | materials, instances, graph nodes, Custom HLSL â€” NOT Niagara particle materials (â†’ VFX), NOT landscape auto-materials (â†’ Environment) | `materials` |
@@ -152,6 +152,7 @@ called via `call_tool` (run `describe_toolset` for action names/params):
 | List / read / filter / tail UE logs | `LogsToolset` |
 | Search / open / save / move / import assets | `AssetTools` |
 | Single-tag gameplay-tag CRUD | `GameplayTagsToolset` (see `gameplay-tags` skill) |
+| Inspect a live Ability System (attributes/tags/effects/abilities), attribute-set discovery, gameplay cues | `GASToolsets.*` (see `gas` skill) |
 
 Performance/Insights tracing is the one net-new VibeUE service â€” `unreal.PerformanceService.*` (see
 the `profiling` skill) â€” because Unreal 5.8 ships no performance toolset.


### PR DESCRIPTION
Part of #536 (skill-only deliverable). Adds `Content/Skills/gas/SKILL.md` and routes it from the `vibeue` skill index.

Grounded in a live UE 5.8 capability spike (Proteus GAS migration, AB#73): every claim was exercised against a running editor + PIE session.

**Verified compositions (no new VibeUE tools needed):**
- Epic `GASToolsets.AbilitySystemInspectorToolset` (`GetAttributeValues` / `GetActiveTags` / `GetActiveEffects` / `GetGrantedAbilities`) takes an actor `refPath` and works on live PIE actors — no selection required.
- `asc.try_activate_ability_by_class(...)` from Python is a reliable, deterministic PIE driver; multiple activations in one `execute_python_code` call share a frame, so caps/lockouts can be hit without wall-clock sleeps.

**Documented Python exposure gaps (candidate future deltas per the epic's "add only when proven" rule):**
- `FGameplayTag` is not constructible from raw Python (`TagName` read-only; `MakeLiteralGameplayTag` takes a tag) — blocks `SendGameplayEventToActor` / `HasMatchingGameplayTag` from Python. The skill documents workarounds (inspector reads, project BlueprintCallable seams); a tiny `GameplayTagService.request_tag(name) -> GameplayTag` delta would close it if a future spike needs raw-Python event sending.
- `UAbilitySystemBlueprintLibrary` is exposed as `unreal.AbilitySystemLibrary`; `get_owned_gameplay_tags` is not exposed.

**C++ handoff gotchas captured:** GE CDO `FindOrAddComponent` fatal assert (editor-killing), SetByCaller cost/cooldown `ApplyCost`/`ApplyCooldown` overrides, `SetAssetTags`, `InitGlobalData`, `GameplayCueNotifyPaths`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
