### PR TITLE
feat(tags): RequestTag / RequestTagContainer - the FGameplayTag editor-scripting escape hatch (#536)

### DIFF
--- a/Content/Skills/gameplay-tags/SKILL.md
+++ b/Content/Skills/gameplay-tags/SKILL.md
@@ -23,8 +23,9 @@ keywords:
 
 Manage Unreal Engine Gameplay Tags. Core CRUD (add / remove / rename / list) is now owned by
 Unreal 5.8's native **`GameplayTagsToolset`** (call it via `call_tool`). VibeUE keeps only the
-delta the engine toolset does NOT provide — runtime hierarchy queries and bulk registration:
-`unreal.GameplayTagService.has_tag` / `get_tag_info` / `get_children` / `add_tags`.
+delta the engine toolset does NOT provide — runtime hierarchy queries, bulk registration, and
+tag-value lookup: `unreal.GameplayTagService.has_tag` / `get_tag_info` / `get_children` /
+`add_tags` / `request_tag` / `request_tag_container`.
 
 Tags are written to INI config **and** registered at runtime — they appear immediately in the editor tag picker without restart.
 
@@ -37,6 +38,7 @@ Tags are written to INI config **and** registered at runtime — they appear imm
 | Add / remove / rename a single tag, list all tags | engine **`GameplayTagsToolset`** via `call_tool` (run `describe_toolset` for its action names/params) |
 | Bulk-register many tags at once | `unreal.GameplayTagService.add_tags([...], comment, source)` |
 | Check existence | `unreal.GameplayTagService.has_tag(name)` |
+| **Obtain an FGameplayTag VALUE** for a tag-typed API | `unreal.GameplayTagService.request_tag(name)` / `request_tag_container(names)` — Python CANNOT construct `FGameplayTag` itself (`TagName` is read-only, `MakeLiteralGameplayTag` takes a tag). Use these for `has_matching_gameplay_tag`, `send_gameplay_event_to_actor`, `assign_tag_set_by_caller_magnitude`, tag-keyed `TMap` authoring, tag queries, etc. `request_tag` returns an invalid tag (never asserts) for unregistered names — check `.is_valid()` |
 | Detailed info (comment/source/redirect/child count) | `unreal.GameplayTagService.get_tag_info(name)` |
 | Direct children of a tag | `unreal.GameplayTagService.get_children(parent)` |
 

--- a/Source/VibeUE/Private/PythonAPI/UGameplayTagService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UGameplayTagService.cpp
@@ -12,6 +12,38 @@
 DEFINE_LOG_CATEGORY_STATIC(LogGameplayTagService, Log, All);
 
 // =================================================================
+// Tag value lookup (editor-scripting escape hatch)
+// =================================================================
+
+FGameplayTag UGameplayTagService::RequestTag(const FString& TagName)
+{
+	const FGameplayTag Tag = UGameplayTagsManager::Get().RequestGameplayTag(FName(*TagName), /*ErrorIfNotFound=*/false);
+	if (!Tag.IsValid())
+	{
+		UE_LOG(LogGameplayTagService, Warning, TEXT("RequestTag: '%s' is not a registered gameplay tag (returning invalid tag)"), *TagName);
+	}
+	return Tag;
+}
+
+FGameplayTagContainer UGameplayTagService::RequestTagContainer(const TArray<FString>& TagNames)
+{
+	FGameplayTagContainer Container;
+	for (const FString& TagName : TagNames)
+	{
+		const FGameplayTag Tag = UGameplayTagsManager::Get().RequestGameplayTag(FName(*TagName), /*ErrorIfNotFound=*/false);
+		if (Tag.IsValid())
+		{
+			Container.AddTag(Tag);
+		}
+		else
+		{
+			UE_LOG(LogGameplayTagService, Warning, TEXT("RequestTagContainer: skipping unregistered tag '%s'"), *TagName);
+		}
+	}
+	return Container;
+}
+
+// =================================================================
 // Internal Helpers
 // =================================================================
 

--- a/Source/VibeUE/Public/PythonAPI/UGameplayTagService.h
+++ b/Source/VibeUE/Public/PythonAPI/UGameplayTagService.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "GameplayTagContainer.h"
 #include "ToolsetRegistry/ToolsetDefinition.h"
 #include "UGameplayTagService.generated.h"
 
@@ -135,6 +136,40 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|GameplayTags")
 	static TArray<FVibeGameplayTagInfo> GetChildren(const FString& ParentTag);
+
+	/**
+	 * Look up a registered gameplay tag by name and return the real FGameplayTag VALUE.
+	 *
+	 * This is the editor-scripting escape hatch: Python cannot construct an FGameplayTag
+	 * (the struct's TagName is read-only and BlueprintGameplayTagLibrary::MakeLiteralGameplayTag
+	 * takes a tag, not a string), which blocks every tag-typed engine API — e.g.
+	 * SendGameplayEventToActor, HasMatchingGameplayTag, AssignTagSetByCallerMagnitude,
+	 * and TMap<FGameplayTag, ...> authoring.
+	 *
+	 * Python:
+	 *   tag = unreal.GameplayTagService.request_tag("Ability.Fire")
+	 *   asc.has_matching_gameplay_tag(tag)
+	 *
+	 * @param TagName - Full tag name (redirects from renamed tags are applied)
+	 * @return The registered tag, or an INVALID tag (is_valid() false) when the name is
+	 *         not registered — never asserts.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|GameplayTags")
+	static FGameplayTag RequestTag(const FString& TagName);
+
+	/**
+	 * Look up several registered tags at once and return them as a container.
+	 * Unregistered names are skipped (see the log for which). Convenience for
+	 * container-typed APIs (tag queries, RemoveActiveEffectsWithGrantedTags, ...).
+	 *
+	 * Python:
+	 *   c = unreal.GameplayTagService.request_tag_container(["State.Stunned", "State.Rooted"])
+	 *
+	 * @param TagNames - Full tag names
+	 * @return Container holding every name that resolved to a registered tag
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|GameplayTags")
+	static FGameplayTagContainer RequestTagContainer(const TArray<FString>& TagNames);
 
 #if WITH_EDITOR
 	// =================================================================

--- a/test_prompts/gameplay-tags/gameplay_tags_tests.md
+++ b/test_prompts/gameplay-tags/gameplay_tags_tests.md
@@ -90,3 +90,20 @@ Add an OnEvent transition from Idle to Patrol.
 Set the transition's event tag to "AI.StartPatrol".
 Compile and save.
 ```
+
+---
+
+### 10. Obtain a real FGameplayTag value for a tag-typed API (request_tag)
+
+```
+Using Python, get the FGameplayTag value for "Cube.StartChasing" via
+unreal.GameplayTagService.request_tag and prove it works end to end: call
+has_matching_gameplay_tag with it on any actor's AbilitySystemComponent (or
+build a container with request_tag_container(["Cube.StartChasing", "Cube.Idle"])
+and print its size). Then request a bogus name "Fake.DoesNotExist" and confirm
+the returned tag reports is_valid() == False without any assert or error.
+```
+
+Expected: request_tag returns a usable tag object (NOT constructible any other
+way from Python), container contains 2 tags, bogus name yields an invalid tag
+plus a LogGameplayTagService warning - never a crash.


### PR DESCRIPTION
Closes the FGameplayTag construction gap documented in the #536 live spike (and hit again today authoring tag-keyed `TMap` properties from Python in the Proteus GAS work).

**The gap (live-verified):** Python cannot obtain an `FGameplayTag` value — `unreal.GameplayTag(tag_name=...)` is rejected, `TagName` is read-only via `set_editor_property`, and `MakeLiteralGameplayTag` takes a tag (circular). That blocks every tag-typed engine API from editor scripting: `SendGameplayEventToActor`, `HasMatchingGameplayTag`, `AssignTagSetByCallerMagnitude`, tag queries, and tag-keyed `TMap` authoring. Until now the workarounds were harvesting tag objects from CDO struct properties or pre-seeding map keys in C++.

**The delta (minimal, per the epic's compose-don't-duplicate rule):**
- `GameplayTagService.RequestTag(name) -> FGameplayTag` — redirect-aware lookup via `UGameplayTagsManager::RequestGameplayTag(ErrorIfNotFound=false)`; returns an invalid tag for unregistered names (never asserts) with a `LogGameplayTagService` warning.
- `GameplayTagService.RequestTagContainer(names) -> FGameplayTagContainer` — batch convenience for container-typed APIs; skips (and logs) unregistered names.

Both are `AICallable` statics matching the existing service surface. The `gameplay-tags` skill routing table and `test_prompts/gameplay-tags` gained matching entries.

Verified in the Proteus project: `request_tag("Proteus.Powerup.Speed")` feeds `has_matching_gameplay_tag` and `assign_tag_set_by_caller_magnitude` end to end (evidence in the PR conversation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
