### PR TITLE
5-8 -> master: verified workflows, GAS skill, and GameplayTag helpers

### DIFF
--- a/BuildAndLaunchGame.ps1
+++ b/BuildAndLaunchGame.ps1
@@ -119,6 +119,30 @@ if (-not $enginePath) {
 
 $buildBat  = Join-Path $enginePath "Engine\Build\BatchFiles\Build.bat"
 $editorExe = Join-Path $enginePath "Engine\Binaries\Win64\UnrealEditor.exe"
+$buildManifestPath = Join-Path $projectRoot "Saved\VibeUE\last-build.json"
+
+function Write-BuildManifest([string]$Status, [Nullable[int]]$ExitCode, [string]$Diagnostic = "") {
+    $manifestDir = Split-Path $buildManifestPath -Parent
+    New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+    $payload = [ordered]@{
+        schema = "vibeue.build.v1"
+        status = $Status
+        projectFile = [IO.Path]::GetFullPath($projectPath)
+        engineRoot = [IO.Path]::GetFullPath($enginePath)
+        target = "${projectName}Editor"
+        platform = "Win64"
+        configuration = $Mode
+        command = "Build.bat ${projectName}Editor Win64 $Mode `"$projectPath`" -waitmutex"
+        completedAtIso = if ($Status -in @("succeeded", "failed", "skipped")) { [DateTime]::UtcNow.ToString("o") } else { $null }
+        exitCode = $ExitCode
+        verdict = $Status
+        logPath = Join-Path $env:LOCALAPPDATA "UnrealBuildTool\Log.txt"
+        diagnostic = $Diagnostic
+    }
+    $temp = "$buildManifestPath.tmp"
+    $payload | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $temp -Encoding UTF8
+    Move-Item -LiteralPath $temp -Destination $buildManifestPath -Force
+}
 
 Write-Host "=== $projectName Build and Launch Script ===" -ForegroundColor Cyan
 Write-Host "Script  : $PSScriptRoot" -ForegroundColor Gray
@@ -227,16 +251,19 @@ if ($StrictRebuild -and -not $Clean) {
 # Build the project
 if (-not $SkipBuild) {
     Write-Host "Building $projectName in $Mode mode (strict: warnings-as-errors via VibeUE.Build.cs)..." -ForegroundColor Yellow
+    Write-BuildManifest "running" $null
     
     & $buildBat "${projectName}Editor" Win64 $Mode $projectPath -waitmutex
     
     if ($LASTEXITCODE -ne 0) {
+        Write-BuildManifest "failed" $LASTEXITCODE "UnrealBuildTool returned a non-zero exit code."
         Write-Host "Build failed! Exit code: $LASTEXITCODE" -ForegroundColor Red
         exit 1
     }
-    
+    Write-BuildManifest "succeeded" 0
     Write-Host "Build completed successfully!" -ForegroundColor Green
 } else {
+    Write-BuildManifest "skipped" $null "Build was skipped by caller; this is not compile verification."
     Write-Host "Skipping build..." -ForegroundColor Yellow
 }
 

--- a/BuildAndLaunchGame.sh
+++ b/BuildAndLaunchGame.sh
@@ -86,6 +86,18 @@ fi
 
 project_root="$(dirname -- "$project_path")"
 project_name="$(basename -- "${project_path%.uproject}")"
+build_manifest="$project_root/Saved/VibeUE/last-build.json"
+
+write_build_manifest() {
+    local status="$1" exit_code="${2:-null}" diagnostic="${3:-}"
+    mkdir -p -- "$(dirname -- "$build_manifest")"
+    local completed="null"
+    [[ "$status" == "succeeded" || "$status" == "failed" || "$status" == "skipped" ]] && completed="\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\""
+    local temp="$build_manifest.tmp"
+    printf '{"schema":"vibeue.build.v1","status":"%s","projectFile":"%s","engineRoot":"%s","target":"%sEditor","platform":"%s","configuration":"%s","completedAtIso":%s,"exitCode":%s,"verdict":"%s","logPath":"","diagnostic":"%s"}\n' \
+        "$status" "$project_path" "$engine_root" "$project_name" "$platform" "$mode" "$completed" "$exit_code" "$status" "$diagnostic" > "$temp"
+    mv -f -- "$temp" "$build_manifest"
+}
 
 stop_editor() {
     local pids
@@ -131,7 +143,16 @@ elif [[ "$strict_rebuild" == true ]]; then
 fi
 
 if [[ "$skip_build" == false ]]; then
-    "$build_script" "${project_name}Editor" "$platform" "$mode" "$project_path" -waitmutex
+    write_build_manifest running null
+    if "$build_script" "${project_name}Editor" "$platform" "$mode" "$project_path" -waitmutex; then
+        write_build_manifest succeeded 0
+    else
+        code=$?
+        write_build_manifest failed "$code" "UnrealBuildTool returned a non-zero exit code."
+        exit "$code"
+    fi
+else
+    write_build_manifest skipped null "Build was skipped by caller; this is not compile verification."
 fi
 
 if [[ -n "$map" ]]; then

--- a/Content/Skills/bulk-maintenance/SKILL.md
+++ b/Content/Skills/bulk-maintenance/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: bulk-maintenance
+display_name: Safe Bulk Maintenance
+description: Plan, dry-run, apply, verify, roll back, and resume explicit bounded batches for Blueprint interface migration, metadata hygiene, asset naming/organization, and unused-asset cleanup preparation.
+vibeue_classes:
+  - WorkflowService
+  - BlueprintService
+  - TransactionService
+keywords:
+  - bulk
+  - migrate interface
+  - metadata hygiene
+  - rename assets
+  - organize assets
+  - unused assets
+  - cleanup
+---
+
+# Safe Bulk Maintenance
+
+Use `unreal.WorkflowService.run_bulk_maintenance(plan_json, apply, batch_size, stop_on_error)` for an
+explicit target list. It is dry-run-first, path-scoped, bounded to 100 targets per GC batch, returns
+one result per target, rolls back a failed apply operation, and writes a resumable report under
+`Saved/VibeUE/Bulk`.
+
+Rules:
+
+1. Discover candidates, but pass the final explicit `targets` array yourself. Never turn a search
+   result directly into deletion.
+2. Call once with `apply=False`, inspect every `would-change`/refusal, then repeat the exact plan with
+   `apply=True` and the same `resume_id`.
+3. Set `path_scope` so a malformed target cannot escape the intended content folder.
+4. Use a small `batch_size` (10–25) for Blueprint work. Each apply target gets a named transaction;
+   compile/save failure is reported as failure and rolled back.
+5. Wrap an unattended task in `start_run` / `finish_run`; attach the bulk report and verification.
+
+## 1. Blueprint interface migration
+
+Discover implementers/referencers with GameIQ when available, compile the candidates before the
+change, and migrate in two reviewed phases:
+
+```python
+import json, unreal
+plan = {
+  "resume_id": "combat-interface-v2",
+  "operation": "interface_add",
+  "path_scope": "/Game/Combat",
+  "interface": "/Game/Combat/Interfaces/BPI_CombatV2",
+  "targets": ["/Game/Combat/BP_Rifle", "/Game/Combat/BP_Sword"]
+}
+print(unreal.WorkflowService.run_bulk_maintenance(json.dumps(plan), False, 10, True))
+# Review, then use True. Remove the old interface only after compile/readback proves v2 is present.
+```
+
+`interface_add` and `interface_remove` compile each Blueprint and save only verified successes.
+
+## 2. Blueprint metadata hygiene
+
+Descriptions are caller-provided intent; the service never invents text. Existing authored metadata
+is preserved unless that specific target says `"overwrite": true`.
+
+```json
+{"resume_id":"combat-metadata-1","operation":"variable_metadata","path_scope":"/Game/Combat","targets":[
+  {"asset":"/Game/Combat/BP_Rifle","variable":"Ammo","category":"Weapon|Ammo","description":"Rounds remaining in the current magazine."},
+  {"asset":"/Game/Combat/BP_Sword","variable":"Damage","category":"Weapon|Damage","description":"Base damage before modifiers."}
+]}
+```
+
+## 3. Asset naming and organization
+
+Audit naming separately, resolve collisions, then supply explicit source/destination pairs. Moves
+outside `path_scope` and existing destinations are refused.
+
+```json
+{"resume_id":"weapon-moves-1","operation":"asset_move","path_scope":"/Game/Weapons","targets":[
+  {"source":"/Game/Weapons/Rifle","destination":"/Game/Weapons/Blueprints/BP_Rifle"}
+]}
+```
+
+After apply, fix redirectors with the normal Unreal workflow and re-run GameIQ references/impact.
+
+## 4. Dead/unused cleanup preparation
+
+Use `cleanup_review` with GameIQ `ProjectStats("unused")` plus `Impact` evidence. This operation is
+deliberately report-only even in apply mode. Deletion is a separate, human-approved action using the
+reviewed exact list; an unused heuristic alone is never approval.
+
+## Partial failure and resume
+
+Reports contain a stable `targetKey`, aggregate counts, rollback status, and `reportPath`. Repeat with
+the same `resume_id`; previously successful targets are `resumed-skip`, so a crash or stop-on-error
+does not duplicate completed work. Fix failed inputs, keep the same explicit scope, and rerun.

--- a/Content/Skills/gameplay-tags/SKILL.md
+++ b/Content/Skills/gameplay-tags/SKILL.md
@@ -23,8 +23,9 @@ keywords:
 
 Manage Unreal Engine Gameplay Tags. Core CRUD (add / remove / rename / list) is now owned by
 Unreal 5.8's native **`GameplayTagsToolset`** (call it via `call_tool`). VibeUE keeps only the
-delta the engine toolset does NOT provide — runtime hierarchy queries and bulk registration:
-`unreal.GameplayTagService.has_tag` / `get_tag_info` / `get_children` / `add_tags`.
+delta the engine toolset does NOT provide — runtime hierarchy queries, bulk registration, and
+tag-value lookup: `unreal.GameplayTagService.has_tag` / `get_tag_info` / `get_children` /
+`add_tags` / `request_tag` / `request_tag_container`.
 
 Tags are written to INI config **and** registered at runtime — they appear immediately in the editor tag picker without restart.
 
@@ -37,6 +38,7 @@ Tags are written to INI config **and** registered at runtime — they appear imm
 | Add / remove / rename a single tag, list all tags | engine **`GameplayTagsToolset`** via `call_tool` (run `describe_toolset` for its action names/params) |
 | Bulk-register many tags at once | `unreal.GameplayTagService.add_tags([...], comment, source)` |
 | Check existence | `unreal.GameplayTagService.has_tag(name)` |
+| **Obtain an FGameplayTag VALUE** for a tag-typed API | `unreal.GameplayTagService.request_tag(name)` / `request_tag_container(names)` — Python CANNOT construct `FGameplayTag` itself (`TagName` is read-only, `MakeLiteralGameplayTag` takes a tag). Use these for `has_matching_gameplay_tag`, `send_gameplay_event_to_actor`, `assign_tag_set_by_caller_magnitude`, tag-keyed `TMap` authoring, tag queries, etc. `request_tag` returns an invalid tag (never asserts) for unregistered names — check `.is_valid()` |
 | Detailed info (comment/source/redirect/child count) | `unreal.GameplayTagService.get_tag_info(name)` |
 | Direct children of a tag | `unreal.GameplayTagService.get_children(parent)` |
 

--- a/Content/Skills/gas/SKILL.md
+++ b/Content/Skills/gas/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: gas
+display_name: Gameplay Ability System (GAS)
+description: Author and PIE-verify Gameplay Ability System content — abilities, attribute sets, gameplay effects, gameplay events, costs/cooldowns, cues — by composing Epic's GASToolsets/GameplayTagsToolset with Blueprint/Object tools and Python. Use when the user asks to add abilities, attributes, damage/buff effects, cooldowns, gameplay cues, or to inspect a live ASC.
+vibeue_classes:
+  - GameplayTagService
+  - BlueprintService
+unreal_classes:
+  - UAbilitySystemComponent
+  - UGameplayAbility
+  - UGameplayEffect
+  - UAttributeSet
+  - UAbilitySystemBlueprintLibrary
+keywords:
+  - gameplay ability system
+  - GAS
+  - ability system component
+  - ASC
+  - attribute set
+  - gameplay effect
+  - gameplay event
+  - gameplay cue
+  - cooldown
+  - cost
+---
+
+> 🧠 **Brains complement:** IF an `unreal-engine-skills-manager` tool (external MCP) exists in this session, call it with `{action: "load", skill: "gameplay-ability-system"}` for UE domain knowledge (ASC setup, attribute/effect/ability APIs, networking) — treat it as the rubric for any review / "best practices" question. If no such tool is available, skip this line entirely and proceed with this skill alone — do NOT attempt the call.
+
+# Gameplay Ability System Skill
+
+**Compose, do not duplicate.** Everything GAS needs already exists across Epic's engine toolsets,
+the generic Blueprint/Object tools, and Python. VibeUE adds no GAS wrapper service; this skill is
+the routing map plus the live-verified gotchas.
+
+## Ownership matrix — who does what
+
+| Operation | Owner |
+|---|---|
+| Inspect a live ASC (PIE): attributes, active tags, active effects, granted abilities | Epic **`GASToolsets.AbilitySystemInspectorToolset`** → `GetAttributeValues` / `GetActiveTags` / `GetActiveEffects` / `GetGrantedAbilities`. Input is `{"actor": {"refPath": "<actor path>"}}` — works on PIE actors, no selection needed |
+| Discover attribute set classes / attributes | Epic **`GASToolsets.AttributeSetToolset`** → `FindAttributeSetClasses` / `ListAttributes` |
+| Gameplay Cue notify assets + cue tags | Epic **`GASToolsets.GameplayCueToolset`** (list/get/create/execute-on-selected) |
+| Tag CRUD (add/remove/rename/list single tags) | Epic **`GameplayTagsToolset`** — see the `gameplay-tags` skill |
+| Bulk tag registration, hierarchy queries, existence checks | `unreal.GameplayTagService` (VibeUE delta — see `gameplay-tags`) |
+| Create GameplayAbility / GameplayEffect / AttributeSet **Blueprint** subclasses, CDO config | Epic `BlueprintTools` + `ObjectTools` (or native Python `BlueprintFactory` with the right `ParentClass`) |
+| Ability / cue Blueprint graphs | Epic `BlueprintTools` + `unreal.BlueprintService.build_graph` (see `blueprint-graphs`) |
+| GameplayEffect legacy tag containers (Asset/Target Tags) | `unreal.BlueprintService.set_property` — maps them onto the UE 5.3+ GE Components (VibeUE #539/#541) |
+| Runtime PIE testing | `EditorToolset.EditorAppToolset` StartPIE/StopPIE + Python on live actors (below) |
+| Native C++ attribute sets / effects / abilities | **Coding-agent handoff** — C++ patterns below are for that agent, not for editor tools |
+
+## Python exposure facts (live-verified, UE 5.8)
+
+- `UAbilitySystemBlueprintLibrary` is exposed as **`unreal.AbilitySystemLibrary`** (the
+  "BlueprintLibrary" name does not exist in Python).
+  `asc = unreal.AbilitySystemLibrary.get_ability_system_component(actor)`.
+- **`FGameplayTag` cannot be constructed from raw Python**: `unreal.GameplayTag(tag_name=...)` is
+  rejected, `TagName` is read-only via `set_editor_property`, and
+  `GameplayTagLibrary.make_literal_gameplay_tag` takes an FGameplayTag (circular). Consequence:
+  tag-parameter APIs (`asc.has_matching_gameplay_tag`, `send_gameplay_event_to_actor`) are
+  unusable from raw Python. Work around it:
+  - **reads** → Epic inspector `GetActiveTags` (returns tag names as strings);
+  - **event sending / tag checks** → call a project-side `BlueprintCallable` seam that owns the
+    tag (e.g. a controller method that sends the event), or hand off to C++.
+- `asc.get_owned_gameplay_tags()` is NOT exposed. Use the inspector.
+- ASC `BlueprintCallable`s that take a **class** work fine:
+  `asc.try_activate_ability_by_class(unreal.MyGA_Class)` — this is the reliable Python path to
+  drive abilities in PIE (it bypasses any component-level gates, which makes tests deterministic).
+- Multiple activations inside ONE `execute_python_code` call happen in the same frame — no
+  timers tick and no GE durations expire between them. Exploit this to hit caps/lockouts
+  deterministically instead of sleeping wall-clock time.
+
+## PIE verification recipe (one round-trip per step)
+
+```python
+import unreal, json
+world = unreal.get_editor_subsystem(unreal.UnrealEditorSubsystem).get_game_world()
+pawn = unreal.GameplayStatics.get_player_pawn(world, 0)
+ref = json.dumps({"actor": {"refPath": pawn.get_path_name()}})
+for tool in ["GetAttributeValues", "GetActiveTags", "GetActiveEffects", "GetGrantedAbilities"]:
+    r = unreal.ToolsetRegistry.execute_tool("GASToolsets.AbilitySystemInspectorToolset", tool, ref)
+    print(tool, r.get_value_as_json_string())
+# drive an ability and re-inspect IN THE SAME CALL for deterministic assertions
+asc = unreal.AbilitySystemLibrary.get_ability_system_component(pawn)
+asc.try_activate_ability_by_class(unreal.MyGA_Fire)
+```
+
+Damage through the classic funnel also exercises GE pipelines when the project routes
+`TakeDamage` into effects: `unreal.GameplayStatics.apply_damage(actor, 25.0, None, None, None)`.
+
+## C++ authoring gotchas (for the coding-agent handoff)
+
+- **Never call `UGameplayEffect::FindOrAddComponent`/`AddComponent` in a GE constructor** — they
+  `NewObject` with an empty name, which fatal-asserts at CDO construction and kills the editor on
+  module load. In constructors use
+  `CreateDefaultSubobject<UTargetTagsGameplayEffectComponent>(TEXT("TargetTags"))`, call
+  `SetAndApplyTargetTagChanges(...)`, then `GEComponents.Add(...)` (protected — do it inside the
+  class).
+- SetByCaller cost/cooldown GEs: `CommitAbility` alone applies a **0-magnitude** spec and logs a
+  warning. Override `ApplyCost`/`ApplyCooldown`, build the spec with
+  `MakeOutgoingGameplayEffectSpec`, `SetSetByCallerMagnitude(tag, value)`, then
+  `ApplyGameplayEffectSpecToOwner`.
+- `AbilityTags` is deprecated in 5.5+ — call `SetAssetTags(container)` in the constructor.
+- `NonInstanced` instancing is deprecated — default to `InstancedPerActor`.
+- `UAbilitySystemGlobals::Get().InitGlobalData()` must run once at startup (GameInstance::Init /
+  AssetManager) or target data and montage prediction fail silently.
+- Set `[/Script/GameplayAbilities.AbilitySystemGlobals]` `+GameplayCueNotifyPaths=/Game/GameplayCues`
+  in DefaultGame.ini, or the cue manager scans all of /Game/ (startup warning + cost).
+
+## Verification rules
+
+After authoring: compile (`unreal.BlueprintEditorLibrary.compile_blueprint`), then prove behavior
+in PIE with the inspector — a successful tool call is not evidence. Attribute deltas, active-tag
+presence, and effect duration/stack readouts are the evidence to report.

--- a/Content/Skills/gas/SKILL.md
+++ b/Content/Skills/gas/SKILL.md
@@ -54,12 +54,14 @@ the routing map plus the live-verified gotchas.
   `asc = unreal.AbilitySystemLibrary.get_ability_system_component(actor)`.
 - **`FGameplayTag` cannot be constructed from raw Python**: `unreal.GameplayTag(tag_name=...)` is
   rejected, `TagName` is read-only via `set_editor_property`, and
-  `GameplayTagLibrary.make_literal_gameplay_tag` takes an FGameplayTag (circular). Consequence:
-  tag-parameter APIs (`asc.has_matching_gameplay_tag`, `send_gameplay_event_to_actor`) are
-  unusable from raw Python. Work around it:
-  - **reads** → Epic inspector `GetActiveTags` (returns tag names as strings);
-  - **event sending / tag checks** → call a project-side `BlueprintCallable` seam that owns the
-    tag (e.g. a controller method that sends the event), or hand off to C++.
+  `GameplayTagLibrary.make_literal_gameplay_tag` takes an FGameplayTag (circular).
+  **Use VibeUE's escape hatch**: `unreal.GameplayTagService.request_tag("A.B.C")` returns the real
+  registered tag VALUE (invalid tag for unknown names — check with
+  `GameplayTagLibrary.is_gameplay_tag_valid`), and `request_tag_container([...])` batches into a
+  container. That unlocks every tag-typed API: `asc.has_matching_gameplay_tag`,
+  `send_gameplay_event_to_actor`, `assign_tag_set_by_caller_magnitude`, tag-keyed `TMap`
+  authoring, and tag queries. For pure READS the Epic inspector `GetActiveTags` also returns tag
+  names as strings without needing tag values.
 - `asc.get_owned_gameplay_tags()` is NOT exposed. Use the inspector.
 - ASC `BlueprintCallable`s that take a **class** work fine:
   `asc.try_activate_ability_by_class(unreal.MyGA_Class)` — this is the reliable Python path to

--- a/Content/Skills/pie-testing/SKILL.md
+++ b/Content/Skills/pie-testing/SKILL.md
@@ -55,6 +55,34 @@ call_tool(toolset="EditorToolset.EditorAppToolset", tool="StopPIE")
 
 ## Standard Test Loop
 
+For repeatable multi-step verification, prefer `WorkflowService.run_scenario()` over hand-composing
+the loop. It queues a state machine on editor ticks, waits for actual PIE readiness, scopes log
+assertions to the scenario start, uses VibeUE's focus-free input injection, captures evidence, and
+always tears PIE down on pass, failure, or cancellation. Poll `get_scenario(id)` until its `status`
+is `passed`, `failed`, or `cancelled`:
+
+```python
+import json, unreal
+spec = {
+  "name": "secondary fire consumes ammo",
+  "preflight": {"save_dirty_assets": True, "compile_blueprints": ["/Game/Weapons/BP_Rifle"]},
+  "steps": [
+    {"action":"start_pie"},
+    {"action":"wait_for_pie", "timeout_seconds":30},
+    {"action":"inject_action", "path":"/Game/Input/IA_Fire_Secondary"},
+    {"action":"wait", "seconds":0.25},
+    {"action":"assert_log", "contains":"SecondaryFire"},
+    {"action":"capture_game", "name":"after-secondary-fire"}
+  ],
+  "teardown": {"stop_pie": True}
+}
+queued = json.loads(unreal.WorkflowService.run_scenario(json.dumps(spec)))
+# Poll in separate tool calls; do not block the editor game thread with time.sleep.
+```
+
+Use the lower-level primitives below for interactive investigation, one-off probes, or actions not in
+the scenario schema. Never spin/sleep inside one editor Python call while waiting for a scenario.
+
 ```
 # 1. Make sure you're starting from a clean state
 call_tool(toolset="EditorToolset.EditorAppToolset", tool="StopPIE")   # no-op if not running

--- a/Content/Skills/vibeue/SKILL.md
+++ b/Content/Skills/vibeue/SKILL.md
@@ -79,7 +79,7 @@ when two areas seem to fit, the one that *excludes* your task is telling you whe
 | Functional area | Use for â€” **NOT** forâ€¦ | Load skill(s) |
 |---|---|---|
 | **Scene & actors** | place / move / arrange / organize / tag actors in a level â€” NOT gameplay logic (â†’ Blueprints), NOT world-scale terrain/foliage (â†’ Environment), NOT attaching a Niagara/particle component (â†’ VFX) | `level-actors` |
-| **Blueprints & gameplay logic** | author Blueprint classes & graphs, Enhanced Input, gameplay tags â€” NOT AI behavior (â†’ AI), NOT AnimBP graphs (â†’ Animation), NOT C++/source (coding-agent handoff) | `blueprints`, `blueprint-graphs`, `enhanced-input`, `gameplay-tags` |
+| **Blueprints & gameplay logic** | author Blueprint classes & graphs, Enhanced Input, gameplay tags, Gameplay Ability System (abilities/attributes/effects/cues) â€” NOT AI behavior (â†’ AI), NOT AnimBP graphs (â†’ Animation), NOT C++/source (coding-agent handoff) | `blueprints`, `blueprint-graphs`, `enhanced-input`, `gameplay-tags`, `gas` |
 | **AI** | author StateTree logic â€” states, tasks, transitions, event payloads, delegate bindings â€” NOT character body animation (â†’ Animation), NOT generic actor placement (â†’ Scene) | `state-trees` |
 | **Animation & rigging** | AnimBP state machines, AnimSequence keyframes, montages & AnimNotify wiring, bone/skeleton editing & retarget â€” NOT cinematic timelines (Epic Sequencer), NOT AI movement (â†’ AI), NOT authoring/adding sound assets â€” even a character's footstep sounds (â†’ Audio) | `animation-blueprint`, `animsequence`, `animation-editing`, `animation-montage`, `skeleton` |
 | **Materials & shading** | materials, instances, graph nodes, Custom HLSL â€” NOT Niagara particle materials (â†’ VFX), NOT landscape auto-materials (â†’ Environment) | `materials` |
@@ -152,6 +152,7 @@ called via `call_tool` (run `describe_toolset` for action names/params):
 | List / read / filter / tail UE logs | `LogsToolset` |
 | Search / open / save / move / import assets | `AssetTools` |
 | Single-tag gameplay-tag CRUD | `GameplayTagsToolset` (see `gameplay-tags` skill) |
+| Inspect a live Ability System (attributes/tags/effects/abilities), attribute-set discovery, gameplay cues | `GASToolsets.*` (see `gas` skill) |
 
 Performance/Insights tracing is the one net-new VibeUE service â€” `unreal.PerformanceService.*` (see
 the `profiling` skill) â€” because Unreal 5.8 ships no performance toolset.

--- a/Content/samples/AGENTS.md.sample
+++ b/Content/samples/AGENTS.md.sample
@@ -5,6 +5,20 @@ into the engine's `ToolsetRegistry` and are reachable through the MCP tools you 
 
 **ALWAYS use the MCP tools / Python API for Unreal operations — NEVER read `.uasset` files from disk.**
 
+### Environment, evidence, and unattended work
+
+- Call `unreal.WorkflowService.get_environment()` before claiming Unreal source, UBT, a compiler,
+  or an engine installation is missing. Prefer the reported `engineSource.path` over memory or web
+  guesses about engine behavior.
+- C++ work is not complete without `lastBuild.status == "succeeded"` from a real build. A skipped,
+  missing, running, failed, or stale result is not verification. Use the plugin's
+  `BuildAndLaunchGame.ps1`/`.sh` when Live Coding is unsafe.
+- Wrap unattended mutations with `start_run(name, metadata)` and `finish_run(run_id, outcome,
+  summary)`. Attach scenario, build, and bulk-report artifacts; affected UObject packages are
+  deduplicated automatically while the run is active.
+- Use `run_scenario(spec_json)` for repeatable PIE input/assert/evidence loops and poll
+  `get_scenario(id)` from separate calls. Use the `bulk-maintenance` skill for dry-run-first batches.
+
 ---
 
 ## 1. The efficient interaction model (read this first)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ VibeUE **complements** them — it focuses on the domains and depth the engine d
   CRUD. Writes go through the editor EdGraph with PIE- and open-editor-aware refusal guards.
 - **Editor safety** — `TransactionService` wraps the editor's transaction buffer (undo / redo /
   checkpoints) so an agent can group and roll back its own edits — the engine's toolsets expose none.
+- **Verified workflows** — `WorkflowService` adds an authoritative engine/build manifest, durable
+  task journals with affected-asset provenance, asynchronous PIE scenarios (compile → input →
+  assertion → capture → guaranteed teardown), and dry-run-first resumable bulk maintenance.
 - **⚡ Performance & profiling** — VibeUE's standout: see the dedicated section below.
 - **Python-first access** — run any `unreal.*` Python in the editor and introspect the whole API.
 - **Web research** — search / fetch / geocode for in-context research and terrain workflows.

--- a/Source/VibeUE/Private/Module.cpp
+++ b/Source/VibeUE/Private/Module.cpp
@@ -23,6 +23,7 @@
 #include "Misc/Paths.h"
 #include "Misc/FileHelper.h"
 #include "PythonAPI/BehaviorTreeServiceInternal.h"
+#include "PythonAPI/UWorkflowService.h"
 #if WITH_VIBEUE_EQS
 #include "PythonAPI/EnvQueryServiceInternal.h"
 #endif
@@ -332,6 +333,7 @@ void FModule::StartupModule()
 	}
 
 	bServicesInitialized = true;
+	UWorkflowService::InitializeJournal();
 
 	// Clear screenshots directory from previous sessions to save disk space
 	FVibeUEPaths::ClearScreenshotsDir();
@@ -485,6 +487,7 @@ void FModule::UnregisterToolsets()
 
 void FModule::ShutdownModule()
 {
+	UWorkflowService::ShutdownJournal();
 	FVibeUEHealthSignal::Stop();
 	FVibeUEReadinessSignal::Remove();
 
@@ -518,6 +521,7 @@ void FModule::ShutdownModule()
 void FModule::OnPreExit()
 {
 	UE_LOG(LogTemp, Display, TEXT("VibeUE OnPreExit - cleaning up Python services"));
+	UWorkflowService::ShutdownJournal();
 	FVibeUEHealthSignal::Stop();
 	FVibeUEReadinessSignal::Remove();
 	

--- a/Source/VibeUE/Private/PythonAPI/UGameplayTagService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UGameplayTagService.cpp
@@ -12,6 +12,38 @@
 DEFINE_LOG_CATEGORY_STATIC(LogGameplayTagService, Log, All);
 
 // =================================================================
+// Tag value lookup (editor-scripting escape hatch)
+// =================================================================
+
+FGameplayTag UGameplayTagService::RequestTag(const FString& TagName)
+{
+	const FGameplayTag Tag = UGameplayTagsManager::Get().RequestGameplayTag(FName(*TagName), /*ErrorIfNotFound=*/false);
+	if (!Tag.IsValid())
+	{
+		UE_LOG(LogGameplayTagService, Warning, TEXT("RequestTag: '%s' is not a registered gameplay tag (returning invalid tag)"), *TagName);
+	}
+	return Tag;
+}
+
+FGameplayTagContainer UGameplayTagService::RequestTagContainer(const TArray<FString>& TagNames)
+{
+	FGameplayTagContainer Container;
+	for (const FString& TagName : TagNames)
+	{
+		const FGameplayTag Tag = UGameplayTagsManager::Get().RequestGameplayTag(FName(*TagName), /*ErrorIfNotFound=*/false);
+		if (Tag.IsValid())
+		{
+			Container.AddTag(Tag);
+		}
+		else
+		{
+			UE_LOG(LogGameplayTagService, Warning, TEXT("RequestTagContainer: skipping unregistered tag '%s'"), *TagName);
+		}
+	}
+	return Container;
+}
+
+// =================================================================
 // Internal Helpers
 // =================================================================
 

--- a/Source/VibeUE/Private/PythonAPI/UWorkflowService_Bulk.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UWorkflowService_Bulk.cpp
@@ -1,0 +1,224 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#include "PythonAPI/UWorkflowService.h"
+
+#include "Dom/JsonObject.h"
+#include "Editor.h"
+#include "EditorAssetLibrary.h"
+#include "Engine/Blueprint.h"
+#include "HAL/FileManager.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "Kismet2/KismetEditorUtilities.h"
+#include "Misc/FileHelper.h"
+#include "Misc/SecureHash.h"
+#include "Misc/Paths.h"
+#include "PythonAPI/UBlueprintService.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+namespace
+{
+	FString SerializeBulk(const TSharedRef<FJsonObject>& Object)
+	{
+		FString Out; FJsonSerializer::Serialize(Object, TJsonWriterFactory<>::Create(&Out)); return Out;
+	}
+
+	FString BulkError(const FString& Error)
+	{
+		TSharedRef<FJsonObject> Root = MakeShared<FJsonObject>(); Root->SetBoolField(TEXT("success"), false);
+		Root->SetStringField(TEXT("error"), Error); return SerializeBulk(Root);
+	}
+
+	FString BulkDir() { return FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("VibeUE/Bulk")); }
+
+	UBlueprint* LoadBulkBlueprint(const FString& Path)
+	{
+		FString ObjectPath = Path;
+		if (!ObjectPath.Contains(TEXT("."))) { ObjectPath += TEXT(".") + FPaths::GetBaseFilename(Path); }
+		return LoadObject<UBlueprint>(nullptr, *ObjectPath);
+	}
+
+	bool InBulkScope(const FString& Path, const FString& Scope)
+	{
+		return Scope.IsEmpty() || Path.StartsWith(Scope, ESearchCase::IgnoreCase);
+	}
+
+	void SaveBulkReport(const FString& Id, const TSharedRef<FJsonObject>& Report)
+	{
+		IFileManager::Get().MakeDirectory(*BulkDir(), true);
+		const FString Path = FPaths::Combine(BulkDir(), Id + TEXT(".json")), Temp = Path + TEXT(".tmp");
+		FFileHelper::SaveStringToFile(SerializeBulk(Report), *Temp, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
+		IFileManager::Get().Move(*Path, *Temp, true, true, false, true);
+	}
+}
+
+FString UWorkflowService::RunBulkMaintenance(const FString& PlanJson, bool bApply, int32 BatchSize, bool bStopOnError)
+{
+	TSharedPtr<FJsonObject> Plan;
+	if (!FJsonSerializer::Deserialize(TJsonReaderFactory<>::Create(PlanJson), Plan) || !Plan.IsValid()) { return BulkError(TEXT("plan_json must be an object")); }
+	FString Operation; if (!Plan->TryGetStringField(TEXT("operation"), Operation)) { return BulkError(TEXT("plan requires operation")); }
+	Operation = Operation.ToLower();
+	const TArray<TSharedPtr<FJsonValue>>* Targets = nullptr;
+	if (!Plan->TryGetArrayField(TEXT("targets"), Targets) || Targets->Num() == 0) { return BulkError(TEXT("an explicit non-empty targets array is required")); }
+	FString Scope; Plan->TryGetStringField(TEXT("path_scope"), Scope);
+	const int32 Cap = FMath::Clamp(BatchSize, 1, 100);
+	FString PlanId; Plan->TryGetStringField(TEXT("resume_id"), PlanId);
+	if (PlanId.IsEmpty()) { PlanId = FMD5::HashAnsiString(*PlanJson).Left(16); }
+	for (TCHAR C : PlanId) { if (!(FChar::IsAlnum(C) || C == '-' || C == '_')) { return BulkError(TEXT("resume_id contains invalid characters")); } }
+
+	TSet<FString> PreviouslyCompleted;
+	const FString ExistingPath = FPaths::Combine(BulkDir(), PlanId + TEXT(".json"));
+	FString ExistingText; TSharedPtr<FJsonObject> Existing;
+	if (bApply && FFileHelper::LoadFileToString(ExistingText, *ExistingPath) && FJsonSerializer::Deserialize(TJsonReaderFactory<>::Create(ExistingText), Existing) && Existing.IsValid() &&
+		Existing->GetStringField(TEXT("mode")) == TEXT("apply"))
+	{
+		const TArray<TSharedPtr<FJsonValue>>* ExistingResults = nullptr;
+		if (Existing->TryGetArrayField(TEXT("results"), ExistingResults))
+		{
+			for (const TSharedPtr<FJsonValue>& Value : *ExistingResults)
+			{
+				const TSharedPtr<FJsonObject> Result = Value->AsObject(); bool bSucceeded = false;
+				if (Result.IsValid() && Result->TryGetBoolField(TEXT("success"), bSucceeded) && bSucceeded) { PreviouslyCompleted.Add(Result->GetStringField(TEXT("targetKey"))); }
+			}
+		}
+	}
+
+	TSharedRef<FJsonObject> Report = MakeShared<FJsonObject>();
+	Report->SetStringField(TEXT("schema"), TEXT("vibeue.bulk.v1")); Report->SetStringField(TEXT("id"), PlanId);
+	Report->SetStringField(TEXT("operation"), Operation); Report->SetStringField(TEXT("mode"), bApply ? TEXT("apply") : TEXT("dry-run"));
+	Report->SetStringField(TEXT("startedAtIso"), FDateTime::UtcNow().ToIso8601()); Report->SetNumberField(TEXT("batchSize"), Cap);
+	Report->SetBoolField(TEXT("gameIQAvailable"), FindObject<UClass>(nullptr, TEXT("/Script/GameIQ.GameIQService")) != nullptr);
+	if (!Report->GetBoolField(TEXT("gameIQAvailable"))) { Report->SetStringField(TEXT("safetyWarning"), TEXT("GameIQ is unavailable; dependency/impact evidence is not attached.")); }
+	else
+	{
+		TArray<TSharedPtr<FJsonValue>> ImpactEvidence;
+		const int32 EvidenceCap = FMath::Min(Targets->Num(), 100);
+		for (int32 Index = 0; Index < EvidenceCap; ++Index)
+		{
+			const TSharedPtr<FJsonValue>& Target = (*Targets)[Index];
+			FString AssetPath;
+			if (Target->Type == EJson::Object)
+			{
+				const TSharedPtr<FJsonObject> TargetObject = Target->AsObject();
+				TargetObject->TryGetStringField(TEXT("asset"), AssetPath);
+				if (AssetPath.IsEmpty()) { TargetObject->TryGetStringField(TEXT("source"), AssetPath); }
+			}
+			else { AssetPath = Target->AsString(); }
+			TSharedRef<FJsonObject> Evidence = MakeShared<FJsonObject>();
+			Evidence->SetStringField(TEXT("target"), AssetPath);
+			const FString ImpactJson = UWorkflowService::GetOptionalGameIQImpact(AssetPath);
+			TSharedPtr<FJsonObject> Impact;
+			if (!ImpactJson.IsEmpty() && FJsonSerializer::Deserialize(TJsonReaderFactory<>::Create(ImpactJson), Impact) && Impact.IsValid())
+			{
+				Evidence->SetObjectField(TEXT("graph"), Impact.ToSharedRef());
+			}
+			else { Evidence->SetStringField(TEXT("warning"), TEXT("GameIQ impact query returned no valid JSON")); }
+			ImpactEvidence.Add(MakeShared<FJsonValueObject>(Evidence));
+		}
+		Report->SetArrayField(TEXT("gameIQImpactEvidence"), ImpactEvidence);
+		Report->SetBoolField(TEXT("gameIQImpactTruncated"), Targets->Num() > EvidenceCap);
+	}
+	TArray<TSharedPtr<FJsonValue>> Results;
+	int32 Succeeded = 0, Failed = 0, Skipped = 0;
+
+	for (int32 Index = 0; Index < Targets->Num(); ++Index)
+	{
+		const TSharedPtr<FJsonValue>& TargetValue = (*Targets)[Index];
+		FString AssetPath, TargetKey;
+		const TSharedPtr<FJsonObject> TargetObject = TargetValue->Type == EJson::Object ? TargetValue->AsObject() : nullptr;
+		if (TargetObject.IsValid()) { TargetObject->TryGetStringField(TEXT("asset"), AssetPath); if (AssetPath.IsEmpty()) { TargetObject->TryGetStringField(TEXT("source"), AssetPath); } }
+		else { AssetPath = TargetValue->AsString(); }
+		TargetKey = TargetObject.IsValid() ? SerializeBulk(TargetObject.ToSharedRef()) : AssetPath;
+		TSharedRef<FJsonObject> Item = MakeShared<FJsonObject>(); Item->SetNumberField(TEXT("index"), Index); Item->SetStringField(TEXT("targetKey"), TargetKey); Item->SetStringField(TEXT("asset"), AssetPath);
+		if (PreviouslyCompleted.Contains(TargetKey))
+		{
+			Item->SetBoolField(TEXT("success"), true); Item->SetStringField(TEXT("status"), TEXT("resumed-skip")); ++Skipped;
+			Results.Add(MakeShared<FJsonValueObject>(Item)); continue;
+		}
+		if (!InBulkScope(AssetPath, Scope))
+		{
+			Item->SetBoolField(TEXT("success"), false); Item->SetStringField(TEXT("error"), TEXT("target is outside path_scope")); ++Failed;
+			Results.Add(MakeShared<FJsonValueObject>(Item)); if (bStopOnError) { break; } continue;
+		}
+		if (!bApply)
+		{
+			Item->SetBoolField(TEXT("success"), true); Item->SetStringField(TEXT("status"), TEXT("would-change")); ++Succeeded;
+			Results.Add(MakeShared<FJsonValueObject>(Item)); continue;
+		}
+
+		const FText TransactionText = FText::FromString(FString::Printf(TEXT("VibeUE bulk %s: %s"), *Operation, *AssetPath));
+		if (GEditor) { GEditor->BeginTransaction(TransactionText); }
+		bool bOk = false, bAttemptedMutation = false; FString Error;
+		if (Operation == TEXT("interface_add") || Operation == TEXT("interface_remove"))
+		{
+			FString InterfacePath; Plan->TryGetStringField(TEXT("interface"), InterfacePath);
+			if (InterfacePath.IsEmpty()) { Error = TEXT("plan requires interface"); }
+			else
+			{
+				bAttemptedMutation = true;
+				bOk = Operation == TEXT("interface_add") ? UBlueprintService::AddInterface(AssetPath, InterfacePath) : UBlueprintService::RemoveInterface(AssetPath, InterfacePath);
+				if (bOk) { bOk = UEditorAssetLibrary::SaveAsset(AssetPath, false); if (!bOk) { Error = TEXT("interface changed but save failed"); } }
+				else { Error = TEXT("interface mutation or compile failed"); }
+			}
+		}
+		else if (Operation == TEXT("variable_metadata"))
+		{
+			FString Variable, Category, Description; bool bOverwrite = false;
+			if (TargetObject.IsValid()) { TargetObject->TryGetStringField(TEXT("variable"), Variable); TargetObject->TryGetStringField(TEXT("category"), Category); TargetObject->TryGetStringField(TEXT("description"), Description); TargetObject->TryGetBoolField(TEXT("overwrite"), bOverwrite); }
+			UBlueprint* Blueprint = LoadBulkBlueprint(AssetPath);
+			if (!Blueprint || Variable.IsEmpty()) { Error = TEXT("Blueprint or variable not found"); }
+			else
+			{
+				FString ExistingTooltip; const bool bHasTooltip = FBlueprintEditorUtils::GetBlueprintVariableMetaData(Blueprint, *Variable, nullptr, TEXT("tooltip"), ExistingTooltip);
+				const FBPVariableDescription* ExistingVariable = Blueprint->NewVariables.FindByPredicate([&Variable](const FBPVariableDescription& V) { return V.VarName == *Variable; });
+				if (!ExistingVariable) { Error = TEXT("variable not found"); }
+				else
+				{
+					const FString ExistingCategory = ExistingVariable->Category.ToString();
+					const bool bAuthoredTooltip = bHasTooltip && !ExistingTooltip.TrimStartAndEnd().IsEmpty() &&
+						!ExistingTooltip.Equals(Variable, ESearchCase::IgnoreCase);
+					const bool bAuthoredCategory = !ExistingCategory.IsEmpty() && !ExistingCategory.Equals(TEXT("Default"), ESearchCase::IgnoreCase);
+					if (!bOverwrite && ((!Description.IsEmpty() && bAuthoredTooltip) || (!Category.IsEmpty() && bAuthoredCategory)))
+					{
+						Error = TEXT("existing authored metadata preserved; set overwrite=true to replace it");
+					}
+					else
+					{
+						bAttemptedMutation = true;
+						if (!Description.IsEmpty()) { FBlueprintEditorUtils::SetBlueprintVariableMetaData(Blueprint, *Variable, nullptr, TEXT("tooltip"), Description); }
+						if (!Category.IsEmpty()) { FBlueprintEditorUtils::SetBlueprintVariableCategory(Blueprint, *Variable, nullptr, FText::FromString(Category), true); }
+						FKismetEditorUtilities::CompileBlueprint(Blueprint); bOk = Blueprint->Status != BS_Error && UEditorAssetLibrary::SaveLoadedAsset(Blueprint, false);
+						if (!bOk) { Error = TEXT("metadata changed but compile/save verification failed"); }
+					}
+				}
+			}
+		}
+		else if (Operation == TEXT("asset_move"))
+		{
+			FString Destination; if (TargetObject.IsValid()) { TargetObject->TryGetStringField(TEXT("destination"), Destination); }
+			if (Destination.IsEmpty() || !InBulkScope(Destination, Scope)) { Error = TEXT("destination missing or outside path_scope"); }
+			else if (UEditorAssetLibrary::DoesAssetExist(Destination)) { Error = TEXT("destination collision"); }
+			else { bAttemptedMutation = true; bOk = UEditorAssetLibrary::RenameAsset(AssetPath, Destination); if (!bOk) { Error = TEXT("asset move failed"); } }
+		}
+		else if (Operation == TEXT("cleanup_review"))
+		{
+			Error = TEXT("cleanup_review is report-only; deletion requires a separate explicit approved operation");
+		}
+		else { Error = TEXT("unsupported operation"); }
+		if (GEditor) { GEditor->EndTransaction(); if (!bOk && bAttemptedMutation) { GEditor->UndoTransaction(); Item->SetStringField(TEXT("rollback"), TEXT("transaction undone")); } }
+		Item->SetBoolField(TEXT("success"), bOk); Item->SetStringField(TEXT("status"), bOk ? TEXT("changed") : TEXT("failed"));
+		if (!Error.IsEmpty()) { Item->SetStringField(TEXT("error"), Error); }
+		bOk ? ++Succeeded : ++Failed; Results.Add(MakeShared<FJsonValueObject>(Item));
+		Report->SetArrayField(TEXT("results"), Results); SaveBulkReport(PlanId, Report);
+		if (!bOk && bStopOnError) { break; }
+		if ((Index + 1) % Cap == 0) { CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS); }
+	}
+	Report->SetArrayField(TEXT("results"), Results); Report->SetNumberField(TEXT("succeeded"), Succeeded);
+	Report->SetNumberField(TEXT("failed"), Failed); Report->SetNumberField(TEXT("skipped"), Skipped);
+	Report->SetBoolField(TEXT("success"), Failed == 0); Report->SetBoolField(TEXT("resumable"), true);
+	Report->SetStringField(TEXT("finishedAtIso"), FDateTime::UtcNow().ToIso8601());
+	Report->SetStringField(TEXT("reportPath"), FPaths::Combine(BulkDir(), PlanId + TEXT(".json"))); SaveBulkReport(PlanId, Report);
+	UWorkflowService::AttachActiveRunArtifact(FPaths::Combine(BulkDir(), PlanId + TEXT(".json")), TEXT("bulk-maintenance"));
+	return SerializeBulk(Report);
+}

--- a/Source/VibeUE/Private/PythonAPI/UWorkflowService_Journal.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UWorkflowService_Journal.cpp
@@ -1,0 +1,429 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#include "PythonAPI/UWorkflowService.h"
+
+#include "Dom/JsonObject.h"
+#include "HAL/FileManager.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "UObject/Package.h"
+#include "UObject/StructOnScope.h"
+#include "UObject/UnrealType.h"
+#include "Utils/VibeUEEnvironment.h"
+
+namespace
+{
+	FString GActiveWorkflowRun;
+	FDelegateHandle GObjectModifiedHandle;
+	bool GWritingWorkflowRun = false;
+
+	FString RunsDir()
+	{
+		return FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("VibeUE/Runs"));
+	}
+
+	bool SafeWorkflowId(const FString& Id)
+	{
+		if (Id.IsEmpty()) { return false; }
+		for (TCHAR C : Id) { if (!(FChar::IsAlnum(C) || C == '-' || C == '_')) { return false; } }
+		return true;
+	}
+
+	FString WorkflowRunPath(const FString& Id) { return FPaths::Combine(RunsDir(), Id + TEXT(".json")); }
+	FString WorkflowRunMarkdownPath(const FString& Id) { return FPaths::Combine(RunsDir(), Id + TEXT(".md")); }
+
+	FString InvokeOptionalGameIQ(const FName FunctionName, const TMap<FName, FString>& Strings,
+		const TMap<FName, int32>& Integers = {})
+	{
+		UClass* ServiceClass = FindObject<UClass>(nullptr, TEXT("/Script/GameIQ.GameIQService"));
+		if (!ServiceClass) { return FString(); }
+		UFunction* Function = ServiceClass->FindFunctionByName(FunctionName);
+		UObject* Service = ServiceClass->GetDefaultObject();
+		if (!Function || !Service) { return FString(); }
+
+		FStructOnScope Parameters(Function);
+		uint8* Memory = Parameters.GetStructMemory();
+		for (TFieldIterator<FProperty> It(Function); It; ++It)
+		{
+			FProperty* Property = *It;
+			if (!Property->HasAnyPropertyFlags(CPF_Parm) || Property->HasAnyPropertyFlags(CPF_ReturnParm)) { continue; }
+			if (FStrProperty* StringProperty = CastField<FStrProperty>(Property))
+			{
+				if (const FString* Value = Strings.Find(Property->GetFName()))
+				{
+					StringProperty->SetPropertyValue_InContainer(Memory, *Value);
+				}
+			}
+			else if (FIntProperty* IntProperty = CastField<FIntProperty>(Property))
+			{
+				if (const int32* Value = Integers.Find(Property->GetFName()))
+				{
+					IntProperty->SetPropertyValue_InContainer(Memory, *Value);
+				}
+			}
+		}
+		Service->ProcessEvent(Function, Memory);
+		for (TFieldIterator<FProperty> It(Function); It; ++It)
+		{
+			if (It->HasAnyPropertyFlags(CPF_ReturnParm))
+			{
+				if (const FStrProperty* ReturnProperty = CastField<FStrProperty>(*It))
+				{
+					return ReturnProperty->GetPropertyValue_InContainer(Memory);
+				}
+			}
+		}
+		return FString();
+	}
+
+	TSharedPtr<FJsonObject> ParseWorkflowObject(const FString& Text)
+	{
+		TSharedPtr<FJsonObject> Object;
+		return !Text.IsEmpty() && FJsonSerializer::Deserialize(TJsonReaderFactory<>::Create(Text), Object) ? Object : nullptr;
+	}
+
+	FString SerializeWorkflow(const TSharedRef<FJsonObject>& Object)
+	{
+		FString Out;
+		FJsonSerializer::Serialize(Object, TJsonWriterFactory<>::Create(&Out));
+		return Out;
+	}
+
+	FString WorkflowError(const FString& Message)
+	{
+		TSharedRef<FJsonObject> Root = MakeShared<FJsonObject>();
+		Root->SetBoolField(TEXT("success"), false);
+		Root->SetStringField(TEXT("error"), Message);
+		return SerializeWorkflow(Root);
+	}
+
+	TSharedPtr<FJsonObject> LoadWorkflowRun(const FString& Id)
+	{
+		if (!SafeWorkflowId(Id)) { return nullptr; }
+		FString Text;
+		if (!FFileHelper::LoadFileToString(Text, *WorkflowRunPath(Id))) { return nullptr; }
+		TSharedPtr<FJsonObject> Object;
+		return FJsonSerializer::Deserialize(TJsonReaderFactory<>::Create(Text), Object) ? Object : nullptr;
+	}
+
+	bool AtomicWriteWorkflow(const FString& Path, const FString& Text)
+	{
+		IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+		const FString Temp = Path + TEXT(".tmp");
+		if (!FFileHelper::SaveStringToFile(Text, *Temp, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM)) { return false; }
+		return IFileManager::Get().Move(*Path, *Temp, true, true, false, true);
+	}
+
+	TSharedPtr<FJsonValue> RedactedWorkflowValue(const TSharedPtr<FJsonValue>& Value)
+	{
+		if (!Value.IsValid()) { return MakeShared<FJsonValueNull>(); }
+		if (Value->Type == EJson::Object)
+		{
+			TSharedRef<FJsonObject> Redacted = MakeShared<FJsonObject>();
+			for (const auto& Pair : Value->AsObject()->Values)
+			{
+				const FString Key = FString(Pair.Key).ToLower();
+				if (Key.Contains(TEXT("token")) || Key.Contains(TEXT("secret")) || Key.Contains(TEXT("password")) ||
+					Key.Contains(TEXT("authorization")) || Key.Contains(TEXT("api_key")))
+				{
+					Redacted->SetStringField(Pair.Key, TEXT("[REDACTED]"));
+				}
+				else { Redacted->SetField(Pair.Key, RedactedWorkflowValue(Pair.Value)); }
+			}
+			return MakeShared<FJsonValueObject>(Redacted);
+		}
+		else if (Value->Type == EJson::Array)
+		{
+			TArray<TSharedPtr<FJsonValue>> Redacted;
+			for (const TSharedPtr<FJsonValue>& Item : Value->AsArray()) { Redacted.Add(RedactedWorkflowValue(Item)); }
+			return MakeShared<FJsonValueArray>(Redacted);
+		}
+		return Value;
+	}
+
+	FString WorkflowMarkdown(const TSharedRef<FJsonObject>& Run)
+	{
+		FString Out = FString::Printf(TEXT("# %s\n\n- Run: `%s`\n- Status: **%s**\n- Started: %s\n"),
+			*Run->GetStringField(TEXT("name")), *Run->GetStringField(TEXT("id")), *Run->GetStringField(TEXT("status")),
+			*Run->GetStringField(TEXT("startedAtIso")));
+		FString Finished;
+		if (Run->TryGetStringField(TEXT("finishedAtIso"), Finished)) { Out += TEXT("- Finished: ") + Finished + TEXT("\n"); }
+		FString Summary;
+		if (Run->TryGetStringField(TEXT("summary"), Summary) && !Summary.IsEmpty()) { Out += TEXT("\n## Summary\n\n") + Summary + TEXT("\n"); }
+		Out += TEXT("\n## Affected assets\n\n");
+		const TArray<TSharedPtr<FJsonValue>>* Assets = nullptr;
+		if (Run->TryGetArrayField(TEXT("affectedAssets"), Assets))
+		{
+			for (const TSharedPtr<FJsonValue>& Asset : *Assets) { Out += TEXT("- `") + Asset->AsString() + TEXT("`\n"); }
+		}
+		Out += TEXT("\n## Events\n\n");
+		const TArray<TSharedPtr<FJsonValue>>* Events = nullptr;
+		if (Run->TryGetArrayField(TEXT("events"), Events))
+		{
+			for (const TSharedPtr<FJsonValue>& Event : *Events)
+			{
+				const TSharedPtr<FJsonObject> E = Event->AsObject();
+				Out += FString::Printf(TEXT("- %s — **%s**"), *E->GetStringField(TEXT("atIso")), *E->GetStringField(TEXT("type")));
+				FString Text; if (E->TryGetStringField(TEXT("text"), Text)) { Out += TEXT(": ") + Text; }
+				Out += TEXT("\n");
+			}
+		}
+		Out += TEXT("\n> Coverage: VibeUE observes changed UObject packages and explicit notes/artifacts while a run is active. Calls made outside the editor, secret arguments, and method names from native Epic toolsets may not be observable.\n");
+		return Out;
+	}
+
+	bool SaveWorkflowRun(const TSharedRef<FJsonObject>& Run)
+	{
+		TGuardValue<bool> Guard(GWritingWorkflowRun, true);
+		const FString Id = Run->GetStringField(TEXT("id"));
+		return AtomicWriteWorkflow(WorkflowRunPath(Id), SerializeWorkflow(Run)) &&
+			AtomicWriteWorkflow(WorkflowRunMarkdownPath(Id), WorkflowMarkdown(Run));
+	}
+
+	void AppendWorkflowEvent(const TSharedRef<FJsonObject>& Run, const FString& Type, const FString& Text,
+		const TSharedPtr<FJsonObject>& Data = nullptr)
+	{
+		TArray<TSharedPtr<FJsonValue>> Events = Run->GetArrayField(TEXT("events"));
+		TSharedRef<FJsonObject> Event = MakeShared<FJsonObject>();
+		Event->SetStringField(TEXT("atIso"), FDateTime::UtcNow().ToIso8601());
+		Event->SetStringField(TEXT("type"), Type);
+		if (!Text.IsEmpty()) { Event->SetStringField(TEXT("text"), Text); }
+		if (Data.IsValid()) { Event->SetObjectField(TEXT("data"), Data.ToSharedRef()); }
+		Events.Add(MakeShared<FJsonValueObject>(Event));
+		Run->SetArrayField(TEXT("events"), Events);
+	}
+
+	void ObserveModifiedObject(UObject* Object)
+	{
+		if (GWritingWorkflowRun || GActiveWorkflowRun.IsEmpty() || !Object) { return; }
+		const UPackage* Package = Object->GetOutermost();
+		if (!Package || Package == GetTransientPackage()) { return; }
+		const FString Path = Package->GetName();
+		if (!(Path.StartsWith(TEXT("/Game/")) || Path.StartsWith(TEXT("/Engine/")) || Path.StartsWith(TEXT("/Plugins/")))) { return; }
+		const TSharedPtr<FJsonObject> Run = LoadWorkflowRun(GActiveWorkflowRun);
+		if (!Run.IsValid() || Run->GetStringField(TEXT("status")) != TEXT("running")) { return; }
+		TArray<TSharedPtr<FJsonValue>> Assets = Run->GetArrayField(TEXT("affectedAssets"));
+		for (const TSharedPtr<FJsonValue>& Asset : Assets) { if (Asset->AsString() == Path) { return; } }
+		Assets.Add(MakeShared<FJsonValueString>(Path));
+		Assets.Sort([](const TSharedPtr<FJsonValue>& A, const TSharedPtr<FJsonValue>& B) { return A->AsString() < B->AsString(); });
+		Run->SetArrayField(TEXT("affectedAssets"), Assets);
+		AppendWorkflowEvent(Run.ToSharedRef(), TEXT("object_modified"), Path);
+		SaveWorkflowRun(Run.ToSharedRef());
+	}
+}
+
+FString UWorkflowService::GetEnvironment()
+{
+	return FVibeUEEnvironment::BuildJson();
+}
+
+FString UWorkflowService::StartRun(const FString& Name, const FString& MetadataJson)
+{
+	TSharedPtr<FJsonObject> Metadata;
+	if (!FJsonSerializer::Deserialize(TJsonReaderFactory<>::Create(MetadataJson.IsEmpty() ? TEXT("{}") : MetadataJson), Metadata) || !Metadata.IsValid())
+	{
+		return WorkflowError(TEXT("metadata_json must be a JSON object"));
+	}
+	const TSharedPtr<FJsonValue> MetadataValue = RedactedWorkflowValue(MakeShared<FJsonValueObject>(Metadata.ToSharedRef()));
+	const FString Id = FDateTime::UtcNow().ToString(TEXT("%Y%m%dT%H%M%SZ")) + TEXT("-") +
+		FGuid::NewGuid().ToString(EGuidFormats::Digits).Left(8);
+	TSharedRef<FJsonObject> Run = MakeShared<FJsonObject>();
+	Run->SetStringField(TEXT("schema"), TEXT("vibeue.run.v1"));
+	Run->SetStringField(TEXT("id"), Id);
+	Run->SetStringField(TEXT("name"), Name.IsEmpty() ? Id : Name);
+	Run->SetStringField(TEXT("status"), TEXT("running"));
+	Run->SetStringField(TEXT("startedAtIso"), FDateTime::UtcNow().ToIso8601());
+	Run->SetObjectField(TEXT("metadata"), MetadataValue->AsObject().ToSharedRef());
+	Run->SetArrayField(TEXT("events"), {});
+	Run->SetArrayField(TEXT("affectedAssets"), {});
+	Run->SetArrayField(TEXT("artifacts"), {});
+	Run->SetStringField(TEXT("coverage"), TEXT("UObject package changes plus explicit workflow notes/artifacts; external calls are not intercepted"));
+	AppendWorkflowEvent(Run, TEXT("run_started"), TEXT("Run journal opened"));
+	TSharedRef<FJsonObject> GameIQ = MakeShared<FJsonObject>();
+	const bool bGameIQAvailable = FindObject<UClass>(nullptr, TEXT("/Script/GameIQ.GameIQService")) != nullptr;
+	GameIQ->SetBoolField(TEXT("available"), bGameIQAvailable);
+	GameIQ->SetStringField(TEXT("freshnessBoundary"), TEXT("GameIQ save-hook/index freshness; unsaved or unsupported changes may be incomplete"));
+	if (bGameIQAvailable)
+	{
+		const FString SnapshotJson = InvokeOptionalGameIQ(TEXT("CreateSnapshot"), {
+			{TEXT("Name"), TEXT("VibeUE before ") + Id},
+			{TEXT("MetadataJson"), FString::Printf(TEXT("{\"vibeueRunId\":\"%s\"}"), *Id)}
+		});
+		if (const TSharedPtr<FJsonObject> Snapshot = ParseWorkflowObject(SnapshotJson))
+		{
+			if (Snapshot->HasTypedField<EJson::Object>(TEXT("result")))
+			{
+				const TSharedPtr<FJsonObject> Result = Snapshot->GetObjectField(TEXT("result"));
+				GameIQ->SetStringField(TEXT("preSnapshotId"), Result->GetStringField(TEXT("id")));
+				GameIQ->SetObjectField(TEXT("preSnapshot"), Result.ToSharedRef());
+			}
+			else
+			{
+				FString Error; Snapshot->TryGetStringField(TEXT("error"), Error);
+				GameIQ->SetStringField(TEXT("warning"), Error.IsEmpty() ? TEXT("GameIQ snapshot returned no result") : Error);
+			}
+		}
+		else { GameIQ->SetStringField(TEXT("warning"), TEXT("GameIQ snapshot call returned invalid JSON")); }
+	}
+	else { GameIQ->SetStringField(TEXT("warning"), TEXT("GameIQ is unavailable; semantic pre/post evidence is omitted")); }
+	Run->SetObjectField(TEXT("gameIQ"), GameIQ);
+	if (!SaveWorkflowRun(Run)) { return WorkflowError(TEXT("failed to write run journal")); }
+	GActiveWorkflowRun = Id;
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true); Result->SetStringField(TEXT("runId"), Id);
+	Result->SetStringField(TEXT("jsonPath"), WorkflowRunPath(Id)); Result->SetStringField(TEXT("markdownPath"), WorkflowRunMarkdownPath(Id));
+	return SerializeWorkflow(Result);
+}
+
+FString UWorkflowService::AddRunNote(const FString& RunId, const FString& Text)
+{
+	const TSharedPtr<FJsonObject> Run = LoadWorkflowRun(RunId);
+	if (!Run.IsValid()) { return WorkflowError(TEXT("run not found")); }
+	AppendWorkflowEvent(Run.ToSharedRef(), TEXT("note"), Text);
+	if (!SaveWorkflowRun(Run.ToSharedRef())) { return WorkflowError(TEXT("failed to update run")); }
+	return SerializeWorkflow(Run.ToSharedRef());
+}
+
+FString UWorkflowService::AttachRunArtifact(const FString& RunId, const FString& PathOrId, const FString& Kind)
+{
+	const TSharedPtr<FJsonObject> Run = LoadWorkflowRun(RunId);
+	if (!Run.IsValid()) { return WorkflowError(TEXT("run not found")); }
+	TArray<TSharedPtr<FJsonValue>> Artifacts = Run->GetArrayField(TEXT("artifacts"));
+	TSharedRef<FJsonObject> Artifact = MakeShared<FJsonObject>();
+	Artifact->SetStringField(TEXT("kind"), Kind); Artifact->SetStringField(TEXT("pathOrId"), PathOrId);
+	Artifact->SetStringField(TEXT("attachedAtIso"), FDateTime::UtcNow().ToIso8601());
+	Artifacts.Add(MakeShared<FJsonValueObject>(Artifact)); Run->SetArrayField(TEXT("artifacts"), Artifacts);
+	AppendWorkflowEvent(Run.ToSharedRef(), TEXT("artifact_attached"), PathOrId);
+	if (!SaveWorkflowRun(Run.ToSharedRef())) { return WorkflowError(TEXT("failed to update run")); }
+	return SerializeWorkflow(Run.ToSharedRef());
+}
+
+FString UWorkflowService::FinishRun(const FString& RunId, const FString& Outcome, const FString& Summary)
+{
+	const TSharedPtr<FJsonObject> Run = LoadWorkflowRun(RunId);
+	if (!Run.IsValid()) { return WorkflowError(TEXT("run not found")); }
+	if (Run->HasTypedField<EJson::Object>(TEXT("gameIQ")))
+	{
+		const TSharedPtr<FJsonObject> GameIQ = Run->GetObjectField(TEXT("gameIQ"));
+		FString PreSnapshotId;
+		if (GameIQ->TryGetStringField(TEXT("preSnapshotId"), PreSnapshotId) && !PreSnapshotId.IsEmpty())
+		{
+			const FString ChangesJson = InvokeOptionalGameIQ(TEXT("Changes"), {
+				{TEXT("SinceSnapshot"), PreSnapshotId}, {TEXT("UntilSnapshot"), TEXT("current")},
+				{TEXT("Kind"), TEXT("")}, {TEXT("PathPrefix"), TEXT("")}
+			}, {{TEXT("Limit"), 500}, {TEXT("Offset"), 0}});
+			if (const TSharedPtr<FJsonObject> Changes = ParseWorkflowObject(ChangesJson))
+			{
+				if (Changes->HasTypedField<EJson::Object>(TEXT("result")))
+				{
+					GameIQ->SetObjectField(TEXT("changes"), Changes->GetObjectField(TEXT("result")).ToSharedRef());
+				}
+				else
+				{
+					FString Error; Changes->TryGetStringField(TEXT("error"), Error);
+					GameIQ->SetStringField(TEXT("finishWarning"), Error.IsEmpty() ? TEXT("GameIQ changes returned no result") : Error);
+				}
+			}
+			else { GameIQ->SetStringField(TEXT("finishWarning"), TEXT("GameIQ changes call returned invalid JSON")); }
+		}
+	}
+	Run->SetStringField(TEXT("status"), Outcome.IsEmpty() ? TEXT("completed") : Outcome.ToLower());
+	Run->SetStringField(TEXT("summary"), Summary);
+	Run->SetStringField(TEXT("finishedAtIso"), FDateTime::UtcNow().ToIso8601());
+	AppendWorkflowEvent(Run.ToSharedRef(), TEXT("run_finished"), Outcome);
+	if (!SaveWorkflowRun(Run.ToSharedRef())) { return WorkflowError(TEXT("failed to finish run")); }
+	if (GActiveWorkflowRun == RunId) { GActiveWorkflowRun.Reset(); }
+	return SerializeWorkflow(Run.ToSharedRef());
+}
+
+FString UWorkflowService::GetRun(const FString& RunId)
+{
+	const TSharedPtr<FJsonObject> Run = LoadWorkflowRun(RunId);
+	return Run.IsValid() ? SerializeWorkflow(Run.ToSharedRef()) : WorkflowError(TEXT("run not found"));
+}
+
+FString UWorkflowService::ListRuns(int32 Limit)
+{
+	TArray<FString> Files; IFileManager::Get().FindFiles(Files, *FPaths::Combine(RunsDir(), TEXT("*.json")), true, false);
+	Files.Sort([](const FString& A, const FString& B) { return A > B; });
+	TArray<TSharedPtr<FJsonValue>> Runs;
+	for (int32 Index = 0; Index < Files.Num() && Runs.Num() < FMath::Clamp(Limit, 1, 500); ++Index)
+	{
+		const TSharedPtr<FJsonObject> Run = LoadWorkflowRun(FPaths::GetBaseFilename(Files[Index]));
+		if (Run.IsValid()) { Runs.Add(MakeShared<FJsonValueObject>(Run.ToSharedRef())); }
+	}
+	TSharedRef<FJsonObject> Root = MakeShared<FJsonObject>(); Root->SetBoolField(TEXT("success"), true);
+	Root->SetArrayField(TEXT("runs"), Runs); Root->SetNumberField(TEXT("total"), Files.Num());
+	return SerializeWorkflow(Root);
+}
+
+FString UWorkflowService::DeleteRun(const FString& RunId)
+{
+	if (!SafeWorkflowId(RunId)) { return WorkflowError(TEXT("invalid run id")); }
+	if (GActiveWorkflowRun == RunId) { return WorkflowError(TEXT("cannot delete the active run; finish it first")); }
+	const bool bJson = IFileManager::Get().Delete(*WorkflowRunPath(RunId), true, true, true);
+	const bool bMarkdown = IFileManager::Get().Delete(*WorkflowRunMarkdownPath(RunId), false, true, true);
+	TSharedRef<FJsonObject> Root = MakeShared<FJsonObject>(); Root->SetBoolField(TEXT("success"), bJson && bMarkdown);
+	Root->SetStringField(TEXT("runId"), RunId); return SerializeWorkflow(Root);
+}
+
+void UWorkflowService::InitializeJournal()
+{
+	if (!GObjectModifiedHandle.IsValid())
+	{
+		GObjectModifiedHandle = FCoreUObjectDelegates::OnObjectModified.AddStatic(&ObserveModifiedObject);
+	}
+	TArray<FString> Files; IFileManager::Get().FindFiles(Files, *FPaths::Combine(RunsDir(), TEXT("*.json")), true, false);
+	for (const FString& File : Files)
+	{
+		const TSharedPtr<FJsonObject> Run = LoadWorkflowRun(FPaths::GetBaseFilename(File));
+		if (Run.IsValid() && Run->GetStringField(TEXT("status")) == TEXT("running"))
+		{
+			Run->SetStringField(TEXT("status"), TEXT("interrupted"));
+			Run->SetStringField(TEXT("finishedAtIso"), FDateTime::UtcNow().ToIso8601());
+			AppendWorkflowEvent(Run.ToSharedRef(), TEXT("interrupted_recovery"), TEXT("Editor exited before finish_run"));
+			SaveWorkflowRun(Run.ToSharedRef());
+		}
+	}
+}
+
+void UWorkflowService::ShutdownJournal()
+{
+	if (!GActiveWorkflowRun.IsEmpty())
+	{
+		const TSharedPtr<FJsonObject> Run = LoadWorkflowRun(GActiveWorkflowRun);
+		if (Run.IsValid())
+		{
+			Run->SetStringField(TEXT("status"), TEXT("interrupted"));
+			Run->SetStringField(TEXT("finishedAtIso"), FDateTime::UtcNow().ToIso8601());
+			AppendWorkflowEvent(Run.ToSharedRef(), TEXT("editor_shutdown"), TEXT("Editor shut down with run active"));
+			SaveWorkflowRun(Run.ToSharedRef());
+		}
+		GActiveWorkflowRun.Reset();
+	}
+	if (GObjectModifiedHandle.IsValid())
+	{
+		FCoreUObjectDelegates::OnObjectModified.Remove(GObjectModifiedHandle); GObjectModifiedHandle.Reset();
+	}
+}
+
+FString UWorkflowService::GetActiveRunId()
+{
+	return GActiveWorkflowRun;
+}
+
+void UWorkflowService::AttachActiveRunArtifact(const FString& PathOrId, const FString& Kind)
+{
+	if (!GActiveWorkflowRun.IsEmpty()) { AttachRunArtifact(GActiveWorkflowRun, PathOrId, Kind); }
+}
+
+FString UWorkflowService::GetOptionalGameIQImpact(const FString& TopicOrId)
+{
+	return InvokeOptionalGameIQ(TEXT("ExportGraph"), {
+		{TEXT("TopicOrId"), TopicOrId}, {TEXT("Format"), TEXT("json")},
+		{TEXT("Direction"), TEXT("both")}, {TEXT("EdgeTypes"), TEXT("")}, {TEXT("Kinds"), TEXT("")}
+	}, {{TEXT("Depth"), 1}, {TEXT("MaxNodes"), 50}});
+}

--- a/Source/VibeUE/Private/PythonAPI/UWorkflowService_Scenario.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UWorkflowService_Scenario.cpp
@@ -1,0 +1,276 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#include "PythonAPI/UWorkflowService.h"
+
+#include "Containers/Ticker.h"
+#include "Dom/JsonObject.h"
+#include "Editor.h"
+#include "EditorAssetLibrary.h"
+#include "Engine/Blueprint.h"
+#include "Engine/Engine.h"
+#include "HAL/FileManager.h"
+#include "IPythonScriptPlugin.h"
+#include "Kismet2/KismetEditorUtilities.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "PythonAPI/UInputService.h"
+#include "PythonAPI/UPerformanceService.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "UnrealClient.h"
+
+namespace
+{
+	struct FWorkflowScenario
+	{
+		FString Id;
+		TSharedRef<FJsonObject> Spec = MakeShared<FJsonObject>();
+		TSharedRef<FJsonObject> Report = MakeShared<FJsonObject>();
+		TArray<TSharedPtr<FJsonValue>> Steps;
+		TArray<TSharedPtr<FJsonValue>> Results;
+		int32 StepIndex = 0;
+		double StartedSeconds = 0.0;
+		double StepStartedSeconds = 0.0;
+		double WaitUntil = 0.0;
+		int32 LogStartChars = 0;
+		bool bOwnsPIE = false;
+		bool bStopPIE = true;
+		bool bTerminal = false;
+	};
+
+	TMap<FString, TSharedPtr<FWorkflowScenario>> GWorkflowScenarios;
+
+	FString ScenarioDir() { return FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("VibeUE/Scenarios")); }
+	FString ScenarioPath(const FString& Id) { return FPaths::Combine(ScenarioDir(), Id + TEXT(".json")); }
+	FString ProjectLogPath() { return FPaths::Combine(FPaths::ProjectLogDir(), FString(FApp::GetProjectName()) + TEXT(".log")); }
+
+	FString SerializeScenario(const TSharedRef<FJsonObject>& Object)
+	{
+		FString Out; FJsonSerializer::Serialize(Object, TJsonWriterFactory<>::Create(&Out)); return Out;
+	}
+
+	FString ScenarioError(const FString& Message)
+	{
+		TSharedRef<FJsonObject> Root = MakeShared<FJsonObject>(); Root->SetBoolField(TEXT("success"), false);
+		Root->SetStringField(TEXT("error"), Message); return SerializeScenario(Root);
+	}
+
+	void SaveScenario(const FWorkflowScenario& Scenario)
+	{
+		IFileManager::Get().MakeDirectory(*ScenarioDir(), true);
+		const FString Path = ScenarioPath(Scenario.Id), Temp = Path + TEXT(".tmp");
+		FFileHelper::SaveStringToFile(SerializeScenario(Scenario.Report), *Temp, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
+		IFileManager::Get().Move(*Path, *Temp, true, true, false, true);
+	}
+
+	FString ReadScenarioLogDelta(const FWorkflowScenario& Scenario)
+	{
+		FString Log; FFileHelper::LoadFileToString(Log, *ProjectLogPath());
+		return Scenario.LogStartChars <= Log.Len() ? Log.Mid(Scenario.LogStartChars) : Log;
+	}
+
+	bool JsonSuccess(const FString& Json, FString& OutError)
+	{
+		TSharedPtr<FJsonObject> Object;
+		if (!FJsonSerializer::Deserialize(TJsonReaderFactory<>::Create(Json), Object) || !Object.IsValid())
+		{
+			OutError = TEXT("operation returned invalid JSON"); return false;
+		}
+		bool bSuccess = false;
+		if (!Object->TryGetBoolField(TEXT("success"), bSuccess)) { bSuccess = !Object->HasField(TEXT("error")); }
+		if (!bSuccess)
+		{
+			if (!Object->TryGetStringField(TEXT("error_message"), OutError)) { Object->TryGetStringField(TEXT("error"), OutError); }
+		}
+		return bSuccess;
+	}
+
+	void FinishScenario(const TSharedPtr<FWorkflowScenario>& Scenario, const FString& Status, const FString& Error)
+	{
+		if (Scenario->bTerminal) { return; }
+		Scenario->bTerminal = true;
+		bool bTeardownOk = true;
+		if (Scenario->bStopPIE && GEditor && GEditor->PlayWorld)
+		{
+			FString StopError; bTeardownOk = JsonSuccess(UPerformanceService::StopPIE(), StopError);
+		}
+		Scenario->Report->SetStringField(TEXT("status"), bTeardownOk ? Status : TEXT("failed"));
+		Scenario->Report->SetBoolField(TEXT("passed"), Status == TEXT("passed") && bTeardownOk);
+		Scenario->Report->SetArrayField(TEXT("steps"), Scenario->Results);
+		Scenario->Report->SetStringField(TEXT("finishedAtIso"), FDateTime::UtcNow().ToIso8601());
+		Scenario->Report->SetNumberField(TEXT("durationMs"), (FPlatformTime::Seconds() - Scenario->StartedSeconds) * 1000.0);
+		Scenario->Report->SetBoolField(TEXT("teardownSucceeded"), bTeardownOk);
+		if (!Error.IsEmpty()) { Scenario->Report->SetStringField(TEXT("error"), Error); }
+		Scenario->Report->SetStringField(TEXT("logDelta"), ReadScenarioLogDelta(*Scenario).Right(50000));
+		SaveScenario(*Scenario);
+		UWorkflowService::AttachActiveRunArtifact(ScenarioPath(Scenario->Id), TEXT("pie-scenario"));
+	}
+
+	void AddScenarioStepResult(const TSharedPtr<FWorkflowScenario>& Scenario, const FString& Action, bool bPassed,
+		const FString& Error = FString(), const FString& Actual = FString(), const FString& Expected = FString())
+	{
+		TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+		Result->SetNumberField(TEXT("index"), Scenario->StepIndex); Result->SetStringField(TEXT("action"), Action);
+		Result->SetStringField(TEXT("status"), bPassed ? TEXT("passed") : TEXT("failed"));
+		Result->SetNumberField(TEXT("durationMs"), (FPlatformTime::Seconds() - Scenario->StepStartedSeconds) * 1000.0);
+		if (!Error.IsEmpty()) { Result->SetStringField(TEXT("error"), Error); }
+		if (!Actual.IsEmpty()) { Result->SetStringField(TEXT("actual"), Actual); }
+		if (!Expected.IsEmpty()) { Result->SetStringField(TEXT("expected"), Expected); }
+		Scenario->Results.Add(MakeShared<FJsonValueObject>(Result)); Scenario->Report->SetArrayField(TEXT("steps"), Scenario->Results);
+		SaveScenario(*Scenario);
+		if (!bPassed) { FinishScenario(Scenario, TEXT("failed"), Error); }
+		else { ++Scenario->StepIndex; Scenario->StepStartedSeconds = 0.0; Scenario->WaitUntil = 0.0; }
+	}
+
+	bool TickWorkflowScenario(float)
+	{
+		TArray<FString> Ids; GWorkflowScenarios.GetKeys(Ids);
+		for (const FString& Id : Ids)
+		{
+			const TSharedPtr<FWorkflowScenario> Scenario = GWorkflowScenarios.FindChecked(Id);
+			if (Scenario->bTerminal) { continue; }
+			if (Scenario->StepIndex >= Scenario->Steps.Num()) { FinishScenario(Scenario, TEXT("passed"), FString()); continue; }
+			const TSharedPtr<FJsonObject> Step = Scenario->Steps[Scenario->StepIndex]->AsObject();
+			if (!Step.IsValid()) { FinishScenario(Scenario, TEXT("failed"), TEXT("step must be a JSON object")); continue; }
+			const FString Action = Step->GetStringField(TEXT("action")).ToLower();
+			const double Now = FPlatformTime::Seconds();
+			if (Scenario->StepStartedSeconds == 0.0) { Scenario->StepStartedSeconds = Now; }
+
+			if (Action == TEXT("start_pie"))
+			{
+				if (GEditor && GEditor->PlayWorld) { AddScenarioStepResult(Scenario, Action, true, FString(), TEXT("already running")); }
+				else { FString Error; const bool bOk = JsonSuccess(UPerformanceService::StartPIE(), Error); Scenario->bOwnsPIE = bOk; AddScenarioStepResult(Scenario, Action, bOk, Error); }
+			}
+			else if (Action == TEXT("wait_for_pie"))
+			{
+				if (GEditor && GEditor->PlayWorld) { AddScenarioStepResult(Scenario, Action, true); }
+				else
+				{
+					double Timeout = 30.0; Step->TryGetNumberField(TEXT("timeout_seconds"), Timeout);
+					if (Now - Scenario->StepStartedSeconds > Timeout) { AddScenarioStepResult(Scenario, Action, false, TEXT("timed out waiting for PIE readiness")); }
+				}
+			}
+			else if (Action == TEXT("wait"))
+			{
+				double Seconds = 0.0; Step->TryGetNumberField(TEXT("seconds"), Seconds);
+				if (Scenario->WaitUntil == 0.0) { Scenario->WaitUntil = Now + FMath::Clamp(Seconds, 0.0, 300.0); }
+				if (Now >= Scenario->WaitUntil) { AddScenarioStepResult(Scenario, Action, true); }
+			}
+			else if (Action == TEXT("inject_action"))
+			{
+				double X = 1.0, Y = 0.0, Z = 0.0; Step->TryGetNumberField(TEXT("x"), X); Step->TryGetNumberField(TEXT("y"), Y); Step->TryGetNumberField(TEXT("z"), Z);
+				FString Error; const bool bOk = JsonSuccess(UInputService::InjectAction(Step->GetStringField(TEXT("path")), X, Y, Z), Error);
+				AddScenarioStepResult(Scenario, Action, bOk, Error);
+			}
+			else if (Action == TEXT("inject_key"))
+			{
+				FString Event = TEXT("tap"); Step->TryGetStringField(TEXT("event"), Event); FString Error;
+				const bool bOk = JsonSuccess(UInputService::InjectKey(Step->GetStringField(TEXT("key")), Event), Error);
+				AddScenarioStepResult(Scenario, Action, bOk, Error);
+			}
+			else if (Action == TEXT("assert_log"))
+			{
+				FString Contains, NotContains; Step->TryGetStringField(TEXT("contains"), Contains); Step->TryGetStringField(TEXT("not_contains"), NotContains);
+				const FString Delta = ReadScenarioLogDelta(*Scenario);
+				const bool bOk = (!Contains.IsEmpty() && Delta.Contains(Contains)) || (!NotContains.IsEmpty() && !Delta.Contains(NotContains));
+				const FString Expected = !Contains.IsEmpty() ? TEXT("contains: ") + Contains : TEXT("does not contain: ") + NotContains;
+				AddScenarioStepResult(Scenario, Action, bOk, bOk ? FString() : TEXT("log assertion failed"), Delta.Right(2000), Expected);
+			}
+			else if (Action == TEXT("python_assert"))
+			{
+				FString Expression, Expected; Step->TryGetStringField(TEXT("expression"), Expression); Step->TryGetStringField(TEXT("expected"), Expected);
+				FPythonCommandEx Command; Command.Command = Expression; Command.ExecutionMode = EPythonCommandExecutionMode::EvaluateStatement;
+				IPythonScriptPlugin* Python = IPythonScriptPlugin::Get(); const bool bExecuted = Python && Python->ExecPythonCommandEx(Command);
+				const bool bOk = bExecuted && Command.CommandResult == Expected;
+				AddScenarioStepResult(Scenario, Action, bOk, bOk ? FString() : TEXT("Python assertion failed"), Command.CommandResult, Expected);
+			}
+			else if (Action == TEXT("capture_game"))
+			{
+				FString Name = FString::Printf(TEXT("scenario-%s-step-%d"), *Scenario->Id, Scenario->StepIndex); Step->TryGetStringField(TEXT("name"), Name);
+				const FString Path = FPaths::Combine(ScenarioDir(), Scenario->Id + TEXT("-") + Name + TEXT(".png"));
+				FScreenshotRequest::RequestScreenshot(Path, true, false, false, FIntRect(), true);
+				TArray<TSharedPtr<FJsonValue>> Captures = Scenario->Report->GetArrayField(TEXT("captures")); Captures.Add(MakeShared<FJsonValueString>(Path)); Scenario->Report->SetArrayField(TEXT("captures"), Captures);
+				AddScenarioStepResult(Scenario, Action, true, FString(), Path);
+			}
+			else if (Action == TEXT("console_command"))
+			{
+				FString Command; Step->TryGetStringField(TEXT("command"), Command); UWorld* World = GEditor && GEditor->PlayWorld ? GEditor->PlayWorld.Get() : (GEditor ? GEditor->GetEditorWorldContext().World() : nullptr);
+				const bool bOk = GEngine && World && !Command.IsEmpty(); if (bOk) { GEngine->Exec(World, *Command); }
+				AddScenarioStepResult(Scenario, Action, bOk, bOk ? FString() : TEXT("no world or empty command"));
+			}
+			else if (Action == TEXT("stop_pie"))
+			{
+				if (!GEditor || !GEditor->PlayWorld) { AddScenarioStepResult(Scenario, Action, true); }
+				else { FString Error; AddScenarioStepResult(Scenario, Action, JsonSuccess(UPerformanceService::StopPIE(), Error), Error); }
+			}
+			else { AddScenarioStepResult(Scenario, Action, false, TEXT("unsupported scenario action: ") + Action); }
+		}
+		return true;
+	}
+
+	FTSTicker::FDelegateHandle GScenarioTicker = FTSTicker::GetCoreTicker().AddTicker(
+		FTickerDelegate::CreateStatic(&TickWorkflowScenario), 0.01f);
+}
+
+FString UWorkflowService::RunScenario(const FString& ScenarioJson)
+{
+	TSharedPtr<FJsonObject> Spec;
+	if (!FJsonSerializer::Deserialize(TJsonReaderFactory<>::Create(ScenarioJson), Spec) || !Spec.IsValid()) { return ScenarioError(TEXT("scenario_json must be an object")); }
+	const TArray<TSharedPtr<FJsonValue>>* Steps = nullptr;
+	if (!Spec->TryGetArrayField(TEXT("steps"), Steps) || Steps->Num() == 0) { return ScenarioError(TEXT("scenario requires a non-empty steps array")); }
+	TSharedPtr<FWorkflowScenario> Scenario = MakeShared<FWorkflowScenario>();
+	Scenario->Id = FDateTime::UtcNow().ToString(TEXT("%Y%m%dT%H%M%SZ")) + TEXT("-") + FGuid::NewGuid().ToString(EGuidFormats::Digits).Left(8);
+	Scenario->Spec = Spec.ToSharedRef(); Scenario->Steps = *Steps; Scenario->StartedSeconds = FPlatformTime::Seconds();
+	FString CurrentLog; FFileHelper::LoadFileToString(CurrentLog, *ProjectLogPath()); Scenario->LogStartChars = CurrentLog.Len();
+	const TSharedPtr<FJsonObject>* Teardown = nullptr; if (Spec->TryGetObjectField(TEXT("teardown"), Teardown)) { (*Teardown)->TryGetBoolField(TEXT("stop_pie"), Scenario->bStopPIE); }
+	Scenario->Report->SetStringField(TEXT("schema"), TEXT("vibeue.scenario.v1")); Scenario->Report->SetStringField(TEXT("id"), Scenario->Id);
+	FString Name = Scenario->Id; Spec->TryGetStringField(TEXT("name"), Name); Scenario->Report->SetStringField(TEXT("name"), Name);
+	Scenario->Report->SetStringField(TEXT("status"), TEXT("running")); Scenario->Report->SetStringField(TEXT("startedAtIso"), FDateTime::UtcNow().ToIso8601());
+	Scenario->Report->SetArrayField(TEXT("steps"), {}); Scenario->Report->SetArrayField(TEXT("captures"), {});
+	TArray<TSharedPtr<FJsonValue>> CompileResults;
+	bool bCompileOk = true;
+	const TSharedPtr<FJsonObject>* Preflight = nullptr;
+	if (Spec->TryGetObjectField(TEXT("preflight"), Preflight))
+	{
+		bool bSave = false; (*Preflight)->TryGetBoolField(TEXT("save_dirty_assets"), bSave);
+		const TArray<TSharedPtr<FJsonValue>>* Blueprints = nullptr;
+		if ((*Preflight)->TryGetArrayField(TEXT("compile_blueprints"), Blueprints))
+		{
+			for (const TSharedPtr<FJsonValue>& Value : *Blueprints)
+			{
+				const FString Path = Value->AsString(); FString ObjectPath = Path;
+				if (!ObjectPath.Contains(TEXT("."))) { ObjectPath += TEXT(".") + FPaths::GetBaseFilename(Path); }
+				UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *ObjectPath);
+				TSharedRef<FJsonObject> Compile = MakeShared<FJsonObject>(); Compile->SetStringField(TEXT("path"), Path);
+				if (!Blueprint) { Compile->SetBoolField(TEXT("success"), false); Compile->SetStringField(TEXT("error"), TEXT("Blueprint not found")); bCompileOk = false; }
+				else
+				{
+					FKismetEditorUtilities::CompileBlueprint(Blueprint);
+					const bool bOk = Blueprint->Status != BS_Error; Compile->SetBoolField(TEXT("success"), bOk); bCompileOk &= bOk;
+					if (bSave && bOk) { Compile->SetBoolField(TEXT("saved"), UEditorAssetLibrary::SaveLoadedAsset(Blueprint, false)); }
+				}
+				CompileResults.Add(MakeShared<FJsonValueObject>(Compile));
+			}
+		}
+	}
+	Scenario->Report->SetArrayField(TEXT("compileResults"), CompileResults); SaveScenario(*Scenario);
+	GWorkflowScenarios.Add(Scenario->Id, Scenario);
+	if (!bCompileOk) { FinishScenario(Scenario, TEXT("failed"), TEXT("Blueprint preflight compile failed")); return SerializeScenario(Scenario->Report); }
+	TSharedRef<FJsonObject> Root = MakeShared<FJsonObject>(); Root->SetBoolField(TEXT("success"), true); Root->SetStringField(TEXT("scenarioId"), Scenario->Id);
+	Root->SetStringField(TEXT("status"), TEXT("running")); Root->SetStringField(TEXT("reportPath"), ScenarioPath(Scenario->Id));
+	return SerializeScenario(Root);
+}
+
+FString UWorkflowService::GetScenario(const FString& ScenarioId)
+{
+	if (const TSharedPtr<FWorkflowScenario>* Found = GWorkflowScenarios.Find(ScenarioId)) { return SerializeScenario((*Found)->Report); }
+	FString Text; return FFileHelper::LoadFileToString(Text, *ScenarioPath(ScenarioId)) ? Text : ScenarioError(TEXT("scenario not found"));
+}
+
+FString UWorkflowService::CancelScenario(const FString& ScenarioId)
+{
+	const TSharedPtr<FWorkflowScenario>* Found = GWorkflowScenarios.Find(ScenarioId);
+	if (!Found) { return ScenarioError(TEXT("scenario not found")); }
+	FinishScenario(*Found, TEXT("cancelled"), TEXT("cancelled by caller")); return SerializeScenario((*Found)->Report);
+}

--- a/Source/VibeUE/Private/PythonAPI/WorkflowServiceTests.cpp
+++ b/Source/VibeUE/Private/PythonAPI/WorkflowServiceTests.cpp
@@ -1,0 +1,180 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#include "PythonAPI/UWorkflowService.h"
+
+#include "Dom/JsonObject.h"
+#include "EditorAssetLibrary.h"
+#include "Engine/Blueprint.h"
+#include "Engine/BlueprintGeneratedClass.h"
+#include "EdGraphSchema_K2.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "Kismet2/KismetEditorUtilities.h"
+#include "Misc/AutomationTest.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+namespace
+{
+	TSharedPtr<FJsonObject> ParseWorkflowJson(const FString& Text)
+	{
+		TSharedPtr<FJsonObject> Object;
+		return FJsonSerializer::Deserialize(TJsonReaderFactory<>::Create(Text), Object) ? Object : nullptr;
+	}
+
+	FString NewWorkflowAssetPath(const TCHAR* Leaf)
+	{
+		return FString::Printf(TEXT("/Game/VibeUE_Automation/Workflow/%s_%s"), Leaf,
+			*FGuid::NewGuid().ToString(EGuidFormats::Digits).Left(8));
+	}
+
+	UBlueprint* CreateWorkflowBlueprint(const FString& Path, EBlueprintType Type = BPTYPE_Normal)
+	{
+		const FString Name = FPaths::GetBaseFilename(Path);
+		UPackage* Package = CreatePackage(*Path);
+		return FKismetEditorUtilities::CreateBlueprint(Type == BPTYPE_Interface ? UInterface::StaticClass() : UObject::StaticClass(),
+			Package, *Name, Type, UBlueprint::StaticClass(), UBlueprintGeneratedClass::StaticClass(), TEXT("WorkflowServiceTests"));
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FWorkflowEnvironmentTest, "VibeUE.Workflow.Environment.Manifest",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FWorkflowEnvironmentTest::RunTest(const FString&)
+{
+	const TSharedPtr<FJsonObject> Environment = ParseWorkflowJson(UWorkflowService::GetEnvironment());
+	if (!TestTrue(TEXT("manifest is JSON"), Environment.IsValid())) { return false; }
+	TestTrue(TEXT("project file is absolute"), !FPaths::IsRelative(Environment->GetStringField(TEXT("projectFile"))));
+	TestTrue(TEXT("engine root is absolute"), !FPaths::IsRelative(Environment->GetStringField(TEXT("engineRoot"))));
+	TestTrue(TEXT("engine source diagnostic is explicit"), Environment->GetObjectField(TEXT("engineSource"))->HasField(TEXT("available")));
+	TestTrue(TEXT("compiler diagnostic is explicit"), Environment->GetObjectField(TEXT("compiler"))->HasField(TEXT("available")));
+	TestTrue(TEXT("last build status is explicit"), Environment->GetObjectField(TEXT("lastBuild"))->HasField(TEXT("status")));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FWorkflowJournalTest, "VibeUE.Workflow.Journal.LifecycleAndRedaction",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FWorkflowJournalTest::RunTest(const FString&)
+{
+	const TSharedPtr<FJsonObject> Started = ParseWorkflowJson(UWorkflowService::StartRun(TEXT("Automation run"), TEXT("{\"api_token\":\"secret-value\",\"ticket\":42}")));
+	if (!TestTrue(TEXT("run starts"), Started.IsValid() && Started->GetBoolField(TEXT("success")))) { return false; }
+	const FString Id = Started->GetStringField(TEXT("runId"));
+	TestTrue(TEXT("note accepted"), ParseWorkflowJson(UWorkflowService::AddRunNote(Id, TEXT("compiled successfully"))).IsValid());
+	TestTrue(TEXT("artifact accepted"), ParseWorkflowJson(UWorkflowService::AttachRunArtifact(Id, TEXT("Saved/Test.png"), TEXT("capture"))).IsValid());
+	const TSharedPtr<FJsonObject> Finished = ParseWorkflowJson(UWorkflowService::FinishRun(Id, TEXT("succeeded"), TEXT("Verified")));
+	if (!TestTrue(TEXT("run finishes"), Finished.IsValid())) { return false; }
+	TestEqual(TEXT("outcome persisted"), Finished->GetStringField(TEXT("status")), FString(TEXT("succeeded")));
+	TestEqual(TEXT("secret redacted"), Finished->GetObjectField(TEXT("metadata"))->GetStringField(TEXT("api_token")), FString(TEXT("[REDACTED]")));
+	TestTrue(TEXT("affected-assets array present"), Finished->HasTypedField<EJson::Array>(TEXT("affectedAssets")));
+	TestTrue(TEXT("optional GameIQ boundary is explicit"), Finished->HasTypedField<EJson::Object>(TEXT("gameIQ")) &&
+		Finished->GetObjectField(TEXT("gameIQ"))->HasField(TEXT("available")));
+	TestTrue(TEXT("delete succeeds"), ParseWorkflowJson(UWorkflowService::DeleteRun(Id))->GetBoolField(TEXT("success")));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FWorkflowJournalRecoveryTest, "VibeUE.Workflow.Journal.InterruptedRecovery",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FWorkflowJournalRecoveryTest::RunTest(const FString&)
+{
+	const TSharedPtr<FJsonObject> Started = ParseWorkflowJson(UWorkflowService::StartRun(TEXT("Interrupted automation run"), TEXT("{}")));
+	if (!TestTrue(TEXT("run starts"), Started.IsValid() && Started->GetBoolField(TEXT("success")))) { return false; }
+	const FString Id = Started->GetStringField(TEXT("runId"));
+	UWorkflowService::ShutdownJournal();
+	const TSharedPtr<FJsonObject> Interrupted = ParseWorkflowJson(UWorkflowService::GetRun(Id));
+	TestTrue(TEXT("interrupted run remains readable"), Interrupted.IsValid());
+	TestEqual(TEXT("shutdown is represented distinctly"), Interrupted->GetStringField(TEXT("status")), FString(TEXT("interrupted")));
+	UWorkflowService::InitializeJournal();
+	TestTrue(TEXT("interrupted run can be removed"), ParseWorkflowJson(UWorkflowService::DeleteRun(Id))->GetBoolField(TEXT("success")));
+	return true;
+}
+
+DEFINE_LATENT_AUTOMATION_COMMAND_THREE_PARAMETER(FWaitWorkflowScenario, FAutomationTestBase*, Test, FString, Id, bool, bExpectedPass);
+bool FWaitWorkflowScenario::Update()
+{
+	static TMap<FString, double> Starts;
+	double& Start = Starts.FindOrAdd(Id, FPlatformTime::Seconds());
+	const TSharedPtr<FJsonObject> Report = ParseWorkflowJson(UWorkflowService::GetScenario(Id));
+	if (!Report.IsValid()) { Test->AddError(TEXT("scenario report is invalid")); Starts.Remove(Id); return true; }
+	const FString Status = Report->GetStringField(TEXT("status"));
+	if (Status == TEXT("running"))
+	{
+		if (FPlatformTime::Seconds() - Start < 10.0) { return false; }
+		Test->AddError(TEXT("scenario timed out")); UWorkflowService::CancelScenario(Id); Starts.Remove(Id); return true;
+	}
+	Test->TestEqual(TEXT("scenario terminal verdict"), Report->GetBoolField(TEXT("passed")), bExpectedPass);
+	Test->TestTrue(TEXT("teardown recorded"), Report->HasField(TEXT("teardownSucceeded")));
+	Starts.Remove(Id); return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FWorkflowScenarioTest, "VibeUE.Workflow.Scenario.PassingAndFailing",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FWorkflowScenarioTest::RunTest(const FString&)
+{
+	const TSharedPtr<FJsonObject> Passing = ParseWorkflowJson(UWorkflowService::RunScenario(
+		TEXT("{\"name\":\"pass\",\"steps\":[{\"action\":\"wait\",\"seconds\":0.01},{\"action\":\"python_assert\",\"expression\":\"1+1\",\"expected\":\"2\"}],\"teardown\":{\"stop_pie\":false}}")));
+	const TSharedPtr<FJsonObject> Failing = ParseWorkflowJson(UWorkflowService::RunScenario(
+		TEXT("{\"name\":\"fail\",\"steps\":[{\"action\":\"python_assert\",\"expression\":\"1+1\",\"expected\":\"3\"}],\"teardown\":{\"stop_pie\":false}}")));
+	if (!TestTrue(TEXT("scenarios queued"), Passing.IsValid() && Failing.IsValid())) { return false; }
+	ADD_LATENT_AUTOMATION_COMMAND(FWaitWorkflowScenario(this, Passing->GetStringField(TEXT("scenarioId")), true));
+	ADD_LATENT_AUTOMATION_COMMAND(FWaitWorkflowScenario(this, Failing->GetStringField(TEXT("scenarioId")), false));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FWorkflowBulkTest, "VibeUE.Workflow.Bulk.InterfaceAndMetadata",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FWorkflowBulkTest::RunTest(const FString&)
+{
+	const FString InterfacePath = NewWorkflowAssetPath(TEXT("BPI_Test"));
+	const FString APath = NewWorkflowAssetPath(TEXT("BP_A"));
+	const FString BPath = NewWorkflowAssetPath(TEXT("BP_B"));
+	UBlueprint* Interface = CreateWorkflowBlueprint(InterfacePath, BPTYPE_Interface);
+	UBlueprint* A = CreateWorkflowBlueprint(APath); UBlueprint* B = CreateWorkflowBlueprint(BPath);
+	if (!TestTrue(TEXT("test assets created"), Interface && A && B)) { return false; }
+	FEdGraphPinType StringType; StringType.PinCategory = UEdGraphSchema_K2::PC_String;
+	FBlueprintEditorUtils::AddMemberVariable(A, TEXT("Description"), StringType);
+	FBlueprintEditorUtils::AddMemberVariable(B, TEXT("Description"), StringType);
+	FBlueprintEditorUtils::AddMemberVariable(B, TEXT("Extra"), StringType);
+	UEditorAssetLibrary::SaveLoadedAsset(Interface, false); UEditorAssetLibrary::SaveLoadedAsset(A, false); UEditorAssetLibrary::SaveLoadedAsset(B, false);
+	const TSharedPtr<FJsonObject> StartedRun = ParseWorkflowJson(UWorkflowService::StartRun(TEXT("Bulk workflow automation"), TEXT("{}")));
+	if (!TestTrue(TEXT("bulk journal starts"), StartedRun.IsValid() && StartedRun->GetBoolField(TEXT("success")))) { return false; }
+	const FString RunId = StartedRun->GetStringField(TEXT("runId"));
+
+	const FString InterfacePlan = FString::Printf(TEXT("{\"resume_id\":\"workflow-interface-%s\",\"operation\":\"interface_add\",\"path_scope\":\"/Game/VibeUE_Automation\",\"interface\":\"%s\",\"targets\":[\"%s\",\"%s\"]}"),
+		*FGuid::NewGuid().ToString(EGuidFormats::Digits).Left(8), *InterfacePath, *APath, *BPath);
+	const TSharedPtr<FJsonObject> DryRun = ParseWorkflowJson(UWorkflowService::RunBulkMaintenance(InterfacePlan, false, 1, true));
+	TestTrue(TEXT("dry run succeeds"), DryRun.IsValid() && DryRun->GetBoolField(TEXT("success")));
+	const TSharedPtr<FJsonObject> Applied = ParseWorkflowJson(UWorkflowService::RunBulkMaintenance(InterfacePlan, true, 1, true));
+	TestTrue(TEXT("interface apply succeeds"), Applied.IsValid() && Applied->GetBoolField(TEXT("success")));
+	const TSharedPtr<FJsonObject> Resumed = ParseWorkflowJson(UWorkflowService::RunBulkMaintenance(InterfacePlan, true, 1, true));
+	TestEqual(TEXT("successful targets are not repeated on resume"), static_cast<int32>(Resumed->GetNumberField(TEXT("skipped"))), 2);
+
+	const FString MetadataPlan = FString::Printf(TEXT("{\"resume_id\":\"workflow-meta-%s\",\"operation\":\"variable_metadata\",\"path_scope\":\"/Game/VibeUE_Automation\",\"targets\":[{\"asset\":\"%s\",\"variable\":\"Description\",\"category\":\"Test\",\"description\":\"A value\"},{\"asset\":\"%s\",\"variable\":\"Description\",\"category\":\"Test\",\"description\":\"B value\"}]}"),
+		*FGuid::NewGuid().ToString(EGuidFormats::Digits).Left(8), *APath, *BPath);
+	const TSharedPtr<FJsonObject> Metadata = ParseWorkflowJson(UWorkflowService::RunBulkMaintenance(MetadataPlan, true, 2, true));
+	TestTrue(TEXT("metadata apply succeeds"), Metadata.IsValid() && Metadata->GetBoolField(TEXT("success")));
+	FString Tooltip; TestTrue(TEXT("metadata readback"), FBlueprintEditorUtils::GetBlueprintVariableMetaData(A, TEXT("Description"), nullptr, TEXT("tooltip"), Tooltip));
+	TestEqual(TEXT("description preserved"), Tooltip, FString(TEXT("A value")));
+
+	const FString PartialPlan = FString::Printf(TEXT("{\"resume_id\":\"workflow-partial-%s\",\"operation\":\"variable_metadata\",\"path_scope\":\"/Game/VibeUE_Automation\",\"targets\":[{\"asset\":\"%s\",\"variable\":\"Description\",\"category\":\"Changed\",\"description\":\"Should not overwrite\"},{\"asset\":\"%s\",\"variable\":\"Extra\",\"category\":\"Test\",\"description\":\"New metadata\"}]}"),
+		*FGuid::NewGuid().ToString(EGuidFormats::Digits).Left(8), *APath, *BPath);
+	const TSharedPtr<FJsonObject> Partial = ParseWorkflowJson(UWorkflowService::RunBulkMaintenance(PartialPlan, true, 2, false));
+	TestEqual(TEXT("partial failure count"), static_cast<int32>(Partial->GetNumberField(TEXT("failed"))), 1);
+	TestEqual(TEXT("partial success count"), static_cast<int32>(Partial->GetNumberField(TEXT("succeeded"))), 1);
+	FString PreservedTooltip;
+	FBlueprintEditorUtils::GetBlueprintVariableMetaData(A, TEXT("Description"), nullptr, TEXT("tooltip"), PreservedTooltip);
+	TestEqual(TEXT("authored metadata survives partial run"), PreservedTooltip, FString(TEXT("A value")));
+
+	const FString CollisionPlan = FString::Printf(TEXT("{\"resume_id\":\"workflow-collision-%s\",\"operation\":\"asset_move\",\"path_scope\":\"/Game/VibeUE_Automation\",\"targets\":[{\"source\":\"%s\",\"destination\":\"%s\"}]}"),
+		*FGuid::NewGuid().ToString(EGuidFormats::Digits).Left(8), *APath, *BPath);
+	const TSharedPtr<FJsonObject> Collision = ParseWorkflowJson(UWorkflowService::RunBulkMaintenance(CollisionPlan, true, 1, true));
+	TestFalse(TEXT("name collision is refused"), Collision->GetBoolField(TEXT("success")));
+
+	const TSharedPtr<FJsonObject> FinishedRun = ParseWorkflowJson(UWorkflowService::FinishRun(RunId, TEXT("partial"), TEXT("Expected collision and metadata refusal verified")));
+	TestTrue(TEXT("bulk reports attach to journal"), FinishedRun->GetArrayField(TEXT("artifacts")).Num() >= 4);
+
+	UEditorAssetLibrary::DeleteAsset(APath); UEditorAssetLibrary::DeleteAsset(BPath); UEditorAssetLibrary::DeleteAsset(InterfacePath);
+	UWorkflowService::DeleteRun(RunId);
+	return true;
+}
+
+#endif

--- a/Source/VibeUE/Private/Utils/VibeUEEnvironment.cpp
+++ b/Source/VibeUE/Private/Utils/VibeUEEnvironment.cpp
@@ -1,0 +1,171 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#include "Utils/VibeUEEnvironment.h"
+
+#include "Dom/JsonObject.h"
+#include "HAL/PlatformProcess.h"
+#include "Interfaces/IPluginManager.h"
+#include "Misc/App.h"
+#include "Misc/EngineVersion.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "ToolsetRegistry/UToolsetRegistry.h"
+#include "Utils/VibeUEPaths.h"
+
+namespace
+{
+	TSharedPtr<FJsonObject> LoadEnvironmentJson(const FString& Path)
+	{
+		FString Text;
+		if (!FFileHelper::LoadFileToString(Text, *Path)) { return nullptr; }
+		TSharedPtr<FJsonObject> Object;
+		return FJsonSerializer::Deserialize(TJsonReaderFactory<>::Create(Text), Object) ? Object : nullptr;
+	}
+
+	TSharedRef<FJsonObject> PathDiagnostic(const FString& Path)
+	{
+		TSharedRef<FJsonObject> Object = MakeShared<FJsonObject>();
+		Object->SetStringField(TEXT("path"), FPaths::ConvertRelativePathToFull(Path));
+		Object->SetBoolField(TEXT("available"), FPaths::FileExists(Path) || FPaths::DirectoryExists(Path));
+		return Object;
+	}
+
+	bool HasBuildInputsNewerThan(const FString& Directory, const FDateTime& BuildTime)
+	{
+		if (!FPaths::DirectoryExists(Directory)) { return false; }
+		TArray<FString> Files;
+		IFileManager::Get().FindFilesRecursive(Files, *Directory, TEXT("*.*"), true, false, false);
+		for (const FString& File : Files)
+		{
+			const FString Extension = FPaths::GetExtension(File).ToLower();
+			if ((Extension == TEXT("cpp") || Extension == TEXT("h") || Extension == TEXT("cs") ||
+				Extension == TEXT("uplugin") || Extension == TEXT("uproject")) &&
+				IFileManager::Get().GetTimeStamp(*File) > BuildTime)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+TSharedRef<FJsonObject> FVibeUEEnvironment::BuildObject()
+{
+	const FString ProjectFile = FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath());
+	const FString ProjectRoot = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+	const FString EngineRoot = FPaths::ConvertRelativePathToFull(FPaths::RootDir());
+#if PLATFORM_WINDOWS
+	const FString BuildScript = FPaths::Combine(EngineRoot, TEXT("Engine/Build/BatchFiles/Build.bat"));
+	const FString EditorExe = FPaths::Combine(EngineRoot, TEXT("Engine/Binaries/Win64/UnrealEditor.exe"));
+	const FString UatPath = FPaths::Combine(EngineRoot, TEXT("Engine/Build/BatchFiles/RunUAT.bat"));
+#elif PLATFORM_MAC
+	const FString BuildScript = FPaths::Combine(EngineRoot, TEXT("Engine/Build/BatchFiles/Mac/Build.sh"));
+	const FString EditorExe = FPaths::Combine(EngineRoot, TEXT("Engine/Binaries/Mac/UnrealEditor.app/Contents/MacOS/UnrealEditor"));
+	const FString UatPath = FPaths::Combine(EngineRoot, TEXT("Engine/Build/BatchFiles/RunUAT.sh"));
+#else
+	const FString BuildScript = FPaths::Combine(EngineRoot, TEXT("Engine/Build/BatchFiles/Linux/Build.sh"));
+	const FString EditorExe = FPaths::Combine(EngineRoot, TEXT("Engine/Binaries/Linux/UnrealEditor"));
+	const FString UatPath = FPaths::Combine(EngineRoot, TEXT("Engine/Build/BatchFiles/RunUAT.sh"));
+#endif
+	const FString UbtPath = FPaths::Combine(EngineRoot, TEXT("Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll"));
+
+	FString Association;
+	if (const TSharedPtr<FJsonObject> Project = LoadEnvironmentJson(ProjectFile))
+	{
+		Project->TryGetStringField(TEXT("EngineAssociation"), Association);
+	}
+	TSharedRef<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("schema"), TEXT("vibeue.environment.v1"));
+	Root->SetStringField(TEXT("projectFile"), ProjectFile);
+	Root->SetStringField(TEXT("projectRoot"), ProjectRoot);
+	Root->SetStringField(TEXT("projectName"), FApp::GetProjectName());
+	Root->SetStringField(TEXT("editorTarget"), FString(FApp::GetProjectName()) + TEXT("Editor"));
+	Root->SetStringField(TEXT("configuration"), LexToString(FApp::GetBuildConfiguration()));
+	Root->SetStringField(TEXT("engineRoot"), EngineRoot);
+	Root->SetStringField(TEXT("engineVersion"), FEngineVersion::Current().ToString());
+	Root->SetStringField(TEXT("engineAssociation"), Association);
+	Root->SetObjectField(TEXT("engineSource"), PathDiagnostic(FPaths::Combine(EngineRoot, TEXT("Engine/Source"))));
+	Root->SetObjectField(TEXT("editorExecutable"), PathDiagnostic(EditorExe));
+	Root->SetObjectField(TEXT("ubt"), PathDiagnostic(UbtPath));
+	Root->SetObjectField(TEXT("uat"), PathDiagnostic(UatPath));
+	Root->SetObjectField(TEXT("engineBuildScript"), PathDiagnostic(BuildScript));
+	Root->SetObjectField(TEXT("vibeueBuildScript"), PathDiagnostic(FPaths::Combine(FVibeUEPaths::GetPluginDir(),
+#if PLATFORM_WINDOWS
+		TEXT("BuildAndLaunchGame.ps1")
+#else
+		TEXT("BuildAndLaunchGame.sh")
+#endif
+	)));
+	Root->SetStringField(TEXT("hostPlatform"), FPlatformProperties::PlatformName());
+	Root->SetStringField(TEXT("architecture"), TEXT("64-bit"));
+	Root->SetNumberField(TEXT("editorPid"), FPlatformProcess::GetCurrentProcessId());
+	Root->SetStringField(TEXT("vibeueVersion"), FVibeUEPaths::GetPluginVersionName());
+	Root->SetBoolField(TEXT("toolsetRegistryAvailable"), UToolsetRegistry::IsAvailable());
+
+	TSharedRef<FJsonObject> Compiler = MakeShared<FJsonObject>();
+	FString CompilerRoot = FPlatformMisc::GetEnvironmentVariable(TEXT("VCToolsInstallDir"));
+#if PLATFORM_WINDOWS
+	Compiler->SetStringField(TEXT("kind"), TEXT("msvc"));
+	Compiler->SetStringField(TEXT("path"), CompilerRoot);
+	Compiler->SetBoolField(TEXT("available"), !CompilerRoot.IsEmpty() && FPaths::DirectoryExists(CompilerRoot));
+	if (CompilerRoot.IsEmpty()) { Compiler->SetStringField(TEXT("diagnostic"), TEXT("VCToolsInstallDir is not present in the editor environment; UBT remains the authoritative toolchain probe.")); }
+#else
+	Compiler->SetStringField(TEXT("kind"), TEXT("platform-default"));
+	Compiler->SetStringField(TEXT("path"), TEXT(""));
+	Compiler->SetBoolField(TEXT("available"), true);
+#endif
+	Root->SetObjectField(TEXT("compiler"), Compiler);
+
+	TArray<TSharedPtr<FJsonValue>> Plugins;
+	for (const TSharedRef<IPlugin>& Plugin : IPluginManager::Get().GetEnabledPlugins())
+	{
+		TSharedRef<FJsonObject> Item = MakeShared<FJsonObject>();
+		Item->SetStringField(TEXT("name"), Plugin->GetName());
+		Item->SetStringField(TEXT("version"), Plugin->GetDescriptor().VersionName);
+		Plugins.Add(MakeShared<FJsonValueObject>(Item));
+	}
+	Plugins.Sort([](const TSharedPtr<FJsonValue>& A, const TSharedPtr<FJsonValue>& B)
+	{
+		return A->AsObject()->GetStringField(TEXT("name")) < B->AsObject()->GetStringField(TEXT("name"));
+	});
+	Root->SetArrayField(TEXT("enabledPlugins"), Plugins);
+
+	const FString LastBuildPath = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("VibeUE/last-build.json"));
+	if (const TSharedPtr<FJsonObject> LastBuild = LoadEnvironmentJson(LastBuildPath))
+	{
+		FString Status;
+		LastBuild->TryGetStringField(TEXT("status"), Status);
+		const FDateTime BuildTime = IFileManager::Get().GetTimeStamp(*LastBuildPath);
+		const bool bStale = Status == TEXT("succeeded") &&
+			(HasBuildInputsNewerThan(FPaths::Combine(ProjectRoot, TEXT("Source")), BuildTime) ||
+			 HasBuildInputsNewerThan(FPaths::Combine(FVibeUEPaths::GetPluginDir(), TEXT("Source")), BuildTime) ||
+			 IFileManager::Get().GetTimeStamp(*ProjectFile) > BuildTime);
+		LastBuild->SetBoolField(TEXT("isStale"), bStale);
+		if (bStale)
+		{
+			LastBuild->SetStringField(TEXT("previousStatus"), Status);
+			LastBuild->SetStringField(TEXT("status"), TEXT("stale"));
+			LastBuild->SetStringField(TEXT("diagnostic"), TEXT("Build inputs changed after the last successful build."));
+		}
+		Root->SetObjectField(TEXT("lastBuild"), LastBuild.ToSharedRef());
+	}
+	else
+	{
+		TSharedRef<FJsonObject> NotRunBuild = MakeShared<FJsonObject>();
+		NotRunBuild->SetStringField(TEXT("status"), TEXT("not-run"));
+		NotRunBuild->SetBoolField(TEXT("isStale"), false);
+		NotRunBuild->SetStringField(TEXT("diagnostic"), TEXT("No VibeUE build-script result has been recorded in this project."));
+		Root->SetObjectField(TEXT("lastBuild"), NotRunBuild);
+	}
+	return Root;
+}
+
+FString FVibeUEEnvironment::BuildJson()
+{
+	FString Out;
+	FJsonSerializer::Serialize(BuildObject(), TJsonWriterFactory<>::Create(&Out));
+	return Out;
+}

--- a/Source/VibeUE/Private/Utils/VibeUEReadinessSignal.cpp
+++ b/Source/VibeUE/Private/Utils/VibeUEReadinessSignal.cpp
@@ -2,6 +2,7 @@
 
 #include "Utils/VibeUEReadinessSignal.h"
 #include "Utils/VibeUEPaths.h"
+#include "Utils/VibeUEEnvironment.h"
 #include "CoreGlobals.h"
 #if WITH_EDITOR
 #include "Editor.h"
@@ -73,6 +74,7 @@ FString FVibeUEReadinessSignal::BuildSignalJson(uint32 ProcessId, const FDateTim
 	Root->SetStringField(TEXT("sessionStartUtc"), SessionStartUtc.ToIso8601());
 	Root->SetStringField(TEXT("pluginVersion"), FVibeUEPaths::GetPluginVersionName());
 	Root->SetStringField(TEXT("currentMap"), CurrentMap);
+	Root->SetObjectField(TEXT("environment"), FVibeUEEnvironment::BuildObject());
 
 	FString Payload;
 	const TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Payload);

--- a/Source/VibeUE/Public/PythonAPI/UGameplayTagService.h
+++ b/Source/VibeUE/Public/PythonAPI/UGameplayTagService.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "GameplayTagContainer.h"
 #include "ToolsetRegistry/ToolsetDefinition.h"
 #include "UGameplayTagService.generated.h"
 
@@ -135,6 +136,40 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|GameplayTags")
 	static TArray<FVibeGameplayTagInfo> GetChildren(const FString& ParentTag);
+
+	/**
+	 * Look up a registered gameplay tag by name and return the real FGameplayTag VALUE.
+	 *
+	 * This is the editor-scripting escape hatch: Python cannot construct an FGameplayTag
+	 * (the struct's TagName is read-only and BlueprintGameplayTagLibrary::MakeLiteralGameplayTag
+	 * takes a tag, not a string), which blocks every tag-typed engine API — e.g.
+	 * SendGameplayEventToActor, HasMatchingGameplayTag, AssignTagSetByCallerMagnitude,
+	 * and TMap<FGameplayTag, ...> authoring.
+	 *
+	 * Python:
+	 *   tag = unreal.GameplayTagService.request_tag("Ability.Fire")
+	 *   asc.has_matching_gameplay_tag(tag)
+	 *
+	 * @param TagName - Full tag name (redirects from renamed tags are applied)
+	 * @return The registered tag, or an INVALID tag (is_valid() false) when the name is
+	 *         not registered — never asserts.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|GameplayTags")
+	static FGameplayTag RequestTag(const FString& TagName);
+
+	/**
+	 * Look up several registered tags at once and return them as a container.
+	 * Unregistered names are skipped (see the log for which). Convenience for
+	 * container-typed APIs (tag queries, RemoveActiveEffectsWithGrantedTags, ...).
+	 *
+	 * Python:
+	 *   c = unreal.GameplayTagService.request_tag_container(["State.Stunned", "State.Rooted"])
+	 *
+	 * @param TagNames - Full tag names
+	 * @return Container holding every name that resolved to a registered tag
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|GameplayTags")
+	static FGameplayTagContainer RequestTagContainer(const TArray<FString>& TagNames);
 
 #if WITH_EDITOR
 	// =================================================================

--- a/Source/VibeUE/Public/PythonAPI/UWorkflowService.h
+++ b/Source/VibeUE/Public/PythonAPI/UWorkflowService.h
@@ -1,0 +1,75 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "ToolsetRegistry/ToolsetDefinition.h"
+#include "UWorkflowService.generated.h"
+
+/** High-level, evidence-producing workflows built from VibeUE's lower-level editor primitives. */
+UCLASS(BlueprintType)
+class VIBEUE_API UWorkflowService : public UToolsetDefinition
+{
+	GENERATED_BODY()
+
+public:
+	/** Authoritative project/engine/toolchain/build context as JSON. Read-only. */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Workflow")
+	static FString GetEnvironment();
+
+	/** Start an opt-in durable task journal under Saved/VibeUE/Runs. */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Workflow|Journal")
+	static FString StartRun(const FString& Name, const FString& MetadataJson = TEXT("{}"));
+
+	/** Add a note to an active or historical run. */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Workflow|Journal")
+	static FString AddRunNote(const FString& RunId, const FString& Text);
+
+	/** Attach a file/capture/scenario/build artifact to a run. */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Workflow|Journal")
+	static FString AttachRunArtifact(const FString& RunId, const FString& PathOrId, const FString& Kind = TEXT("file"));
+
+	/** Finish a run and write final JSON plus readable Markdown atomically. */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Workflow|Journal")
+	static FString FinishRun(const FString& RunId, const FString& Outcome, const FString& Summary);
+
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Workflow|Journal")
+	static FString GetRun(const FString& RunId);
+
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Workflow|Journal")
+	static FString ListRuns(int32 Limit = 50);
+
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Workflow|Journal")
+	static FString DeleteRun(const FString& RunId);
+
+	/**
+	 * Queue a deterministic PIE scenario. Returns a scenario id immediately; poll GetScenario until
+	 * status is passed/failed/cancelled. Teardown is guaranteed on every terminal path.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Workflow|PIE")
+	static FString RunScenario(const FString& ScenarioJson);
+
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Workflow|PIE")
+	static FString GetScenario(const FString& ScenarioId);
+
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Workflow|PIE")
+	static FString CancelScenario(const FString& ScenarioId);
+
+	/**
+	 * Execute or dry-run an explicit, bounded maintenance plan. Supported operations:
+	 * interface_add, interface_remove, variable_metadata, asset_move, cleanup_review.
+	 * Plan JSON owns targets/options; dry-run is the default and cleanup never deletes.
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable), Category = "VibeUE|Workflow|Bulk")
+	static FString RunBulkMaintenance(const FString& PlanJson, bool bApply = false, int32 BatchSize = 20,
+		bool bStopOnError = false);
+
+	/** Module lifecycle hooks for mutation observation and interrupted-run recovery. */
+	static void InitializeJournal();
+	static void ShutdownJournal();
+
+	/** Internal workflow composition helpers. They intentionally are not exposed as agent tools. */
+	static FString GetActiveRunId();
+	static void AttachActiveRunArtifact(const FString& PathOrId, const FString& Kind);
+	static FString GetOptionalGameIQImpact(const FString& TopicOrId);
+};

--- a/Source/VibeUE/Public/Utils/VibeUEEnvironment.h
+++ b/Source/VibeUE/Public/Utils/VibeUEEnvironment.h
@@ -1,0 +1,15 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FJsonObject;
+
+/** Canonical, read-only project/engine/build context shared by the tool and readiness signal. */
+class VIBEUE_API FVibeUEEnvironment
+{
+public:
+	static TSharedRef<FJsonObject> BuildObject();
+	static FString BuildJson();
+};

--- a/test_prompts/gameplay-tags/gameplay_tags_tests.md
+++ b/test_prompts/gameplay-tags/gameplay_tags_tests.md
@@ -90,3 +90,20 @@ Add an OnEvent transition from Idle to Patrol.
 Set the transition's event tag to "AI.StartPatrol".
 Compile and save.
 ```
+
+---
+
+### 10. Obtain a real FGameplayTag value for a tag-typed API (request_tag)
+
+```
+Using Python, get the FGameplayTag value for "Cube.StartChasing" via
+unreal.GameplayTagService.request_tag and prove it works end to end: call
+has_matching_gameplay_tag with it on any actor's AbilitySystemComponent (or
+build a container with request_tag_container(["Cube.StartChasing", "Cube.Idle"])
+and print its size). Then request a bogus name "Fake.DoesNotExist" and confirm
+the returned tag reports is_valid() == False without any assert or error.
+```
+
+Expected: request_tag returns a usable tag object (NOT constructible any other
+way from Python), container contains 2 tags, bogus name yields an invalid tag
+plus a LogGameplayTagService warning - never a crash.


### PR DESCRIPTION
## Summary

Promotes the UE 5.8 development branch changes merged since #560.

### Verified agent workflows

- deterministic PIE scenario orchestration with input, assertions, evidence, and guaranteed teardown;
- durable run journals with affected-asset tracking and optional GameIQ pre/post evidence;
- authoritative project, engine, source, toolchain, readiness, and last-build manifests;
- dry-run-first, resumable bulk Blueprint and asset-maintenance workflows;
- automation coverage plus generated agent and skill guidance.

### GAS and Gameplay Tags

- adds the live-verified GAS routing skill and routes it from the VibeUE skill index;
- adds `GameplayTagService.RequestTag` and `RequestTagContainer` for real `FGameplayTag` values in editor Python;
- documents and tests safe handling of registered and unregistered tag names.

## Included pull requests

- #561 — GAS routing skill from the live Proteus capability spike
- #562 — `FGameplayTag` / container request helpers
- #568 — verified workflow orchestration, journals, environment manifest, and bulk maintenance

## Validation

- The workflow feature passed a strict VibeUE build and the complete `VibeUE.Workflow` automation suite before integration.
- The GAS/tag work was verified against a live UE 5.8 Proteus PIE session.
- The combined source merged cleanly into `5-8`; final host-project build is intentionally deferred to the maintainer.

## Issues

Closes #563.
Closes #564.
Closes #565.
Closes #566.

Refs #536. The broader GAS fixture, authoring matrix, multiplayer/prediction audit, and remaining #536 deliverables stay open.
