### PR TITLE
ModelingService: Modeling Mode operators as an AI toolset

### DIFF
--- a/Content/Skills/modeling/SKILL.md
+++ b/Content/Skills/modeling/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: modeling
+display_name: Mesh Modeling
+description: Create and edit static/skeletal mesh geometry programmatically (ModelingService) — primitives, booleans, extrude/inset/bevel on selections, remesh/simplify/subdivide, deform, voxel ops, auto-UV, normals, repair, collision, LODs, bake, and saving to assets. Use when the user asks to build, kitbash, block out, fix, clean up, or generate 3D meshes in the editor without Blender.
+vibeue_classes:
+  - ModelingService
+unreal_classes:
+  - DynamicMesh
+  - StaticMesh
+  - GeometryScript_MeshPrimitives
+  - GeometryScript_MeshBooleans
+  - GeometryScript_MeshUVs
+  - StaticMeshEditorSubsystem
+keywords:
+  - modeling
+  - mesh
+  - geometry
+  - geometry script
+  - primitive
+  - boolean
+  - extrude
+  - inset
+  - bevel
+  - remesh
+  - simplify
+  - subdivide
+  - voxel
+  - collision
+  - lod
+  - bake normal map
+  - kitbash
+  - blockout
+  - procedural mesh
+---
+
+> 🧠 **Brains complement:** IF an `unreal-engine-skills-manager` tool (external MCP) exists in this session, call it with `{action: "load", skill: "meshes-static-and-skeletal"}` for UE domain knowledge on this topic — correct APIs, architecture, best practices — and treat it as the rubric for any review / "best practices" question. If no such tool is available (e.g. running under Claude Code or Codex without that MCP), skip this line entirely and proceed with this skill alone — do NOT attempt the call.
+
+# Mesh Modeling Skill
+
+`ModelingService` (`unreal.ModelingService`) is the programmatic half of Unreal's **Modeling Mode**:
+the same operators the 97 interactive tools are built on, exposed as functions on an in-memory
+`DynamicMesh` that you build up and then save as a `StaticMesh` / `SkeletalMesh` asset. Nothing
+here needs a viewport, a gizmo, or Blender.
+
+**Mental model — a session of mesh handles:**
+
+1. `create_mesh()` / `load_mesh_from_static_mesh(path)` / `load_mesh_from_actor(label)` → an integer **handle**.
+2. Every op mutates the handle's mesh in place and returns an `FModelingResult` (`success`, `message`, `triangle_count`, `vertex_count`).
+3. `save_mesh_to_static_mesh(handle, "/Game/Props/SM_Crate")` writes the asset (creates or replaces); `spawn_static_mesh_actor(...)` places it.
+4. `release_mesh(handle)` when done (or `release_all_meshes()`); handles are session-scoped and not saved.
+
+Operations that take a **selection** use a named selection created on the same handle
+(`select_all`, `select_by_normal_angle`, `select_in_box`, `select_in_sphere`, `select_by_material_id`,
+`expand_contract_selection`, `invert_selection`). Pass `""` as the selection name to mean "the whole mesh".
+
+## Quick start — a crate with a lid seam, UVs, collision, LODs
+
+```python
+import unreal
+svc = unreal.ModelingService
+h = svc.create_mesh()
+svc.append_box(h, unreal.Transform(), 100, 100, 100)                       # body
+lid = svc.create_mesh()
+svc.append_box(lid, unreal.Transform(unreal.Vector(0, 0, 90)), 104, 104, 4) # lid slab
+svc.boolean(h, lid, "Union")
+svc.select_by_normal_angle(h, "top", unreal.Vector(0, 0, 1), 5.0)
+svc.inset_faces(h, "top", 6.0)                                              # panel line on the lid
+svc.extrude_faces(h, "top", -1.5)                                           # recess it
+svc.bevel_polygroups(h, 0.8)
+svc.recompute_normals(h, 30.0)
+svc.auto_uv(h, "PatchBuilder", 0)
+r = svc.save_mesh_to_static_mesh(h, "/Game/Props/SM_Crate", True, True)     # nanite off, collision on
+print("CREATED:", r.asset_path, r.triangle_count, "tris")
+svc.generate_collision("/Game/Props/SM_Crate", "ConvexHulls", 4)
+svc.set_lods("/Game/Props/SM_Crate", [1.0, 0.5, 0.25])
+svc.spawn_static_mesh_actor("/Game/Props/SM_Crate", unreal.Transform(unreal.Vector(0, 0, 0)), "Crate_01")
+svc.release_all_meshes()
+```
+
+Then **look at it**: `call_tool(tool_name="CaptureViewport", toolset_name="EditorToolset.EditorAppToolset")`
+framed on the actor. A successful call is not proof the shape is right.
+
+## Function map (Python names)
+
+| Area | Functions |
+|---|---|
+| Session | `create_mesh()`, `load_mesh_from_static_mesh(path, lod=0)`, `load_mesh_from_skeletal_mesh(path, lod=0)`, `load_mesh_from_actor(label)`, `copy_mesh(handle)`, `release_mesh(handle)`, `release_all_meshes()`, `list_meshes()`, `get_mesh_info(handle)` |
+| Primitives (append into a handle) | `append_box`, `append_sphere`, `append_cylinder`, `append_cone`, `append_capsule`, `append_torus`, `append_rectangle`, `append_disc`, `append_stairs`, `append_extrude_polygon(handle, points2d, height)`, `append_revolve_polygon(handle, points2d, radius, steps, degrees)`, `append_mesh(handle, other_handle, transform)` |
+| Booleans | `boolean(target, tool, "Union|Subtract|Intersection", tool_transform)`, `self_union`, `plane_cut(handle, plane_transform, fill_holes)`, `mirror(handle, plane_transform, weld)` |
+| Selections | `select_all(handle, name)`, `select_by_normal_angle(handle, name, normal, max_angle_deg)`, `select_in_box(handle, name, box_min, box_max)`, `select_in_sphere(handle, name, center, radius)`, `select_by_material_id(handle, name, material_id)`, `expand_contract_selection(handle, name, iterations, contract)`, `invert_selection(handle, name)`, `selection_count(handle, name)` |
+| Poly edit on selections | `extrude_faces(handle, sel, distance, direction)`, `offset_faces(handle, sel, distance)`, `inset_faces(handle, sel, distance)`, `outset_faces(handle, sel, distance)`, `delete_faces(handle, sel)`, `translate_selection(handle, sel, delta)`, `bevel_polygroups(handle, distance, subdivisions)`, `offset_mesh(handle, distance)`, `shell_mesh(handle, thickness)` |
+| Mesh | `remesh(handle, target_triangles, edge_length=0)`, `simplify_to_triangle_count(handle, n)`, `simplify_to_tolerance(handle, tolerance)`, `subdivide(handle, level, "PN|Uniform|CatmullClark|Loop")`, `smooth(handle, sel, iterations, alpha)`, `fill_holes(handle)`, `weld_edges(handle, tolerance)`, `repair(handle)` (degenerates + small components), `remove_hidden_triangles(handle)`, `split_by_components(handle)` → new handles |
+| Deform | `bend(handle, orientation, angle, extent)`, `twist(...)`, `flare(handle, orientation, percent_x, percent_y, extent)`, `noise(handle, sel, magnitude, frequency, seed)`, `displace_from_texture(handle, sel, texture_path, magnitude, uv_layer)` |
+| Voxel | `voxel_solidify(handle, grid_resolution)`, `voxel_morphology(handle, "Dilate|Contract|Open|Close", distance, grid_resolution)` |
+| UVs / normals / groups / materials / colors | `auto_uv(handle, "XAtlas|PatchBuilder", uv_layer)`, `project_uv(handle, "Planar|Box|Cylinder", transform, uv_layer, sel)`, `repack_uv(handle, uv_layer, resolution)`, `set_num_uv_layers`, `recompute_normals(handle, hard_angle_deg)`, `flip_normals`, `compute_polygroups(handle, crease_angle)`, `set_material_id(handle, sel, id)`, `set_vertex_color(handle, sel, color)` |
+| Transform | `transform_mesh(handle, transform)`, `translate_mesh`, `rotate_mesh`, `scale_mesh`, `recenter_mesh(handle, "Bounds|Base")` |
+| Assets | `save_mesh_to_static_mesh(handle, path, replace_existing, enable_collision, enable_nanite)`, `save_mesh_to_skeletal_mesh(handle, path, skeleton_path)`, `transfer_bone_weights(handle, source_skeletal_mesh_path)`, `generate_collision(asset_path, "MinVolumeShapes|ConvexHulls|AlignedBoxes|OrientedBoxes|MinimalSpheres|Capsules|SweptHulls", max_hulls)`, `set_lods(asset_path, [percent_triangles...])`, `bake_textures(target_handle, source_handle, "TangentNormal,AmbientOcclusion,Curvature,ObjectNormal,Position", resolution, out_folder, base_name)`, `spawn_static_mesh_actor(asset_path, transform, label)` |
+
+Exact signatures: `discover_python_class('unreal.ModelingService')`. The long tail — anything not
+here — is reachable directly: the mesh behind a handle is `svc.get_dynamic_mesh(handle)`, which you
+can pass to any `unreal.GeometryScript_*` library function in the same script.
+
+## Critical rules
+
+- **Units are centimeters, +Z up, origin at the base by default** for `append_box`/`append_cylinder`
+  (`origin="Center"` to change). A 100 cm crate at `Transform()` sits on the floor.
+- **Booleans want closed meshes.** Run `get_mesh_info` — `is_closed` false or `open_border_edges > 0`
+  means fill holes / weld first, or the boolean produces flaps. `self_union` cleans up kitbash overlaps.
+- **Selections are recomputed, not tracked.** After a topology-changing op (extrude, boolean, remesh)
+  re-run the `select_*` call; old selections may point at triangles that no longer exist.
+- **Order for a clean asset:** model → `repair` → `recompute_normals` → `auto_uv` → `save` →
+  `generate_collision` → `set_lods`. UVs before save, collision and LODs after (they act on the asset).
+- **`save_mesh_to_static_mesh` replaces LOD0 of an existing asset** when `replace_existing` is true;
+  its materials are kept. Existing collision/LODs on that asset are not touched — regenerate them if
+  the silhouette changed.
+- **Log for rollback:** `print("CREATED:", path)` after each save; there is no undo for handle ops
+  (they are in memory), but assets go through the editor and `TransactionService` checkpoints apply.
+- **Verify with evidence.** `get_mesh_info` after each stage (triangle/vertex counts, bounds, closed),
+  and a viewport capture once it is in the level.
+- **Budget triangles.** Voxel ops and PN tessellation explode counts; follow them with
+  `simplify_to_triangle_count`. Keep props under ~20k tris unless Nanite is on.
+
+## Common mistakes
+
+- Calling `extrude_faces` with `""` (whole mesh) — that shells the whole object outward. Select faces first.
+- Forgetting `auto_uv` before `bake_textures` or before saving a mesh that will take a textured material.
+- `set_lods` with `[1.0]` only — that removes extra LODs. Give one entry per LOD, LOD0 first.
+- Loading a mesh from an actor and saving back to a *new* path, then wondering why the level didn't change — spawn or reassign the actor's mesh.
+
+## Return types
+
+- `FModelingResult`: `success`, `message`, `handle`, `triangle_count`, `vertex_count`, `asset_path`.
+- `FModelingMeshInfo` (`get_mesh_info`): `handle`, `triangle_count`, `vertex_count`, `is_closed`, `open_border_edges`, `connected_components`, `bounds_min`, `bounds_max`, `surface_area`, `volume`, `num_uv_layers`, `has_vertex_colors`, `material_ids`.
+- `FModelingSplitResult` (`split_by_components`): `success`, `handles`.

--- a/Content/Skills/modeling/SKILL.md
+++ b/Content/Skills/modeling/SKILL.md
@@ -132,6 +132,13 @@ can pass to any `unreal.GeometryScript_*` library function in the same script.
   (they are in memory), but assets go through the editor and `TransactionService` checkpoints apply.
 - **Verify with evidence.** `get_mesh_info` after each stage (triangle/vertex counts, bounds, closed),
   and a viewport capture once it is in the level.
+- **Swept surfaces can come out inside-out.** After `append_sweep_polyline` + `fill_holes`, check
+  `get_mesh_info(h).volume`; a negative volume means the normals face inward and `self_union` /
+  `boolean` will silently discard the part as negative space. Call `flip_normals(h)` first. Sweep
+  frame semantics: with frame rotation yaw 90 the profile's X runs along world -X from the frame
+  position and its Y along world Z; put the profile scale (e.g. a wing chord) in the frame's Scale.
+- **XAtlas needs a compact mesh.** `fill_holes` and boolean cuts leave id gaps; `auto_uv` compacts
+  automatically from 2.2, older builds need `unreal.GeometryScript_MeshRepair.compact_mesh(svc.get_dynamic_mesh(h))` first.
 - **Budget triangles.** Voxel ops and PN tessellation explode counts; follow them with
   `simplify_to_triangle_count`. Keep props under ~20k tris unless Nanite is on.
 

--- a/Content/Skills/modeling/SKILL.md
+++ b/Content/Skills/modeling/SKILL.md
@@ -85,17 +85,17 @@ framed on the actor. A successful call is not proof the shape is right.
 | Area | Functions |
 |---|---|
 | Session | `create_mesh()`, `load_mesh_from_static_mesh(path, lod=0)`, `load_mesh_from_skeletal_mesh(path, lod=0)`, `load_mesh_from_actor(label)`, `copy_mesh(handle)`, `release_mesh(handle)`, `release_all_meshes()`, `list_meshes()`, `get_mesh_info(handle)` |
-| Primitives (append into a handle) | `append_box`, `append_sphere`, `append_sphere_box`, `append_cylinder`, `append_cone`, `append_capsule`, `append_torus`, `append_rectangle`, `append_disc`, `append_stairs`, `append_curved_stairs`, `append_extrude_polygon(handle, transform, points2d, height)`, `append_revolve_polygon(handle, transform, points2d, radius, steps, degrees)`, `append_sweep_polyline(handle, transform, profile2d, path_transforms)` (open tube — prefer the next one for solids), `append_loft(handle, transform, closed_profile2d, frames)` (capped, always outward; frame scale = chord), `append_mesh(handle, other_handle, transform)` |
-| Booleans | `boolean(target, tool, "Union|Subtract|Intersection", tool_transform)`, `self_union`, `plane_cut(handle, plane_transform, fill_holes)`, `mirror(handle, plane_transform, weld)` |
+| Primitives (append into a handle) | `append_box`, `append_sphere`, `append_sphere_box`, `append_cylinder`, `append_cone`, `append_capsule`, `append_torus`, `append_rectangle`, `append_disc`, `append_stairs`, `append_curved_stairs`, `append_extrude_polygon(handle, transform, points2d, height)`, `append_revolve_polygon(handle, transform, points2d, radius, steps, degrees)`, `append_sweep_polyline(handle, transform, profile2d, path_transforms)` (open tube — prefer the next one for solids), `append_loft(handle, transform, closed_profile2d, frames)` (capped, always outward; frame scale = chord), `append_mesh(handle, other_handle, transform)`, `append_mesh_at_transforms(handle, other, [transforms])`, `append_mesh_along_polyline(handle, other, points, spacing, up)` |
+| Booleans | `boolean(target, tool, "Union|Subtract|Intersection", tool_transform)`, `self_union`, `plane_cut(handle, plane_transform, fill_holes)`, `mirror(handle, plane_transform, weld)`, `cut_groove_along_polyline(handle, points, width, depth, up)` |
 | Selections | `select_all(handle, name)`, `select_by_normal_angle(handle, name, normal, max_angle_deg)`, `select_in_box(handle, name, box_min, box_max)`, `select_in_sphere(handle, name, center, radius)`, `select_by_material_id(handle, name, material_id)`, `select_by_polygroup(handle, name, group_id)`, `select_connected(handle, name, point)` (whole connected piece nearest the point), `expand_contract_selection(handle, name, new_name, iterations, contract)`, `invert_selection(handle, name, new_name)`, `selection_count(handle, name)`, `selection_bounds(handle, name)` → `(min, max)` (Python drops the bool; an empty selection gives zero vectors), `clear_selections(handle)` |
 | Poly edit on selections | `extrude_faces(handle, sel, distance, direction)`, `offset_faces(handle, sel, distance)`, `inset_faces(handle, sel, distance)`, `outset_faces(handle, sel, distance)`, `delete_faces(handle, sel)`, `translate_selection(handle, sel, delta)`, `bevel_polygroups(handle, distance, subdivisions)`, `offset_mesh(handle, distance)`, `shell_mesh(handle, thickness)` |
 | Mesh | `remesh(handle, target_triangles, edge_length=0)`, `simplify_to_triangle_count(handle, n)`, `simplify_to_vertex_count(handle, n)`, `simplify_to_tolerance(handle, tolerance)`, `simplify_planar(handle)` (lossless, coplanar only), `subdivide(handle, level, "PN|Uniform|CatmullClark|Loop")`, `smooth(handle, sel, iterations, alpha)`, `fill_holes(handle)`, `weld_edges(handle, tolerance)`, `repair(handle)` (degenerates + small components), `remove_hidden_triangles(handle)`, `split_by_components(handle)` → new handles |
 | Queries, sampling, hulls | `ray_cast(handle, origin, direction)` / `nearest_point(handle, point)` → `{found, position, triangle_id, distance}`, `is_point_inside(handle, point)`, `sample_surface_points(handle, radius, max)` → transforms for scattering, `convex_hull(handle)`, `convex_decomposition(handle, num_hulls)`, `swept_hull(handle, frame)` → NEW handles, `measure_distance(a, b)` → max/mean/rms (verify LODs and simplifications) |
 | Deform | `bend(handle, orientation, angle, extent)`, `twist(...)`, `flare(handle, orientation, percent_x, percent_y, extent)`, `noise(handle, sel, magnitude, frequency, seed)`, `displace_from_texture(handle, sel, texture_path, magnitude, uv_layer)` |
 | Voxel | `voxel_solidify(handle, grid_resolution)`, `voxel_morphology(handle, "Dilate|Contract|Open|Close", distance, grid_resolution)` |
-| UVs / normals / groups / materials / colors | `auto_uv(handle, "XAtlas|PatchBuilder", uv_layer)`, `project_uv(handle, "Planar|Box|Cylinder", transform, uv_layer, sel)`, `repack_uv(handle, uv_layer, resolution)`, `set_num_uv_layers`, `recompute_normals(handle, hard_angle_deg)`, `flip_normals`, `ensure_outward(handle)` (flip if the enclosed volume is negative), `compute_polygroups(handle, "Angle|UVIslands|Components|Polygons", crease_angle)`, `set_material_id(handle, sel, id)`, `remap_material_id(handle, from, to)`, `set_vertex_color(handle, sel, color)` |
+| UVs / normals / groups / materials / colors | `auto_uv(handle, "XAtlas|PatchBuilder", uv_layer)`, `project_uv(handle, "Planar|Box|Cylinder", transform, uv_layer, sel)`, `repack_uv(handle, uv_layer, resolution)`, `set_num_uv_layers`, `recompute_normals(handle, hard_angle_deg)`, `flip_normals`, `ensure_outward(handle)` (flip if the enclosed volume is negative), `compute_polygroups(handle, "Angle|UVIslands|Components|Polygons", crease_angle)`, `set_material_id(handle, sel, id)`, `remap_material_id(handle, from, to)`, `set_vertex_color(handle, sel, color)`, `set_polygroup(handle, sel, group_id=-1)`, `recompute_uvs(handle, uv_layer, "Polygroups|UVIslands", "SpectralConformal|Conformal|ExpMap", sel)`, `transform_uv(handle, uv_layer, sel, translation, scale, rotation_deg, origin)`, `layout_uv(handle, uv_layer, "Repack|Stack|Normalize|Transform", sel, resolution)`, `pack_uv_per_material(handle, uv_layer, resolution)`, `get_uv_stats(handle, uv_layer)` → islands/coverage/overlap/texel density, `world_to_uv(handle, point, uv_layer)` |
 | Transform | `transform_mesh(handle, transform)`, `translate_mesh`, `rotate_mesh`, `scale_mesh`, `recenter_mesh(handle, "Bounds|Base")` |
-| Assets | `save_mesh_to_static_mesh(handle, path, replace_existing, enable_collision, enable_nanite)`, `save_mesh_to_skeletal_mesh(handle, path, skeleton_path="")` ("" creates `<path>_Skeleton` from the mesh bones), `set_asset_materials(asset_path, "/Game/M_A,/Game/M_B")`, `transfer_bone_weights(handle, source_skeletal_mesh_path)`, `smooth_bone_weights(handle, skeleton_path)`, `prune_bone_weights(handle, "bone,bone")`, `create_bones(handle, [ModelingBoneDef(name, parent_name, transform)])`, `bind_selection_to_bone(handle, sel, bone, weight=1)`, `list_bones(handle)` → per-bone vertex counts, `generate_collision(asset_path, "MinVolumeShapes|ConvexHulls|AlignedBoxes|OrientedBoxes|MinimalSpheres|Capsules|SweptHulls", max_hulls)`, `set_lods(asset_path, [percent_triangles...])`, `bake_textures(target_handle, source_handle, "TangentNormal,AmbientOcclusion,Curvature,ObjectNormal,Position", resolution, out_folder, base_name)`, `spawn_static_mesh_actor(asset_path, transform, label)`; `load_mesh_from_actor` also reads skeletal / dynamic mesh actors |
+| Assets | `save_mesh_to_static_mesh(handle, path, replace_existing, enable_collision, enable_nanite)`, `save_mesh_to_skeletal_mesh(handle, path, skeleton_path="")` ("" creates `<path>_Skeleton` from the mesh bones), `set_asset_materials(asset_path, "/Game/M_A,/Game/M_B")`, `transfer_bone_weights(handle, source_skeletal_mesh_path)`, `smooth_bone_weights(handle, skeleton_path)`, `prune_bone_weights(handle, "bone,bone")`, `create_bones(handle, [ModelingBoneDef(name, parent_name, transform)])`, `bind_selection_to_bone(handle, sel, bone, weight=1)`, `list_bones(handle)` → per-bone vertex counts, `generate_collision(asset_path, "MinVolumeShapes|ConvexHulls|AlignedBoxes|OrientedBoxes|MinimalSpheres|Capsules|SweptHulls", max_hulls)`, `set_lods(asset_path, [percent_triangles...])`, `bake_textures(target_handle, source_handle, "TangentNormal,AmbientOcclusion,Curvature,ObjectNormal,Position,VertexColor,MaterialID,UVShell,Height", resolution, out_folder, base_name)`, `bake_texture_transfer(target, source, "T_A,T_B", resolution, out_folder, base_name)`, `import_texture(file, asset_path, srgb, "Default|Normalmap|Masks|Grayscale|HDR")`, `create_noise_texture(asset_path, w, h, cells, octaves)`, `draw_on_texture(asset_path, "Line|Dots|Rect|Fill", uv_points, color, thickness_px, spacing_px)`, `spawn_static_mesh_actor(asset_path, transform, label)`; `load_mesh_from_actor` also reads skeletal / dynamic mesh actors |
 
 ## GeometryScript coverage
 
@@ -210,3 +210,39 @@ svc.create_bones(h, [
 Animate the result like any skeletal mesh — an AnimSequence keyed on the control bones (see the
 `animation` skill), a Control Rig, or `SetBoneRotationByName` on a PoseableMeshComponent for a quick
 check in a level.
+
+## Texturing pipeline (UVs you control, masks you can make, pixels you can draw)
+
+Auto-unwraps (`auto_uv`) are fine for baking AO, useless for markings: hundreds of seams and uneven
+texel density. For anything an artist would paint, build the islands yourself and verify them.
+
+1. **Define islands.** Assign a polygroup per panel/region: `compute_polygroups(h, "Angle", 30)` for
+   hard-surface parts, then override with selections — `select_in_box` / `select_by_normal_angle` /
+   `select_connected` + `set_polygroup(h, sel, -1)` (a new group) so a wing top, a fuselage side or a
+   whole rudder is one island.
+2. **Unwrap** each island conformally: `recompute_uvs(h, 0, "Polygroups", "SpectralConformal")`. Big
+   round shapes (fuselage) can instead take `project_uv(h, "Cylinder", transform, 0, sel)`.
+3. **Pack** — `layout_uv(h, 0, "Repack", "", 4096)` for one texture set, or
+   `pack_uv_per_material(h, 0, 4096)` so every material slot (fuselage / wings / details) fills its own
+   0–1 range and gets its own 4K.
+4. **Verify** with `get_uv_stats(h)`: islands, coverage, `overlap_fraction` (must be ~0 unless you
+   packed per material), `num_unset_triangles` (must be 0) and `texels_per_cm_at_1k`. Fix before
+   baking. `world_to_uv(h, point)` tells you where a spot on the mesh lands on the texture.
+5. **Masks without painting.** Select regions on the mesh, `set_vertex_color(h, sel, color)` per
+   channel (R walkways, G stripes, B dirt…) and bake with `bake_textures(h, h, "VertexColor", …)`.
+   `"MaterialID"` bakes a per-slot mask for free; `"UVShell"` draws the island outlines — panel lines
+   when islands are panels; `"Height"` and the normals/AO/curvature bakes remain.
+6. **Pixels.** `create_noise_texture(path, 2048, 2048, cells, octaves)` for tileable grunge/wear;
+   `draw_on_texture(path, "Line|Dots|Rect|Fill", uv_points, color, thickness_px, spacing_px)` to draw
+   rivet rows, stripes and blocks straight into an 8-bit texture in UV space (use `world_to_uv` to
+   place them); `import_texture(file, path, srgb, "Default|Normalmap|Masks|Grayscale")` for anything
+   made elsewhere (a PolyHaven PBR set downloaded with `urllib` in the same Python script works).
+   `bake_texture_transfer(target, source, "T_A,T_B", …)` re-projects textures from one unwrap onto
+   another (after re-unwrapping, or from a detail mesh).
+7. **Geometry detail for normal maps.** Build it on a copy: `append_mesh_along_polyline(h, rivet, points,
+   spacing)` for fastener rows, `append_mesh_at_transforms(h, bolt, sample_surface_points(...))` for
+   scatter, `cut_groove_along_polyline(h, points, width, depth)` for recessed panel lines — then
+   `bake_textures(game_mesh, detail_mesh, "TangentNormal,AmbientOcclusion", 4096, …)`.
+
+Crisp markings (roundels, numbers) are still best as decals: `set_num_uv_layers(h, 2)` +
+`project_uv(h, "Planar", transform, 1, sel)` gives a clamped UV1 the material samples a decal through.

--- a/Content/Skills/modeling/SKILL.md
+++ b/Content/Skills/modeling/SKILL.md
@@ -85,17 +85,17 @@ framed on the actor. A successful call is not proof the shape is right.
 | Area | Functions |
 |---|---|
 | Session | `create_mesh()`, `load_mesh_from_static_mesh(path, lod=0)`, `load_mesh_from_skeletal_mesh(path, lod=0)`, `load_mesh_from_actor(label)`, `copy_mesh(handle)`, `release_mesh(handle)`, `release_all_meshes()`, `list_meshes()`, `get_mesh_info(handle)` |
-| Primitives (append into a handle) | `append_box`, `append_sphere`, `append_sphere_box`, `append_cylinder`, `append_cone`, `append_capsule`, `append_torus`, `append_rectangle`, `append_disc`, `append_stairs`, `append_curved_stairs`, `append_extrude_polygon(handle, transform, points2d, height)`, `append_revolve_polygon(handle, transform, points2d, radius, steps, degrees)`, `append_sweep_polyline(handle, transform, profile2d, path_transforms)`, `append_mesh(handle, other_handle, transform)` |
+| Primitives (append into a handle) | `append_box`, `append_sphere`, `append_sphere_box`, `append_cylinder`, `append_cone`, `append_capsule`, `append_torus`, `append_rectangle`, `append_disc`, `append_stairs`, `append_curved_stairs`, `append_extrude_polygon(handle, transform, points2d, height)`, `append_revolve_polygon(handle, transform, points2d, radius, steps, degrees)`, `append_sweep_polyline(handle, transform, profile2d, path_transforms)` (open tube — prefer the next one for solids), `append_loft(handle, transform, closed_profile2d, frames)` (capped, always outward; frame scale = chord), `append_mesh(handle, other_handle, transform)` |
 | Booleans | `boolean(target, tool, "Union|Subtract|Intersection", tool_transform)`, `self_union`, `plane_cut(handle, plane_transform, fill_holes)`, `mirror(handle, plane_transform, weld)` |
-| Selections | `select_all(handle, name)`, `select_by_normal_angle(handle, name, normal, max_angle_deg)`, `select_in_box(handle, name, box_min, box_max)`, `select_in_sphere(handle, name, center, radius)`, `select_by_material_id(handle, name, material_id)`, `select_by_polygroup(handle, name, group_id)`, `expand_contract_selection(handle, name, new_name, iterations, contract)`, `invert_selection(handle, name, new_name)`, `selection_count(handle, name)`, `selection_bounds(handle, name)` → `(min, max)` (Python drops the bool; an empty selection gives zero vectors), `clear_selections(handle)` |
+| Selections | `select_all(handle, name)`, `select_by_normal_angle(handle, name, normal, max_angle_deg)`, `select_in_box(handle, name, box_min, box_max)`, `select_in_sphere(handle, name, center, radius)`, `select_by_material_id(handle, name, material_id)`, `select_by_polygroup(handle, name, group_id)`, `select_connected(handle, name, point)` (whole connected piece nearest the point), `expand_contract_selection(handle, name, new_name, iterations, contract)`, `invert_selection(handle, name, new_name)`, `selection_count(handle, name)`, `selection_bounds(handle, name)` → `(min, max)` (Python drops the bool; an empty selection gives zero vectors), `clear_selections(handle)` |
 | Poly edit on selections | `extrude_faces(handle, sel, distance, direction)`, `offset_faces(handle, sel, distance)`, `inset_faces(handle, sel, distance)`, `outset_faces(handle, sel, distance)`, `delete_faces(handle, sel)`, `translate_selection(handle, sel, delta)`, `bevel_polygroups(handle, distance, subdivisions)`, `offset_mesh(handle, distance)`, `shell_mesh(handle, thickness)` |
 | Mesh | `remesh(handle, target_triangles, edge_length=0)`, `simplify_to_triangle_count(handle, n)`, `simplify_to_vertex_count(handle, n)`, `simplify_to_tolerance(handle, tolerance)`, `simplify_planar(handle)` (lossless, coplanar only), `subdivide(handle, level, "PN|Uniform|CatmullClark|Loop")`, `smooth(handle, sel, iterations, alpha)`, `fill_holes(handle)`, `weld_edges(handle, tolerance)`, `repair(handle)` (degenerates + small components), `remove_hidden_triangles(handle)`, `split_by_components(handle)` → new handles |
 | Queries, sampling, hulls | `ray_cast(handle, origin, direction)` / `nearest_point(handle, point)` → `{found, position, triangle_id, distance}`, `is_point_inside(handle, point)`, `sample_surface_points(handle, radius, max)` → transforms for scattering, `convex_hull(handle)`, `convex_decomposition(handle, num_hulls)`, `swept_hull(handle, frame)` → NEW handles, `measure_distance(a, b)` → max/mean/rms (verify LODs and simplifications) |
 | Deform | `bend(handle, orientation, angle, extent)`, `twist(...)`, `flare(handle, orientation, percent_x, percent_y, extent)`, `noise(handle, sel, magnitude, frequency, seed)`, `displace_from_texture(handle, sel, texture_path, magnitude, uv_layer)` |
 | Voxel | `voxel_solidify(handle, grid_resolution)`, `voxel_morphology(handle, "Dilate|Contract|Open|Close", distance, grid_resolution)` |
-| UVs / normals / groups / materials / colors | `auto_uv(handle, "XAtlas|PatchBuilder", uv_layer)`, `project_uv(handle, "Planar|Box|Cylinder", transform, uv_layer, sel)`, `repack_uv(handle, uv_layer, resolution)`, `set_num_uv_layers`, `recompute_normals(handle, hard_angle_deg)`, `flip_normals`, `compute_polygroups(handle, "Angle|UVIslands|Components|Polygons", crease_angle)`, `set_material_id(handle, sel, id)`, `remap_material_id(handle, from, to)`, `set_vertex_color(handle, sel, color)` |
+| UVs / normals / groups / materials / colors | `auto_uv(handle, "XAtlas|PatchBuilder", uv_layer)`, `project_uv(handle, "Planar|Box|Cylinder", transform, uv_layer, sel)`, `repack_uv(handle, uv_layer, resolution)`, `set_num_uv_layers`, `recompute_normals(handle, hard_angle_deg)`, `flip_normals`, `ensure_outward(handle)` (flip if the enclosed volume is negative), `compute_polygroups(handle, "Angle|UVIslands|Components|Polygons", crease_angle)`, `set_material_id(handle, sel, id)`, `remap_material_id(handle, from, to)`, `set_vertex_color(handle, sel, color)` |
 | Transform | `transform_mesh(handle, transform)`, `translate_mesh`, `rotate_mesh`, `scale_mesh`, `recenter_mesh(handle, "Bounds|Base")` |
-| Assets | `save_mesh_to_static_mesh(handle, path, replace_existing, enable_collision, enable_nanite)`, `save_mesh_to_skeletal_mesh(handle, path, skeleton_path)`, `transfer_bone_weights(handle, source_skeletal_mesh_path)`, `smooth_bone_weights(handle, skeleton_path)`, `prune_bone_weights(handle, "bone,bone")`, `generate_collision(asset_path, "MinVolumeShapes|ConvexHulls|AlignedBoxes|OrientedBoxes|MinimalSpheres|Capsules|SweptHulls", max_hulls)`, `set_lods(asset_path, [percent_triangles...])`, `bake_textures(target_handle, source_handle, "TangentNormal,AmbientOcclusion,Curvature,ObjectNormal,Position", resolution, out_folder, base_name)`, `spawn_static_mesh_actor(asset_path, transform, label)`; `load_mesh_from_actor` also reads skeletal / dynamic mesh actors |
+| Assets | `save_mesh_to_static_mesh(handle, path, replace_existing, enable_collision, enable_nanite)`, `save_mesh_to_skeletal_mesh(handle, path, skeleton_path="")` ("" creates `<path>_Skeleton` from the mesh bones), `set_asset_materials(asset_path, "/Game/M_A,/Game/M_B")`, `transfer_bone_weights(handle, source_skeletal_mesh_path)`, `smooth_bone_weights(handle, skeleton_path)`, `prune_bone_weights(handle, "bone,bone")`, `create_bones(handle, [ModelingBoneDef(name, parent_name, transform)])`, `bind_selection_to_bone(handle, sel, bone, weight=1)`, `list_bones(handle)` → per-bone vertex counts, `generate_collision(asset_path, "MinVolumeShapes|ConvexHulls|AlignedBoxes|OrientedBoxes|MinimalSpheres|Capsules|SweptHulls", max_hulls)`, `set_lods(asset_path, [percent_triangles...])`, `bake_textures(target_handle, source_handle, "TangentNormal,AmbientOcclusion,Curvature,ObjectNormal,Position", resolution, out_folder, base_name)`, `spawn_static_mesh_actor(asset_path, transform, label)`; `load_mesh_from_actor` also reads skeletal / dynamic mesh actors |
 
 ## GeometryScript coverage
 
@@ -154,3 +154,59 @@ can pass to any `unreal.GeometryScript_*` library function in the same script.
 - `FModelingResult`: `success`, `message`, `handle`, `triangle_count`, `vertex_count`, `asset_path`.
 - `FModelingMeshInfo` (`get_mesh_info`): `handle`, `triangle_count`, `vertex_count`, `is_closed`, `open_border_edges`, `connected_components`, `bounds_min`, `bounds_max`, `surface_area`, `volume`, `num_uv_layers`, `has_vertex_colors`, `material_ids`.
 - `FModelingSplitResult` (`split_by_components`): `success`, `handles`.
+
+## Lofted solids (wings, fins, hulls)
+
+`append_loft(h, transform, profile, frames, material_id)` sweeps a **closed** 2D profile through a list of
+frames, caps both ends, and guarantees an outward-facing closed solid (it checks the enclosed volume and
+flips when the sweep came out inside-out). Frame semantics:
+
+- The profile lies in each frame's local **YZ** plane: profile X runs along the frame's Y axis, profile Y
+  along its Z axis.
+- The frame's **scale** multiplies the profile — put the chord (or radius) there, per frame, for taper.
+- Frames are positioned along the path; two frames make a straight tapered section.
+
+A wing running out along +Y with its chord toward −X and 6 % thickness:
+
+```python
+airfoil = [unreal.Vector2D(x, y) for x, y in ((0,0),(0.05,0.03),(0.3,0.06),(0.7,0.04),(1,0),(0.7,-0.03),(0.3,-0.04),(0.05,-0.02))]
+frames = [unreal.Transform(unreal.Vector(880, 100, 0), unreal.Rotator(0, 0, 90), unreal.Vector(480, 480, 480)),   # root: LE at x=880, chord 480
+          unreal.Transform(unreal.Vector(600, 640, 0), unreal.Rotator(0, 0, 90), unreal.Vector(160, 160, 160))]   # tip
+svc.append_loft(h, unreal.Transform(), airfoil, frames, 0)
+```
+
+`ensure_outward(h)` does the same volume check on any closed part you built another way (revolves, raw
+sweeps) — run it before `self_union`, which silently discards inside-out parts as negative space.
+
+## Rigging control surfaces (rudders, flaps, canopies, turrets)
+
+Bones and skin weights are authored straight on the session mesh; saving with an empty skeleton path
+creates the Skeleton asset for you.
+
+1. **Isolate each moving piece** as its own connected component: cut a through-slot along the hinge line
+   and at both ends (`boolean` Subtract with thin boxes), so the flap is no longer attached to the wing.
+2. **Grab it** with `select_connected(h, "flap_L", point_on_the_flap)` — no radius to tune, it takes the
+   whole piece nearest the point. `selection_bounds` then gives you the hinge line (the piece's forward edge).
+3. **Define the hierarchy** with `create_bones(h, [ModelingBoneDef, ...])`: the first bone is the root,
+   every other one names a parent listed earlier. Transforms are in mesh space; point each bone's **X
+   axis along its hinge** so the surface deflects by rolling the bone (a swept hinge just needs the
+   right yaw). Everything starts bound to the root.
+4. **Bind** each piece: `bind_selection_to_bone(h, "flap_L", "flap_L", 1.0)`.
+5. **Verify** with `list_bones(h)` — every control bone should report the vertex count of its piece and
+   the root the rest; a bone with 0 vertices means the selection missed.
+6. **Save**: `save_mesh_to_skeletal_mesh(h, "/Game/Vehicles/SK_Jet", "", True, True)` creates
+   `SK_Jet` plus `SK_Jet_Skeleton`; then `set_asset_materials("/Game/Vehicles/SK_Jet", "/Game/M_Paint,/Game/M_Glass")`
+   fills the material slots (one slot per material ID).
+
+```python
+B = unreal.ModelingBoneDef
+hinge_yaw = 0.0   # yaw of the hinge line in the XY plane
+svc.create_bones(h, [
+    B(name="root"),
+    B(name="flap_L", parent_name="root", transform=unreal.Transform(unreal.Vector(534, 100, 0), unreal.Rotator(0, 0, 90 + hinge_yaw), unreal.Vector(1, 1, 1))),
+])
+```
+
+Animate the result like any skeletal mesh — an AnimSequence keyed on the control bones (see the
+`animation` skill), a Control Rig, or `SetBoneRotationByName` on a PoseableMeshComponent for a quick
+check in a level.

--- a/Content/Skills/modeling/SKILL.md
+++ b/Content/Skills/modeling/SKILL.md
@@ -85,16 +85,30 @@ framed on the actor. A successful call is not proof the shape is right.
 | Area | Functions |
 |---|---|
 | Session | `create_mesh()`, `load_mesh_from_static_mesh(path, lod=0)`, `load_mesh_from_skeletal_mesh(path, lod=0)`, `load_mesh_from_actor(label)`, `copy_mesh(handle)`, `release_mesh(handle)`, `release_all_meshes()`, `list_meshes()`, `get_mesh_info(handle)` |
-| Primitives (append into a handle) | `append_box`, `append_sphere`, `append_cylinder`, `append_cone`, `append_capsule`, `append_torus`, `append_rectangle`, `append_disc`, `append_stairs`, `append_extrude_polygon(handle, points2d, height)`, `append_revolve_polygon(handle, points2d, radius, steps, degrees)`, `append_mesh(handle, other_handle, transform)` |
+| Primitives (append into a handle) | `append_box`, `append_sphere`, `append_sphere_box`, `append_cylinder`, `append_cone`, `append_capsule`, `append_torus`, `append_rectangle`, `append_disc`, `append_stairs`, `append_curved_stairs`, `append_extrude_polygon(handle, transform, points2d, height)`, `append_revolve_polygon(handle, transform, points2d, radius, steps, degrees)`, `append_sweep_polyline(handle, transform, profile2d, path_transforms)`, `append_mesh(handle, other_handle, transform)` |
 | Booleans | `boolean(target, tool, "Union|Subtract|Intersection", tool_transform)`, `self_union`, `plane_cut(handle, plane_transform, fill_holes)`, `mirror(handle, plane_transform, weld)` |
-| Selections | `select_all(handle, name)`, `select_by_normal_angle(handle, name, normal, max_angle_deg)`, `select_in_box(handle, name, box_min, box_max)`, `select_in_sphere(handle, name, center, radius)`, `select_by_material_id(handle, name, material_id)`, `expand_contract_selection(handle, name, iterations, contract)`, `invert_selection(handle, name)`, `selection_count(handle, name)` |
+| Selections | `select_all(handle, name)`, `select_by_normal_angle(handle, name, normal, max_angle_deg)`, `select_in_box(handle, name, box_min, box_max)`, `select_in_sphere(handle, name, center, radius)`, `select_by_material_id(handle, name, material_id)`, `select_by_polygroup(handle, name, group_id)`, `expand_contract_selection(handle, name, new_name, iterations, contract)`, `invert_selection(handle, name, new_name)`, `selection_count(handle, name)`, `selection_bounds(handle, name)` → `(min, max)` (Python drops the bool; an empty selection gives zero vectors), `clear_selections(handle)` |
 | Poly edit on selections | `extrude_faces(handle, sel, distance, direction)`, `offset_faces(handle, sel, distance)`, `inset_faces(handle, sel, distance)`, `outset_faces(handle, sel, distance)`, `delete_faces(handle, sel)`, `translate_selection(handle, sel, delta)`, `bevel_polygroups(handle, distance, subdivisions)`, `offset_mesh(handle, distance)`, `shell_mesh(handle, thickness)` |
-| Mesh | `remesh(handle, target_triangles, edge_length=0)`, `simplify_to_triangle_count(handle, n)`, `simplify_to_tolerance(handle, tolerance)`, `subdivide(handle, level, "PN|Uniform|CatmullClark|Loop")`, `smooth(handle, sel, iterations, alpha)`, `fill_holes(handle)`, `weld_edges(handle, tolerance)`, `repair(handle)` (degenerates + small components), `remove_hidden_triangles(handle)`, `split_by_components(handle)` → new handles |
+| Mesh | `remesh(handle, target_triangles, edge_length=0)`, `simplify_to_triangle_count(handle, n)`, `simplify_to_vertex_count(handle, n)`, `simplify_to_tolerance(handle, tolerance)`, `simplify_planar(handle)` (lossless, coplanar only), `subdivide(handle, level, "PN|Uniform|CatmullClark|Loop")`, `smooth(handle, sel, iterations, alpha)`, `fill_holes(handle)`, `weld_edges(handle, tolerance)`, `repair(handle)` (degenerates + small components), `remove_hidden_triangles(handle)`, `split_by_components(handle)` → new handles |
+| Queries, sampling, hulls | `ray_cast(handle, origin, direction)` / `nearest_point(handle, point)` → `{found, position, triangle_id, distance}`, `is_point_inside(handle, point)`, `sample_surface_points(handle, radius, max)` → transforms for scattering, `convex_hull(handle)`, `convex_decomposition(handle, num_hulls)`, `swept_hull(handle, frame)` → NEW handles, `measure_distance(a, b)` → max/mean/rms (verify LODs and simplifications) |
 | Deform | `bend(handle, orientation, angle, extent)`, `twist(...)`, `flare(handle, orientation, percent_x, percent_y, extent)`, `noise(handle, sel, magnitude, frequency, seed)`, `displace_from_texture(handle, sel, texture_path, magnitude, uv_layer)` |
 | Voxel | `voxel_solidify(handle, grid_resolution)`, `voxel_morphology(handle, "Dilate|Contract|Open|Close", distance, grid_resolution)` |
-| UVs / normals / groups / materials / colors | `auto_uv(handle, "XAtlas|PatchBuilder", uv_layer)`, `project_uv(handle, "Planar|Box|Cylinder", transform, uv_layer, sel)`, `repack_uv(handle, uv_layer, resolution)`, `set_num_uv_layers`, `recompute_normals(handle, hard_angle_deg)`, `flip_normals`, `compute_polygroups(handle, crease_angle)`, `set_material_id(handle, sel, id)`, `set_vertex_color(handle, sel, color)` |
+| UVs / normals / groups / materials / colors | `auto_uv(handle, "XAtlas|PatchBuilder", uv_layer)`, `project_uv(handle, "Planar|Box|Cylinder", transform, uv_layer, sel)`, `repack_uv(handle, uv_layer, resolution)`, `set_num_uv_layers`, `recompute_normals(handle, hard_angle_deg)`, `flip_normals`, `compute_polygroups(handle, "Angle|UVIslands|Components|Polygons", crease_angle)`, `set_material_id(handle, sel, id)`, `remap_material_id(handle, from, to)`, `set_vertex_color(handle, sel, color)` |
 | Transform | `transform_mesh(handle, transform)`, `translate_mesh`, `rotate_mesh`, `scale_mesh`, `recenter_mesh(handle, "Bounds|Base")` |
-| Assets | `save_mesh_to_static_mesh(handle, path, replace_existing, enable_collision, enable_nanite)`, `save_mesh_to_skeletal_mesh(handle, path, skeleton_path)`, `transfer_bone_weights(handle, source_skeletal_mesh_path)`, `generate_collision(asset_path, "MinVolumeShapes|ConvexHulls|AlignedBoxes|OrientedBoxes|MinimalSpheres|Capsules|SweptHulls", max_hulls)`, `set_lods(asset_path, [percent_triangles...])`, `bake_textures(target_handle, source_handle, "TangentNormal,AmbientOcclusion,Curvature,ObjectNormal,Position", resolution, out_folder, base_name)`, `spawn_static_mesh_actor(asset_path, transform, label)` |
+| Assets | `save_mesh_to_static_mesh(handle, path, replace_existing, enable_collision, enable_nanite)`, `save_mesh_to_skeletal_mesh(handle, path, skeleton_path)`, `transfer_bone_weights(handle, source_skeletal_mesh_path)`, `smooth_bone_weights(handle, skeleton_path)`, `prune_bone_weights(handle, "bone,bone")`, `generate_collision(asset_path, "MinVolumeShapes|ConvexHulls|AlignedBoxes|OrientedBoxes|MinimalSpheres|Capsules|SweptHulls", max_hulls)`, `set_lods(asset_path, [percent_triangles...])`, `bake_textures(target_handle, source_handle, "TangentNormal,AmbientOcclusion,Curvature,ObjectNormal,Position", resolution, out_folder, base_name)`, `spawn_static_mesh_actor(asset_path, transform, label)`; `load_mesh_from_actor` also reads skeletal / dynamic mesh actors |
+
+## GeometryScript coverage
+
+ModelingService wraps ~115 of GeometryScript's 622 functions — every operator behind a Modeling
+Mode tool plus the asset plumbing. What it deliberately does not wrap, and how to reach it:
+
+| Not wrapped | Why | Reach it with |
+|---|---|---|
+| `GeometryScript_List*`, `VectorMath`, `Transform`, `Box`, `OrientedBox`, `Ray`, `SimplePolygon`, `PolyPath`, `PolygonList`, `PointSetSampling` | Pure math / container helpers, not editor operations | Call directly — they take plain values |
+| `MeshWeightMap`, `MeshSculptLayers`, `MeshGeodesic`, `TextureMap`, `VolumeTextureBake`, `EditorTextureMap` | Niche; would double the API for rare use | `mesh = svc.get_dynamic_mesh(handle)` then e.g. `unreal.GeometryScript_MeshGeodesics.create_surface_path(mesh, ...)` |
+| Per-function option structs (remesh smoothing type, bake bit depth, XAtlas iterations, ...) | The wrappers fix sensible defaults | Same trick — the handle's `UDynamicMesh` is the live object; GeometryScript calls edit it in place and the next `svc.*` call sees the result |
+
+Discover any of them with `discover_python_class('unreal.GeometryScript_<Library>')`.
 
 Exact signatures: `discover_python_class('unreal.ModelingService')`. The long tail — anything not
 here — is reachable directly: the mesh behind a handle is `svc.get_dynamic_mesh(handle)`, which you
@@ -106,8 +120,9 @@ can pass to any `unreal.GeometryScript_*` library function in the same script.
   (`origin="Center"` to change). A 100 cm crate at `Transform()` sits on the floor.
 - **Booleans want closed meshes.** Run `get_mesh_info` — `is_closed` false or `open_border_edges > 0`
   means fill holes / weld first, or the boolean produces flaps. `self_union` cleans up kitbash overlaps.
-- **Selections are recomputed, not tracked.** After a topology-changing op (extrude, boolean, remesh)
-  re-run the `select_*` call; old selections may point at triangles that no longer exist.
+- **Selections go stale when topology changes.** After extrude, inset, boolean, remesh, bevel, etc.
+  re-run the `select_*` call before using the name again; the service refuses a selection made
+  before the mesh changed (`success: false`, "stale") rather than acting on wrong triangles.
 - **Order for a clean asset:** model → `repair` → `recompute_normals` → `auto_uv` → `save` →
   `generate_collision` → `set_lods`. UVs before save, collision and LODs after (they act on the asset).
 - **`save_mesh_to_static_mesh` replaces LOD0 of an existing asset** when `replace_existing` is true;

--- a/Content/Skills/modeling/scripts/exercise_all.txt
+++ b/Content/Skills/modeling/scripts/exercise_all.txt
@@ -188,6 +188,37 @@ call("save_mesh_to_skeletal_mesh", rg, sk_path, "", True, False)
 assert unreal.EditorAssetLibrary.does_asset_exist(sk_path + "_Skeleton"), "skeleton should be created next to the mesh"
 call("set_asset_materials", sk_path, "/Engine/BasicShapes/BasicShapeMaterial", False)
 
+# --- UV control: polygroup islands, conformal unwrap, packing, verification
+uv = call("create_mesh").handle
+call("append_box", uv, T(), 100, 100, 100)
+call("select_by_normal_angle", uv, "top", unreal.Vector(0, 0, 1), 5.0)
+call("set_material_id", uv, "top", 1)
+call("compute_polygroups", uv, "Angle", 15.0, 1)
+call("set_polygroup", uv, "top", -1)
+call("recompute_uvs", uv, 0, "Polygroups", "SpectralConformal", "", True)
+call("layout_uv", uv, 0, "Repack", "", 512, 1.0, unreal.Vector2D(0, 0))
+st = call("get_uv_stats", uv, 0, 256)
+assert st.success and st.num_islands == 6 and st.overlap_fraction < 0.01, (st.num_islands, st.overlap_fraction)
+call("transform_uv", uv, 0, "top", unreal.Vector2D(0.05, 0.0), unreal.Vector2D(1, 1), 0.0, unreal.Vector2D(0.5, 0.5))
+call("pack_uv_per_material", uv, 0, 512)
+assert call("world_to_uv", uv, unreal.Vector(0, 0, 100), 0) is not None, "world_to_uv should find the top face"
+
+# --- bakes and image tools
+call("set_vertex_color", uv, "", unreal.LinearColor(1, 0, 0, 1))
+bk = call("bake_textures", uv, uv, "VertexColor,MaterialID,UVShell,Height", 64, ROOT, "UVEx", 0, 1); assert len(bk.texture_paths) == 4, bk.message
+call("create_noise_texture", ROOT + "/T_ExNoise", 64, 64, 4.0, 3, 0.5, 3, False)
+call("draw_on_texture", ROOT + "/T_ExNoise", "Line", [unreal.Vector2D(0.1, 0.1), unreal.Vector2D(0.9, 0.9)], unreal.LinearColor(1, 1, 1, 1), 3.0, 8.0, False)
+call("draw_on_texture", ROOT + "/T_ExNoise", "Dots", [unreal.Vector2D(0.1, 0.9), unreal.Vector2D(0.9, 0.1)], unreal.LinearColor(0, 0, 0, 1), 2.0, 6.0, False)
+xf = call("bake_texture_transfer", uv, uv, ROOT + "/T_ExNoise", 64, ROOT, "UVEx", 0, 0, 1); assert xf.texture_paths, xf.message
+call("import_texture", unreal.Paths.engine_content_dir() + "Slate/Checkerboard.png", ROOT + "/T_ExImported", False, "Masks", False)
+
+# --- surface detail: rivet stamps and a panel-line groove
+rv = call("create_mesh").handle
+call("append_sphere", rv, T(), 2.0, 4, 6)
+call("append_mesh_at_transforms", uv, rv, [T(unreal.Vector(-30, 0, 100)), T(unreal.Vector(0, 0, 100)), T(unreal.Vector(30, 0, 100))])
+call("append_mesh_along_polyline", uv, rv, [unreal.Vector(-40, 20, 100), unreal.Vector(40, 20, 100)], 20.0, unreal.Vector(0, 0, 1), 1.0)
+call("cut_groove_along_polyline", uv, [unreal.Vector(-60, -30, 100), unreal.Vector(60, -30, 100)], 2.0, 1.0, unreal.Vector(0, 0, 1))
+
 # --- skeletal (only when the project has a skeletal mesh)
 ar = unreal.AssetRegistryHelpers.get_asset_registry()
 skms = ar.get_assets_by_class(unreal.TopLevelAssetPath("/Script/Engine", "SkeletalMesh"), False)
@@ -213,7 +244,7 @@ if unreal.EditorAssetLibrary.does_directory_exist(ROOT):
 
 # --- coverage
 public = {n for n in dir(svc) if not n.startswith("_") and callable(getattr(svc, n)) and n not in dir(unreal.ToolsetDefinition)}
-public -= {"set_lo_ds"}   # Python alias of set_lods (ScriptName), not a separate function
+public -= {"set_lo_ds", "recompute_u_vs"}   # Python aliases from ScriptName (set_lods, recompute_uvs), not separate functions
 missed = sorted(public - CALLED)
 print("called %d/%d functions; failed %d" % (len(CALLED & public), len(public), len(FAILED)))
 for f in FAILED:

--- a/Content/Skills/modeling/scripts/exercise_all.txt
+++ b/Content/Skills/modeling/scripts/exercise_all.txt
@@ -1,0 +1,196 @@
+# Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+# exercise_all.txt — Call EVERY ModelingService function once and report PASS/FAIL, then prove
+# nothing was skipped by diffing against dir(unreal.ModelingService).
+#
+# Sample/verification script for the modeling skill. Run via execute_python_code. It only writes
+# under /Game/Developers/VibeUEModelingExercise and removes everything it created at the end.
+# Skeletal-mesh calls use the first SkeletalMesh found in the project (skipped when there is none).
+import unreal
+
+svc = unreal.ModelingService
+ROOT = "/Game/Developers/VibeUEModelingExercise"
+CALLED, FAILED = set(), []
+
+def call(name, *args):
+    CALLED.add(name)
+    fn = getattr(svc, name)
+    r = fn(*args)
+    ok = r.success if hasattr(r, "success") else (r if isinstance(r, bool) else (r >= 0 if isinstance(r, int) else r is not None))
+    if not ok:
+        FAILED.append((name, getattr(r, "message", str(r))[:120]))
+    return r
+
+svc.release_all_meshes(); CALLED.add("release_all_meshes")
+T = unreal.Transform
+
+# --- session
+h = call("create_mesh").handle
+call("append_box", h, T(), 100, 100, 100)
+copy_h = call("copy_mesh", h).handle
+info = call("get_mesh_info", h)
+assert info.triangle_count == 12, info.triangle_count
+assert svc.get_dynamic_mesh(h) is not None; CALLED.add("get_dynamic_mesh")
+assert h in list(call("list_meshes"))
+assert call("release_mesh", copy_h)
+
+# --- primitives
+p = call("create_mesh").handle
+call("append_sphere", p, T(), 30, 8, 12)
+call("append_cylinder", p, T(unreal.Vector(120, 0, 0)), 20, 60, 12)
+call("append_cone", p, T(unreal.Vector(240, 0, 0)), 20, 5, 60)
+call("append_capsule", p, T(unreal.Vector(360, 0, 0)), 15, 40)
+call("append_torus", p, T(unreal.Vector(480, 0, 0)), 30, 10)
+call("append_rectangle", p, T(unreal.Vector(0, 120, 0)), 50, 50)
+call("append_disc", p, T(unreal.Vector(120, 120, 0)), 25, 16, 0, 0.0, 270.0, 10.0)
+call("append_stairs", p, T(unreal.Vector(240, 120, 0)), 60, 15, 20, 5)
+call("append_curved_stairs", p, T(unreal.Vector(0, 300, 0)), 60, 15, 80, 90.0, 6)
+call("append_sphere_box", p, T(unreal.Vector(360, 120, 0)), 25, 4)
+call("append_extrude_polygon", p, T(unreal.Vector(480, 120, 0)), [unreal.Vector2D(0, 0), unreal.Vector2D(40, 0), unreal.Vector2D(40, 20), unreal.Vector2D(0, 30)], 15.0)
+call("append_revolve_polygon", p, T(unreal.Vector(0, 240, 0)), [unreal.Vector2D(0, 0), unreal.Vector2D(20, 0), unreal.Vector2D(25, 40), unreal.Vector2D(0, 60)], 0.0, 16, 360.0)
+path = [T(unreal.Vector(0, 0, 0)), T(unreal.Vector(0, 0, 50)), T(unreal.Vector(30, 0, 100))]
+call("append_sweep_polyline", p, T(unreal.Vector(120, 240, 0)), [unreal.Vector2D(-4, 0), unreal.Vector2D(0, 4), unreal.Vector2D(4, 0)], path)
+call("append_mesh", h, p, T(unreal.Vector(0, 0, 200)))
+
+# --- booleans
+a = call("create_mesh").handle; call("append_box", a, T(), 100, 100, 100)
+b = call("create_mesh").handle; call("append_sphere", b, T(unreal.Vector(50, 50, 50)), 40, 10, 16)
+call("boolean", a, b, "Subtract", T())
+call("self_union", a)
+call("plane_cut", a, T(unreal.Vector(0, 0, 80)), True)
+call("mirror", a, T(unreal.Vector(0, 0, 0), unreal.Rotator(0, 0, 90)), True, True)
+
+# --- selections + poly edit
+c = call("create_mesh").handle; call("append_box", c, T(), 100, 100, 100)
+assert call("select_all", c, "all") == 12
+assert call("select_by_normal_angle", c, "top", unreal.Vector(0, 0, 1), 5.0) == 2
+assert call("select_in_box", c, "lower", unreal.Vector(-60, -60, -1), unreal.Vector(60, 60, 30)) > 0
+assert call("select_in_sphere", c, "corner", unreal.Vector(50, 50, 100), 150.0) > 0   # every vertex of a face triangle must be inside
+call("compute_polygroups", c, "Angle", 15.0)
+assert call("select_by_polygroup", c, "group0", 1) >= 0
+call("expand_contract_selection", c, "top", "top_grown", 1, False)
+call("invert_selection", c, "top", "not_top")
+assert call("selection_count", c, "top") == 2
+mn, mx = svc.selection_bounds(c, "top"); CALLED.add("selection_bounds"); assert mx.z > 99, mx   # Python drops the bool; empty selection -> zero vectors
+call("inset_faces", c, "top", 5.0)
+call("select_by_normal_angle", c, "top", unreal.Vector(0, 0, 1), 5.0)
+call("extrude_faces", c, "top", -3.0)
+call("select_by_normal_angle", c, "top", unreal.Vector(0, 0, 1), 5.0)
+call("outset_faces", c, "top", 2.0)
+call("select_by_normal_angle", c, "side", unreal.Vector(1, 0, 0), 5.0)
+call("offset_faces", c, "side", 2.0)
+assert not svc.translate_selection(c, "side", unreal.Vector(1, 0, 0)).success, "stale selection must be refused after offset_faces changed topology"
+call("select_by_normal_angle", c, "side", unreal.Vector(1, 0, 0), 5.0)
+call("translate_selection", c, "side", unreal.Vector(1, 0, 0))
+call("set_material_id", c, "side", 3)
+assert call("select_by_material_id", c, "mat3", 3) > 0
+call("remap_material_id", c, 3, 1)
+call("set_vertex_color", c, "side", unreal.LinearColor(0, 1, 0, 1))
+call("set_vertex_color", c, "", unreal.LinearColor(1, 1, 1, 1))
+call("compute_polygroups", c, "Angle", 15.0)
+call("bevel_polygroups", c, 0.5)
+call("select_by_normal_angle", c, "bottom", unreal.Vector(0, 0, -1), 5.0)
+call("delete_faces", c, "bottom")
+call("fill_holes", c)
+assert call("clear_selections", c)
+d = call("create_mesh").handle; call("append_rectangle", d, T(), 50, 50)
+call("shell_mesh", d, 2.0)
+call("offset_mesh", d, 1.0)
+
+# --- mesh ops
+m = call("create_mesh").handle; call("append_sphere", m, T(), 40, 16, 24)
+call("noise", m, "", 2.0, 0.1, 3)
+call("remesh", m, 1500)
+call("simplify_to_triangle_count", m, 600)
+call("simplify_to_vertex_count", m, 250)
+call("simplify_to_tolerance", m, 0.5)
+call("subdivide", m, 1, "PN"); call("subdivide", m, 1, "Uniform"); call("subdivide", m, 1, "Loop")
+q = call("create_mesh").handle; call("append_box", q, T(), 50, 50, 50); call("compute_polygroups", q, "Polygons"); call("subdivide", q, 1, "CatmullClark")
+call("simplify_planar", q, 0.01)
+call("smooth", m, "", 2, 0.2)
+call("weld_edges", m, 0.001)
+call("repair", m)
+call("remove_hidden_triangles", m)
+sp = call("split_by_components", h); assert sp.handles
+call("compute_polygroups", m, "UVIslands"); call("compute_polygroups", m, "Components")
+
+# --- deform + voxel
+v = call("create_mesh").handle; call("append_cylinder", v, T(), 20, 100, 12, 8)
+call("bend", v, T(unreal.Vector(0, 0, 50)), 30.0, 50.0)
+call("twist", v, T(unreal.Vector(0, 0, 50)), 30.0, 50.0)
+call("flare", v, T(unreal.Vector(0, 0, 50)), 20.0, 20.0, 50.0)
+call("voxel_solidify", v, 32)
+call("voxel_morphology", v, "Close", 2.0, 32)
+tex = ar_tex = unreal.AssetRegistryHelpers.get_asset_registry().get_assets_by_class(unreal.TopLevelAssetPath("/Script/Engine", "Texture2D"), False)
+if tex:
+    dp = call("create_mesh").handle; call("append_rectangle", dp, T(), 100, 100, 8, 8); call("auto_uv", dp, "XAtlas", 0)
+    call("displace_from_texture", dp, "", tex[0].get_asset().get_path_name(), 5.0, 0)
+else:
+    CALLED.add("displace_from_texture"); print("SKIPPED (no Texture2D in project): displace_from_texture")
+
+# --- UVs / normals / transform
+u = call("create_mesh").handle; call("append_box", u, T(), 60, 60, 60)
+call("set_num_uv_layers", u, 2)
+call("auto_uv", u, "XAtlas", 0); call("auto_uv", u, "PatchBuilder", 1)
+call("project_uv", u, "Planar", T(), 0, ""); call("project_uv", u, "Box", T(), 0, ""); call("project_uv", u, "Cylinder", T(), 1, "")
+call("repack_uv", u, 0, 512)
+call("recompute_normals", u, 30.0); call("recompute_normals", u, -1.0); call("flip_normals", u); call("flip_normals", u)
+call("transform_mesh", u, T(unreal.Vector(10, 0, 0))); call("translate_mesh", u, unreal.Vector(-10, 0, 0))
+call("rotate_mesh", u, unreal.Rotator(0, 45, 0), unreal.Vector()); call("scale_mesh", u, unreal.Vector(1, 1, 2), unreal.Vector())
+call("recenter_mesh", u, "Bounds"); call("recenter_mesh", u, "Base")
+
+# --- queries / sampling / hulls / comparison
+s = call("create_mesh").handle; call("append_sphere", s, T(), 50, 12, 18)
+hit = call("ray_cast", s, unreal.Vector(-200, 0, 0), unreal.Vector(1, 0, 0), 0.0); assert hit.found and abs(hit.position.x + 50) < 2, hit.position
+near = call("nearest_point", s, unreal.Vector(0, 0, 120), 0.0); assert near.found and abs(near.position.z - 50) < 2
+assert svc.is_point_inside(s, unreal.Vector(0, 0, 0)) and not svc.is_point_inside(s, unreal.Vector(0, 0, 500)); CALLED.add("is_point_inside")
+pts = call("sample_surface_points", s, 15.0, 0); assert len(pts) > 20, len(pts)
+hull = call("convex_hull", s, 0); assert hull.triangle_count > 0
+dec = call("convex_decomposition", a, 2); assert dec.triangle_count > 0
+sw = call("swept_hull", s, T()); assert sw.triangle_count > 0
+rep = call("measure_distance", s, hull.handle); assert rep.success and rep.max_distance < 5.0, rep.message
+
+# --- assets
+sm_path = ROOT + "/SM_Exercise"
+r = call("save_mesh_to_static_mesh", c, sm_path, True, True, False, True); assert r.asset_path
+call("save_mesh_to_static_mesh", c, sm_path, True, True, False, True)   # replace path
+lh = call("load_mesh_from_static_mesh", sm_path, 0).handle
+call("generate_collision", sm_path, "ConvexHulls", 2)
+call("set_lods", sm_path, [1.0, 0.5])
+sp_r = call("spawn_static_mesh_actor", sm_path, T(unreal.Vector(0, 0, -5000)), "VibeUEModelingExerciseActor")
+ah = call("load_mesh_from_actor", "VibeUEModelingExerciseActor", True, 0).handle
+bake = call("bake_textures", u, s, "TangentNormal,AmbientOcclusion", 64, ROOT, "Exercise", 0, 1); assert bake.texture_paths
+
+# --- skeletal (only when the project has a skeletal mesh)
+ar = unreal.AssetRegistryHelpers.get_asset_registry()
+skms = ar.get_assets_by_class(unreal.TopLevelAssetPath("/Script/Engine", "SkeletalMesh"), False)
+if skms:
+    skm = skms[0].get_asset(); skel = skm.skeleton
+    kh = call("load_mesh_from_skeletal_mesh", skm.get_path_name(), 0).handle
+    call("transfer_bone_weights", kh, skm.get_path_name(), 0)
+    call("smooth_bone_weights", kh, skel.get_path_name(), 0.2, 4)
+    call("prune_bone_weights", kh, str(skel.get_editor_property("reference_skeleton").get_editor_property("raw_ref_bone_info")[0].get_editor_property("name")) if False else "root")
+    call("save_mesh_to_skeletal_mesh", kh, ROOT + "/SK_Exercise", skel.get_path_name(), True, False)
+else:
+    for n in ("load_mesh_from_skeletal_mesh", "transfer_bone_weights", "smooth_bone_weights", "prune_bone_weights", "save_mesh_to_skeletal_mesh"):
+        CALLED.add(n); print("SKIPPED (no SkeletalMesh in project):", n)
+
+# --- cleanup
+eas = unreal.get_editor_subsystem(unreal.EditorActorSubsystem)
+for actor in eas.get_all_level_actors():
+    if actor.get_actor_label() == "VibeUEModelingExerciseActor":
+        eas.destroy_actor(actor)
+svc.release_all_meshes()
+if unreal.EditorAssetLibrary.does_directory_exist(ROOT):
+    unreal.EditorAssetLibrary.delete_directory(ROOT)
+
+# --- coverage
+public = {n for n in dir(svc) if not n.startswith("_") and callable(getattr(svc, n)) and n not in dir(unreal.ToolsetDefinition)}
+public -= {"set_lo_ds"}   # Python alias of set_lods (ScriptName), not a separate function
+missed = sorted(public - CALLED)
+print("called %d/%d functions; failed %d" % (len(CALLED & public), len(public), len(FAILED)))
+for f in FAILED:
+    print("  FAIL", f)
+if missed:
+    print("  NOT CALLED:", missed)
+print("RESULT:", "PASS" if not FAILED and not missed else "FAIL")

--- a/Content/Skills/modeling/scripts/exercise_all.txt
+++ b/Content/Skills/modeling/scripts/exercise_all.txt
@@ -161,6 +161,33 @@ sp_r = call("spawn_static_mesh_actor", sm_path, T(unreal.Vector(0, 0, -5000)), "
 ah = call("load_mesh_from_actor", "VibeUEModelingExerciseActor", True, 0).handle
 bake = call("bake_textures", u, s, "TangentNormal,AmbientOcclusion", 64, ROOT, "Exercise", 0, 1); assert bake.texture_paths
 
+# --- lofts, orientation, connected pieces
+lf = call("create_mesh").handle
+profile = [unreal.Vector2D(x, y) for x, y in ((0, 0), (0.3, 0.06), (0.7, 0.04), (1, 0), (0.7, -0.04), (0.3, -0.06))]
+frames = [unreal.Transform(unreal.Vector(0, 0, 0), unreal.Rotator(0, 0, 90), unreal.Vector(200, 200, 200)),
+          unreal.Transform(unreal.Vector(-50, 400, 0), unreal.Rotator(0, 0, 90), unreal.Vector(100, 100, 100))]
+call("append_loft", lf, T(), profile, frames, 0)
+assert svc.get_mesh_info(lf).is_closed and svc.get_mesh_info(lf).volume > 0, "loft must be closed and outward"
+call("flip_normals", lf)
+call("ensure_outward", lf); assert svc.get_mesh_info(lf).volume > 0, "ensure_outward must flip an inside-out mesh"
+call("append_box", lf, T(unreal.Vector(0, -300, 0)), 50, 50, 50)
+assert call("select_connected", lf, "piece", unreal.Vector(0, -300, 25)) == 12
+
+# --- rigging: bones authored on the mesh, saved with a freshly created skeleton
+rg = call("create_mesh").handle
+call("append_box", rg, T(), 100, 100, 100)
+call("append_box", rg, T(unreal.Vector(0, 200, 0)), 50, 50, 50)
+call("select_connected", rg, "flap", unreal.Vector(0, 200, 25))
+B = unreal.ModelingBoneDef
+call("create_bones", rg, [B(name="root"), B(name="flap", parent_name="root", transform=T(unreal.Vector(0, 175, 0)))])
+call("bind_selection_to_bone", rg, "flap", "flap", 1.0)
+bones = call("list_bones", rg)
+assert len(bones) == 2 and bones[1].influenced_vertices == 8, [(str(b.name), b.influenced_vertices) for b in bones]
+sk_path = ROOT + "/SK_ExerciseRig"
+call("save_mesh_to_skeletal_mesh", rg, sk_path, "", True, False)
+assert unreal.EditorAssetLibrary.does_asset_exist(sk_path + "_Skeleton"), "skeleton should be created next to the mesh"
+call("set_asset_materials", sk_path, "/Engine/BasicShapes/BasicShapeMaterial", False)
+
 # --- skeletal (only when the project has a skeletal mesh)
 ar = unreal.AssetRegistryHelpers.get_asset_registry()
 skms = ar.get_assets_by_class(unreal.TopLevelAssetPath("/Script/Engine", "SkeletalMesh"), False)

--- a/Content/samples/AGENTS.md.sample
+++ b/Content/samples/AGENTS.md.sample
@@ -63,7 +63,8 @@ tool in a toolset (the most token-heavy thing here); reach for a **skill** plus 
 AnimMontage, AnimGraph, Landscape(+Material), Foliage, MetaSound, SoundCue, Niagara(+Emitter,
 +ScratchPad), StateTree, BehaviorTree, Blackboard, Input, EnumStruct, UVMapping,
 RuntimeVirtualTexture, MapBlockout, GameplayTag, Viewport, Actor, Engine/ProjectSettings,
-**Performance** (`unreal.PerformanceService.frame_timing()`).
+**Modeling** (`unreal.ModelingService` — build/edit meshes on session handles and save them as
+assets; load the `modeling` skill first), **Performance** (`unreal.PerformanceService.frame_timing()`).
 These overlap-trimmed services keep only what the engine lacks — for plain asset/actor/blueprint
 basics the engine's own tools may be simpler (below).
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ your editor through Unreal's standard MCP endpoint.
 Unreal 5.8 ships its own AI toolsets (Blueprints, materials, actors, assets, meshes, data tables, …).
 VibeUE **complements** them — it focuses on the domains and depth the engine doesn't cover:
 
+- **Mesh modeling** — the operator half of Modeling Mode without a viewport: `ModelingService`
+  builds meshes from primitives, booleans, extrude/inset/bevel on selections, remesh/simplify/
+  subdivide, deform and voxel ops, auto-UV, normals, repair, then saves StaticMesh/SkeletalMesh
+  assets with collision, LODs, and baked maps. Kitbash and block out props in-engine, no Blender.
 - **Terrain & world** — Landscape sculpting/heightmaps/splines, landscape auto-materials + RVT,
   Foliage, procedural FPS **Map Blockout**, and **real-world terrain** (heightmaps + water from GPS).
 - **Audio** — MetaSound and SoundCue graph authoring.

--- a/Source/VibeUE/Private/PythonAPI/ModelingServiceTests.cpp
+++ b/Source/VibeUE/Private/PythonAPI/ModelingServiceTests.cpp
@@ -1,0 +1,390 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#include "Misc/AutomationTest.h"
+
+#if WITH_AUTOMATION_TESTS
+
+#include "PythonAPI/UModelingService.h"
+#include "EditorAssetLibrary.h"
+#include "Editor.h"
+#include "GameFramework/Actor.h"
+#include "Subsystems/EditorActorSubsystem.h"
+
+// Self-provisioning: every test builds its own geometry through the service, writes only under
+// kModelingTestDir, and releases / deletes what it made. No project content is required.
+
+static const EAutomationTestFlags kModelingTestFlags =
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter;
+static const TCHAR* kModelingTestDir = TEXT("/Game/Developers/VibeUEModelingTests");
+
+namespace
+{
+	struct FScopedModelingSession
+	{
+		~FScopedModelingSession() { UModelingService::ReleaseAllMeshes(); }
+	};
+
+	int32 MakeBox(float Size = 100.f)
+	{
+		const int32 Handle = UModelingService::CreateMesh().Handle;
+		UModelingService::AppendBox(Handle, FTransform::Identity, Size, Size, Size);
+		return Handle;
+	}
+
+	int32 MakeSphere(float Radius = 50.f)
+	{
+		const int32 Handle = UModelingService::CreateMesh().Handle;
+		UModelingService::AppendSphere(Handle, FTransform::Identity, Radius, 12, 18);
+		return Handle;
+	}
+}
+
+// ---------------------------------------------------------------------------------------------
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeModelingSessionTest, "VibeUE.Modeling.Session", kModelingTestFlags)
+bool FVibeModelingSessionTest::RunTest(const FString&)
+{
+	FScopedModelingSession Session;
+	const FModelingResult Created = UModelingService::CreateMesh();
+	TestTrue(TEXT("create succeeds"), Created.bSuccess);
+	TestTrue(TEXT("handle is positive"), Created.Handle > 0);
+
+	const FModelingResult Box = UModelingService::AppendBox(Created.Handle, FTransform::Identity, 100.f, 100.f, 100.f);
+	TestEqual(TEXT("box has 12 triangles"), Box.TriangleCount, 12);
+
+	const FModelingMeshInfo Info = UModelingService::GetMeshInfo(Created.Handle);
+	TestTrue(TEXT("info succeeds"), Info.bSuccess);
+	TestEqual(TEXT("info triangle count"), Info.TriangleCount, 12);
+	TestEqual(TEXT("info vertex count"), Info.VertexCount, 8);
+	TestTrue(TEXT("box is closed"), Info.bIsClosed);
+	TestEqual(TEXT("box bounds min z is 0 (Base origin)"), Info.BoundsMin.Z, 0.0);
+	TestTrue(TEXT("bounds max z ~100"), FMath::IsNearlyEqual(Info.BoundsMax.Z, 100.0, 0.01));
+
+	const FModelingResult Copy = UModelingService::CopyMesh(Created.Handle);
+	TestTrue(TEXT("copy succeeds"), Copy.bSuccess && Copy.Handle != Created.Handle);
+	TestEqual(TEXT("copy has same triangles"), Copy.TriangleCount, 12);
+	TestEqual(TEXT("two meshes listed"), UModelingService::ListMeshes().Num(), 2);
+	TestTrue(TEXT("dynamic mesh accessible"), UModelingService::GetDynamicMesh(Created.Handle) != nullptr);
+	TestTrue(TEXT("release copy"), UModelingService::ReleaseMesh(Copy.Handle));
+	TestFalse(TEXT("release twice fails"), UModelingService::ReleaseMesh(Copy.Handle));
+	TestEqual(TEXT("release all count"), UModelingService::ReleaseAllMeshes(), 1);
+	TestEqual(TEXT("nothing listed"), UModelingService::ListMeshes().Num(), 0);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeModelingPrimitivesTest, "VibeUE.Modeling.Primitives", kModelingTestFlags)
+bool FVibeModelingPrimitivesTest::RunTest(const FString&)
+{
+	FScopedModelingSession Session;
+	const int32 H = UModelingService::CreateMesh().Handle;
+	int32 Last = 0;
+	auto Grows = [&](const FModelingResult& R, const TCHAR* What)
+	{
+		TestTrue(FString::Printf(TEXT("%s succeeds: %s"), What, *R.Message), R.bSuccess);
+		TestTrue(FString::Printf(TEXT("%s adds triangles"), What), R.TriangleCount > Last);
+		Last = R.TriangleCount;
+	};
+	Grows(UModelingService::AppendBox(H, FTransform::Identity), TEXT("box"));
+	Grows(UModelingService::AppendSphere(H, FTransform(FVector(120, 0, 0))), TEXT("sphere"));
+	Grows(UModelingService::AppendSphereBox(H, FTransform(FVector(240, 0, 0))), TEXT("sphere box"));
+	Grows(UModelingService::AppendCylinder(H, FTransform(FVector(360, 0, 0))), TEXT("cylinder"));
+	Grows(UModelingService::AppendCone(H, FTransform(FVector(480, 0, 0))), TEXT("cone"));
+	Grows(UModelingService::AppendCapsule(H, FTransform(FVector(600, 0, 0))), TEXT("capsule"));
+	Grows(UModelingService::AppendTorus(H, FTransform(FVector(720, 0, 0))), TEXT("torus"));
+	Grows(UModelingService::AppendRectangle(H, FTransform(FVector(0, 120, 0))), TEXT("rectangle"));
+	Grows(UModelingService::AppendDisc(H, FTransform(FVector(120, 120, 0)), 50.f, 16, 0, 0.f, 270.f, 10.f), TEXT("disc"));
+	Grows(UModelingService::AppendStairs(H, FTransform(FVector(240, 120, 0))), TEXT("stairs"));
+	Grows(UModelingService::AppendCurvedStairs(H, FTransform(FVector(0, 300, 0))), TEXT("curved stairs"));
+	const TArray<FVector2D> L = { FVector2D(0, 0), FVector2D(40, 0), FVector2D(40, 20), FVector2D(0, 30) };
+	Grows(UModelingService::AppendExtrudePolygon(H, FTransform(FVector(480, 120, 0)), L, 15.f), TEXT("extrude polygon"));
+	const TArray<FVector2D> Profile = { FVector2D(0, 0), FVector2D(20, 0), FVector2D(25, 40), FVector2D(0, 60) };
+	Grows(UModelingService::AppendRevolvePolygon(H, FTransform(FVector(0, 240, 0)), Profile, 0.f, 16, 360.f), TEXT("revolve"));
+	const TArray<FVector2D> V = { FVector2D(-4, 0), FVector2D(0, 4), FVector2D(4, 0) };
+	const TArray<FTransform> Path = { FTransform(FVector(0, 0, 0)), FTransform(FVector(0, 0, 50)), FTransform(FVector(30, 0, 100)) };
+	Grows(UModelingService::AppendSweepPolyline(H, FTransform(FVector(120, 240, 0)), V, Path), TEXT("sweep"));
+
+	const int32 Other = MakeBox(20.f);
+	Grows(UModelingService::AppendMesh(H, Other, FTransform(FVector(0, 0, 300))), TEXT("append mesh"));
+	TestFalse(TEXT("unknown origin rejected"), UModelingService::AppendBox(H, FTransform::Identity, 1, 1, 1, 0, 0, 0, TEXT("Sideways")).bSuccess);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeModelingBooleanTest, "VibeUE.Modeling.Booleans", kModelingTestFlags)
+bool FVibeModelingBooleanTest::RunTest(const FString&)
+{
+	FScopedModelingSession Session;
+	const int32 A = MakeBox();
+	const int32 B = UModelingService::CreateMesh().Handle;
+	UModelingService::AppendSphere(B, FTransform(FVector(50, 50, 50)), 40.f, 10, 16);
+
+	const FModelingResult Sub = UModelingService::Boolean(A, B, TEXT("Subtract"), FTransform::Identity);
+	TestTrue(TEXT("subtract succeeds"), Sub.bSuccess);
+	TestTrue(TEXT("subtract still closed"), UModelingService::GetMeshInfo(A).bIsClosed);
+	TestTrue(TEXT("subtract changed topology"), Sub.TriangleCount > 12);
+
+	const int32 C = MakeBox();
+	const int32 D = UModelingService::CreateMesh().Handle;
+	UModelingService::AppendBox(D, FTransform(FVector(50, 0, 0)), 100.f, 100.f, 100.f);
+	TestTrue(TEXT("union"), UModelingService::Boolean(C, D, TEXT("Union"), FTransform::Identity).bSuccess);
+	TestTrue(TEXT("intersection"), UModelingService::Boolean(MakeBox(), D, TEXT("Intersection"), FTransform::Identity).bSuccess);
+	TestTrue(TEXT("self union"), UModelingService::SelfUnion(C).bSuccess);
+	TestTrue(TEXT("plane cut"), UModelingService::PlaneCut(C, FTransform(FVector(0, 0, 80)), true).bSuccess);
+	TestEqual(TEXT("plane cut keeps mesh closed"), UModelingService::GetMeshInfo(C).OpenBorderEdges, 0);
+	const FModelingMeshInfo Before = UModelingService::GetMeshInfo(C);
+	TestTrue(TEXT("mirror"), UModelingService::Mirror(C, FTransform(FRotator(0, 0, 90)), true, true).bSuccess);
+	const FModelingMeshInfo After = UModelingService::GetMeshInfo(C);
+	TestTrue(TEXT("mirror produced geometry"), After.TriangleCount > 0 && Before.TriangleCount > 0);
+	TestFalse(TEXT("unknown op rejected"), UModelingService::Boolean(A, B, TEXT("Frobnicate"), FTransform::Identity).bSuccess);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeModelingSelectionEditTest, "VibeUE.Modeling.SelectionsPolyEdit", kModelingTestFlags)
+bool FVibeModelingSelectionEditTest::RunTest(const FString&)
+{
+	FScopedModelingSession Session;
+	const int32 H = MakeBox();
+	TestEqual(TEXT("select all"), UModelingService::SelectAll(H, TEXT("all")), 12);
+	TestEqual(TEXT("select top by normal"), UModelingService::SelectByNormalAngle(H, TEXT("top"), FVector::UpVector, 5.f), 2);
+	TestTrue(TEXT("select in box"), UModelingService::SelectInBox(H, TEXT("lower"), FVector(-60, -60, -1), FVector(60, 60, 30)) > 0);
+	TestTrue(TEXT("select in sphere"), UModelingService::SelectInSphere(H, TEXT("corner"), FVector(50, 50, 100), 150.f) > 0);
+	TestEqual(TEXT("selection count"), UModelingService::SelectionCount(H, TEXT("top")), 2);
+	FVector Min, Max;
+	TestTrue(TEXT("selection bounds"), UModelingService::SelectionBounds(H, TEXT("top"), Min, Max));
+	TestTrue(TEXT("top bounds at z=100"), FMath::IsNearlyEqual(Max.Z, 100.0, 0.01) && FMath::IsNearlyEqual(Min.Z, 100.0, 0.01));
+	TestTrue(TEXT("expand"), UModelingService::ExpandContractSelection(H, TEXT("top"), TEXT("grown"), 1, false) > 2);
+	TestEqual(TEXT("invert"), UModelingService::InvertSelection(H, TEXT("top"), TEXT("not_top")), 10);
+	TestTrue(TEXT("polygroups by angle"), UModelingService::ComputePolygroups(H, TEXT("Angle"), 15.f).bSuccess);
+	TestTrue(TEXT("select by polygroup"), UModelingService::SelectByPolygroup(H, TEXT("g1"), 1) >= 0);
+
+	TestTrue(TEXT("inset"), UModelingService::InsetFaces(H, TEXT("top"), 6.f).bSuccess);
+	UModelingService::SelectByNormalAngle(H, TEXT("top"), FVector::UpVector, 5.f);
+	const FModelingResult Extruded = UModelingService::ExtrudeFaces(H, TEXT("top"), -1.5f);
+	TestTrue(TEXT("extrude"), Extruded.bSuccess);
+	UModelingService::SelectByNormalAngle(H, TEXT("top"), FVector::UpVector, 5.f);
+	TestTrue(TEXT("outset"), UModelingService::OutsetFaces(H, TEXT("top"), 2.f).bSuccess);
+	TestTrue(TEXT("side select"), UModelingService::SelectByNormalAngle(H, TEXT("side"), FVector(1, 0, 0), 5.f) > 0);
+	TestTrue(TEXT("offset faces"), UModelingService::OffsetFaces(H, TEXT("side"), 2.f).bSuccess);
+	TestFalse(TEXT("stale side selection refused after offset"), UModelingService::TranslateSelection(H, TEXT("side"), FVector(1, 0, 0)).bSuccess);
+	UModelingService::SelectByNormalAngle(H, TEXT("side"), FVector(1, 0, 0), 5.f);
+	TestTrue(TEXT("translate selection"), UModelingService::TranslateSelection(H, TEXT("side"), FVector(1, 0, 0)).bSuccess);
+	TestTrue(TEXT("set material id"), UModelingService::SetMaterialID(H, TEXT("side"), 3).bSuccess);
+	TestTrue(TEXT("select by material id"), UModelingService::SelectByMaterialID(H, TEXT("mat3"), 3) > 0);
+	TestTrue(TEXT("remap material id"), UModelingService::RemapMaterialID(H, 3, 1).bSuccess);
+	TestEqual(TEXT("material 3 gone"), UModelingService::SelectByMaterialID(H, TEXT("mat3b"), 3), 0);
+	TestTrue(TEXT("vertex color on selection"), UModelingService::SetVertexColor(H, TEXT("side"), FLinearColor::Green).bSuccess);
+	TestTrue(TEXT("constant vertex color"), UModelingService::SetVertexColor(H, TEXT(""), FLinearColor::White).bSuccess);
+	TestTrue(TEXT("bevel"), (UModelingService::ComputePolygroups(H, TEXT("Angle"), 15.f), UModelingService::BevelPolygroups(H, 0.5f).bSuccess));
+	TestTrue(TEXT("bottom select"), UModelingService::SelectByNormalAngle(H, TEXT("bottom"), FVector::DownVector, 5.f) > 0);
+	TestTrue(TEXT("delete faces"), UModelingService::DeleteFaces(H, TEXT("bottom")).bSuccess);
+	TestTrue(TEXT("hole after delete"), UModelingService::GetMeshInfo(H).OpenBorderEdges > 0);
+	TestTrue(TEXT("fill holes"), UModelingService::FillHoles(H).bSuccess);
+	TestEqual(TEXT("closed after fill"), UModelingService::GetMeshInfo(H).OpenBorderEdges, 0);
+	TestTrue(TEXT("clear selections"), UModelingService::ClearSelections(H));
+	TestFalse(TEXT("missing selection rejected"), UModelingService::InsetFaces(H, TEXT("nope"), 1.f).bSuccess);
+	UModelingService::SelectByNormalAngle(H, TEXT("stale"), FVector(1, 0, 0), 5.f);
+	UModelingService::Subdivide(H, 1, TEXT("Uniform"));
+	TestFalse(TEXT("stale selection rejected after topology change"), UModelingService::TranslateSelection(H, TEXT("stale"), FVector(1, 0, 0)).bSuccess);
+
+	const int32 Flat = UModelingService::CreateMesh().Handle;
+	UModelingService::AppendRectangle(Flat, FTransform::Identity, 50.f, 50.f);
+	TestTrue(TEXT("shell"), UModelingService::ShellMesh(Flat, 2.f).bSuccess);
+	TestTrue(TEXT("shell is closed"), UModelingService::GetMeshInfo(Flat).bIsClosed);
+	TestTrue(TEXT("offset mesh"), UModelingService::OffsetMesh(Flat, 1.f).bSuccess);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeModelingMeshOpsTest, "VibeUE.Modeling.MeshOps", kModelingTestFlags)
+bool FVibeModelingMeshOpsTest::RunTest(const FString&)
+{
+	FScopedModelingSession Session;
+	const int32 M = MakeSphere(40.f);
+	TestTrue(TEXT("noise"), UModelingService::Noise(M, TEXT(""), 2.f, 0.1f, 3).bSuccess);
+	const FModelingResult Remeshed = UModelingService::Remesh(M, 1500);
+	TestTrue(TEXT("remesh"), Remeshed.bSuccess && Remeshed.TriangleCount > 1000);
+	const FModelingResult Simp = UModelingService::SimplifyToTriangleCount(M, 600);
+	TestTrue(TEXT("simplify to tris"), Simp.bSuccess && Simp.TriangleCount <= 620);
+	TestTrue(TEXT("simplify to verts"), UModelingService::SimplifyToVertexCount(M, 250).bSuccess);
+	TestTrue(TEXT("simplify to tolerance"), UModelingService::SimplifyToTolerance(M, 0.5f).bSuccess);
+	for (const TCHAR* Method : { TEXT("PN"), TEXT("Uniform"), TEXT("Loop") })
+	{
+		const int32 Before = UModelingService::GetMeshInfo(M).TriangleCount;
+		const FModelingResult R = UModelingService::Subdivide(M, 1, Method);
+		TestTrue(FString::Printf(TEXT("subdivide %s"), Method), R.bSuccess && R.TriangleCount > Before);
+		UModelingService::SimplifyToTriangleCount(M, 600);
+	}
+	const int32 Q = MakeBox(50.f);
+	UModelingService::ComputePolygroups(Q, TEXT("Polygons"));
+	const FModelingResult CC = UModelingService::Subdivide(Q, 1, TEXT("CatmullClark"));
+	TestTrue(TEXT("subdivide CatmullClark"), CC.bSuccess && CC.TriangleCount > 12);
+	TestTrue(TEXT("planar simplify"), UModelingService::SimplifyPlanar(MakeBox(), 0.01f).bSuccess);
+	TestFalse(TEXT("unknown subdivide rejected"), UModelingService::Subdivide(M, 1, TEXT("Sierpinski")).bSuccess);
+	TestTrue(TEXT("smooth"), UModelingService::Smooth(M, TEXT(""), 2, 0.2f).bSuccess);
+	TestTrue(TEXT("weld"), UModelingService::WeldEdges(M, 0.001f).bSuccess);
+	TestTrue(TEXT("repair"), UModelingService::Repair(M).bSuccess);
+	TestTrue(TEXT("remove hidden"), UModelingService::RemoveHiddenTriangles(M).bSuccess);
+
+	const int32 Two = MakeBox();
+	UModelingService::AppendBox(Two, FTransform(FVector(500, 0, 0)));
+	TestEqual(TEXT("two components"), UModelingService::GetMeshInfo(Two).ConnectedComponents, 2);
+	const FModelingSplitResult Split = UModelingService::SplitByComponents(Two);
+	TestTrue(TEXT("split succeeds"), Split.bSuccess);
+	TestEqual(TEXT("split into two handles"), Split.Handles.Num(), 2);
+	TestTrue(TEXT("polygroups UV islands"), UModelingService::ComputePolygroups(M, TEXT("UVIslands")).bSuccess);
+	TestTrue(TEXT("polygroups components"), UModelingService::ComputePolygroups(M, TEXT("Components")).bSuccess);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeModelingDeformVoxelTest, "VibeUE.Modeling.DeformVoxel", kModelingTestFlags)
+bool FVibeModelingDeformVoxelTest::RunTest(const FString&)
+{
+	FScopedModelingSession Session;
+	const int32 V = UModelingService::CreateMesh().Handle;
+	UModelingService::AppendCylinder(V, FTransform::Identity, 20.f, 100.f, 12, 8);
+	const FTransform Mid(FVector(0, 0, 50));
+	TestTrue(TEXT("bend"), UModelingService::Bend(V, Mid, 30.f, 50.f).bSuccess);
+	TestTrue(TEXT("twist"), UModelingService::Twist(V, Mid, 30.f, 50.f).bSuccess);
+	TestTrue(TEXT("flare"), UModelingService::Flare(V, Mid, 20.f, 20.f, 50.f).bSuccess);
+	const FModelingResult Solid = UModelingService::VoxelSolidify(V, 32);
+	TestTrue(TEXT("voxel solidify"), Solid.bSuccess && Solid.TriangleCount > 0);
+	TestTrue(TEXT("solidified is closed"), UModelingService::GetMeshInfo(V).bIsClosed);
+	TestTrue(TEXT("voxel close"), UModelingService::VoxelMorphology(V, TEXT("Close"), 2.f, 32).bSuccess);
+	TestFalse(TEXT("unknown morphology rejected"), UModelingService::VoxelMorphology(V, TEXT("Wobble"), 1.f, 32).bSuccess);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeModelingAttributesTest, "VibeUE.Modeling.AttributesTransforms", kModelingTestFlags)
+bool FVibeModelingAttributesTest::RunTest(const FString&)
+{
+	FScopedModelingSession Session;
+	const int32 U = MakeBox(60.f);
+	TestTrue(TEXT("set uv layers"), UModelingService::SetNumUVLayers(U, 2).bSuccess);
+	TestEqual(TEXT("two uv layers"), UModelingService::GetMeshInfo(U).NumUVLayers, 2);
+	TestTrue(TEXT("auto uv xatlas"), UModelingService::AutoUV(U, TEXT("XAtlas"), 0).bSuccess);
+	TestTrue(TEXT("auto uv patch builder"), UModelingService::AutoUV(U, TEXT("PatchBuilder"), 1).bSuccess);
+	TestFalse(TEXT("unknown uv method rejected"), UModelingService::AutoUV(U, TEXT("Magic"), 0).bSuccess);
+	for (const TCHAR* Method : { TEXT("Planar"), TEXT("Box"), TEXT("Cylinder") })
+	{
+		TestTrue(FString::Printf(TEXT("project uv %s"), Method), UModelingService::ProjectUV(U, Method, FTransform::Identity, 0).bSuccess);
+	}
+	TestTrue(TEXT("repack"), UModelingService::RepackUV(U, 0, 512).bSuccess);
+	TestTrue(TEXT("normals hard"), UModelingService::RecomputeNormals(U, 30.f).bSuccess);
+	TestTrue(TEXT("normals smooth"), UModelingService::RecomputeNormals(U, -1.f).bSuccess);
+	TestTrue(TEXT("flip normals"), UModelingService::FlipNormals(U).bSuccess && UModelingService::FlipNormals(U).bSuccess);
+
+	const FModelingMeshInfo Before = UModelingService::GetMeshInfo(U);
+	TestTrue(TEXT("transform"), UModelingService::TransformMesh(U, FTransform(FVector(10, 0, 0))).bSuccess);
+	TestTrue(TEXT("translate"), UModelingService::TranslateMesh(U, FVector(-10, 0, 0)).bSuccess);
+	TestTrue(TEXT("rotate"), UModelingService::RotateMesh(U, FRotator(0, 45, 0)).bSuccess);
+	TestTrue(TEXT("scale"), UModelingService::ScaleMesh(U, FVector(1, 1, 2)).bSuccess);
+	TestTrue(TEXT("scaled height doubled"), FMath::IsNearlyEqual(UModelingService::GetMeshInfo(U).BoundsMax.Z, Before.BoundsMax.Z * 2.0, 0.1));
+	TestTrue(TEXT("recenter bounds"), UModelingService::RecenterMesh(U, TEXT("Bounds")).bSuccess);
+	TestTrue(TEXT("centered"), FMath::IsNearlyZero(UModelingService::GetMeshInfo(U).BoundsMin.Z + UModelingService::GetMeshInfo(U).BoundsMax.Z, 0.1));
+	TestTrue(TEXT("recenter base"), UModelingService::RecenterMesh(U, TEXT("Base")).bSuccess);
+	TestTrue(TEXT("on the floor"), FMath::IsNearlyZero(UModelingService::GetMeshInfo(U).BoundsMin.Z, 0.01));
+	TestFalse(TEXT("unknown recenter rejected"), UModelingService::RecenterMesh(U, TEXT("Sideways")).bSuccess);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeModelingQueriesTest, "VibeUE.Modeling.QueriesHulls", kModelingTestFlags)
+bool FVibeModelingQueriesTest::RunTest(const FString&)
+{
+	FScopedModelingSession Session;
+	const int32 S = MakeSphere(50.f);
+	const FModelingSurfacePoint Hit = UModelingService::RayCast(S, FVector(-200, 0, 0), FVector(1, 0, 0));
+	TestTrue(TEXT("ray hits"), Hit.bFound);
+	TestTrue(TEXT("ray hit near x=-50"), FMath::IsNearlyEqual(Hit.Position.X, -50.0, 2.0));
+	TestFalse(TEXT("ray miss"), UModelingService::RayCast(S, FVector(-200, 500, 0), FVector(1, 0, 0)).bFound);
+	const FModelingSurfacePoint Near = UModelingService::NearestPoint(S, FVector(0, 0, 120));
+	TestTrue(TEXT("nearest found"), Near.bFound && FMath::IsNearlyEqual(Near.Position.Z, 50.0, 2.0));
+	TestTrue(TEXT("origin inside"), UModelingService::IsPointInside(S, FVector::ZeroVector));
+	TestFalse(TEXT("far point outside"), UModelingService::IsPointInside(S, FVector(0, 0, 500)));
+	TestTrue(TEXT("samples"), UModelingService::SampleSurfacePoints(S, 15.f).Num() > 20);
+
+	const FModelingResult Hull = UModelingService::ConvexHull(S);
+	TestTrue(TEXT("convex hull"), Hull.bSuccess && Hull.TriangleCount > 0 && Hull.Handle != S);
+	const FModelingDistanceReport Report = UModelingService::MeasureDistance(S, Hull.Handle);
+	TestTrue(TEXT("distance measured"), Report.bSuccess);
+	TestTrue(TEXT("hull hugs sphere"), Report.MaxDistance < 5.f);
+	const int32 Boxes = MakeBox();
+	UModelingService::AppendBox(Boxes, FTransform(FVector(150, 0, 0)), 50.f, 50.f, 50.f);
+	const FModelingResult Decomp = UModelingService::ConvexDecomposition(Boxes, 2);
+	TestTrue(TEXT("convex decomposition"), Decomp.bSuccess && Decomp.TriangleCount > 0);
+	const FModelingResult Swept = UModelingService::SweptHull(S, FTransform::Identity);
+	TestTrue(TEXT("swept hull"), Swept.bSuccess && Swept.TriangleCount > 0);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeModelingAssetsTest, "VibeUE.Modeling.Assets", kModelingTestFlags)
+bool FVibeModelingAssetsTest::RunTest(const FString&)
+{
+	FScopedModelingSession Session;
+	const FString AssetPath = FString(kModelingTestDir) / TEXT("SM_ModelingTest");
+	if (UEditorAssetLibrary::DoesDirectoryExist(kModelingTestDir))
+	{
+		UEditorAssetLibrary::DeleteDirectory(kModelingTestDir);
+	}
+
+	const int32 H = MakeBox();
+	UModelingService::AutoUV(H, TEXT("XAtlas"), 0);
+	const FModelingResult Saved = UModelingService::SaveMeshToStaticMesh(H, AssetPath, true, true, false, false);
+	TestTrue(FString::Printf(TEXT("save creates asset: %s"), *Saved.Message), Saved.bSuccess);
+	TestTrue(TEXT("asset exists"), UEditorAssetLibrary::DoesAssetExist(AssetPath));
+	TestFalse(TEXT("replace refused when disabled"), UModelingService::SaveMeshToStaticMesh(H, AssetPath, false, true, false, false).bSuccess);
+	TestTrue(TEXT("replace LOD0"), UModelingService::SaveMeshToStaticMesh(H, AssetPath, true, true, false, false).bSuccess);
+
+	const FModelingResult Loaded = UModelingService::LoadMeshFromStaticMesh(AssetPath, 0);
+	TestTrue(TEXT("load back"), Loaded.bSuccess && Loaded.TriangleCount == 12);
+	TestTrue(TEXT("collision"), UModelingService::GenerateCollision(AssetPath, TEXT("ConvexHulls"), 2, 25, false).bSuccess);
+	TestFalse(TEXT("unknown collision method rejected"), UModelingService::GenerateCollision(AssetPath, TEXT("Blobs"), 1, 25, false).bSuccess);
+	const FModelingResult LODs = UModelingService::SetLODs(AssetPath, { 1.f, 0.5f }, true, false);
+	TestTrue(FString::Printf(TEXT("lods: %s"), *LODs.Message), LODs.bSuccess);
+
+	const FModelingResult Spawned = UModelingService::SpawnStaticMeshActor(AssetPath, FTransform(FVector(0, 0, -5000)), TEXT("VibeUEModelingTestActor"));
+	TestTrue(TEXT("spawn"), Spawned.bSuccess);
+	const FModelingResult FromActor = UModelingService::LoadMeshFromActor(TEXT("VibeUEModelingTestActor"), true, 0);
+	TestTrue(TEXT("load from actor"), FromActor.bSuccess && FromActor.TriangleCount == 12);
+	TestTrue(TEXT("world space applied"), UModelingService::GetMeshInfo(FromActor.Handle).BoundsMin.Z < -4000.0);
+
+	const int32 Source = MakeSphere(60.f);
+	const FModelingBakeResult Bake = UModelingService::BakeTextures(H, Source, TEXT("TangentNormal,AmbientOcclusion"), 64, kModelingTestDir, TEXT("ModelingTest"));
+	TestTrue(FString::Printf(TEXT("bake: %s"), *Bake.Message), Bake.bSuccess);
+	TestEqual(TEXT("two textures"), Bake.TexturePaths.Num(), 2);
+	TestFalse(TEXT("unknown bake type rejected"), UModelingService::BakeTextures(H, Source, TEXT("Sparkle"), 64, kModelingTestDir, TEXT("X")).bSuccess);
+
+	// Cleanup: actor, then the whole test folder.
+	if (UEditorActorSubsystem* Actors = GEditor ? GEditor->GetEditorSubsystem<UEditorActorSubsystem>() : nullptr)
+	{
+		for (AActor* Actor : Actors->GetAllLevelActors())
+		{
+			if (Actor && Actor->GetActorLabel() == TEXT("VibeUEModelingTestActor"))
+			{
+				Actors->DestroyActor(Actor);
+			}
+		}
+	}
+	UModelingService::ReleaseAllMeshes();
+	TestTrue(TEXT("test folder removed"), UEditorAssetLibrary::DeleteDirectory(kModelingTestDir));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeModelingErrorsTest, "VibeUE.Modeling.Errors", kModelingTestFlags)
+bool FVibeModelingErrorsTest::RunTest(const FString&)
+{
+	FScopedModelingSession Session;
+	const FModelingResult NoHandle = UModelingService::AppendBox(999, FTransform::Identity);
+	TestFalse(TEXT("unknown handle fails"), NoHandle.bSuccess);
+	TestTrue(TEXT("unknown handle explains"), NoHandle.Message.Contains(TEXT("create_mesh")));
+	const int32 H = MakeBox();
+	const FModelingResult BadOp = UModelingService::Boolean(H, H, TEXT("Frobnicate"), FTransform::Identity);
+	TestTrue(TEXT("bad enum lists values"), !BadOp.bSuccess && BadOp.Message.Contains(TEXT("Union")));
+	TestFalse(TEXT("empty mesh cannot be saved"), UModelingService::SaveMeshToStaticMesh(UModelingService::CreateMesh().Handle, TEXT("/Game/Developers/Nope"), true, true, false, false).bSuccess);
+	TestFalse(TEXT("relative asset path rejected"), UModelingService::SaveMeshToStaticMesh(H, TEXT("Nope"), true, true, false, false).bSuccess);
+	TestFalse(TEXT("missing texture rejected"), UModelingService::DisplaceFromTexture(H, TEXT(""), TEXT("/Game/Developers/DoesNotExist"), 1.f).bSuccess);
+	TestFalse(TEXT("missing skeleton rejected"), UModelingService::SmoothBoneWeights(H, TEXT("/Game/Developers/NoSkeleton")).bSuccess);
+	TestFalse(TEXT("empty bone list rejected"), UModelingService::PruneBoneWeights(H, TEXT(" , ")).bSuccess);
+	TestEqual(TEXT("selection on unknown handle"), UModelingService::SelectAll(4242, TEXT("x")), -1);
+	TestFalse(TEXT("ray cast on unknown handle"), UModelingService::RayCast(4242, FVector::ZeroVector, FVector::UpVector).bFound);
+	return true;
+}
+
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/VibeUE/Private/PythonAPI/ModelingServiceTests.cpp
+++ b/Source/VibeUE/Private/PythonAPI/ModelingServiceTests.cpp
@@ -6,6 +6,8 @@
 
 #include "PythonAPI/UModelingService.h"
 #include "EditorAssetLibrary.h"
+#include "Animation/Skeleton.h"
+#include "AssetCompilingManager.h"
 #include "Editor.h"
 #include "GameFramework/Actor.h"
 #include "Subsystems/EditorActorSubsystem.h"
@@ -362,6 +364,7 @@ bool FVibeModelingAssetsTest::RunTest(const FString&)
 			}
 		}
 	}
+	FAssetCompilingManager::Get().FinishAllCompilation();
 	UModelingService::ReleaseAllMeshes();
 	TestTrue(TEXT("test folder removed"), UEditorAssetLibrary::DeleteDirectory(kModelingTestDir));
 	return true;
@@ -384,6 +387,79 @@ bool FVibeModelingErrorsTest::RunTest(const FString&)
 	TestFalse(TEXT("empty bone list rejected"), UModelingService::PruneBoneWeights(H, TEXT(" , ")).bSuccess);
 	TestEqual(TEXT("selection on unknown handle"), UModelingService::SelectAll(4242, TEXT("x")), -1);
 	TestFalse(TEXT("ray cast on unknown handle"), UModelingService::RayCast(4242, FVector::ZeroVector, FVector::UpVector).bFound);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeModelingRiggingTest, "VibeUE.Modeling.LoftsRigging", kModelingTestFlags)
+bool FVibeModelingRiggingTest::RunTest(const FString&)
+{
+	FScopedModelingSession Session;
+
+	// Loft: a tapered wing section must come out closed and outward-facing whatever the sweep's winding.
+	const int32 Wing = UModelingService::CreateMesh().Handle;
+	const TArray<FVector2D> Profile = { FVector2D(0, 0), FVector2D(0.3, 0.06), FVector2D(0.7, 0.04), FVector2D(1, 0), FVector2D(0.7, -0.04), FVector2D(0.3, -0.06) };
+	const TArray<FTransform> Frames = {
+		FTransform(FRotator(0, 90, 0), FVector(0, 0, 0), FVector(200)),
+		FTransform(FRotator(0, 90, 0), FVector(-50, 400, 0), FVector(100)) };
+	const FModelingResult Loft = UModelingService::AppendLoft(Wing, FTransform::Identity, Profile, Frames);
+	TestTrue(FString::Printf(TEXT("loft: %s"), *Loft.Message), Loft.bSuccess);
+	const FModelingMeshInfo WingInfo = UModelingService::GetMeshInfo(Wing);
+	TestTrue(TEXT("loft is closed"), WingInfo.bIsClosed);
+	TestTrue(TEXT("loft faces outward"), WingInfo.Volume > 0.f);
+	TestTrue(TEXT("loft spans the frames"), WingInfo.BoundsMax.Y > 390.0 && WingInfo.BoundsMin.X < -150.0);
+	UModelingService::FlipNormals(Wing);
+	TestTrue(TEXT("flipped volume is negative"), UModelingService::GetMeshInfo(Wing).Volume < 0.f);
+	TestTrue(TEXT("ensure_outward flips"), UModelingService::EnsureOutward(Wing).Message.Contains(TEXT("Flipped")));
+	TestTrue(TEXT("volume positive again"), UModelingService::GetMeshInfo(Wing).Volume > 0.f);
+	TestTrue(TEXT("ensure_outward is idempotent"), UModelingService::EnsureOutward(Wing).Message.Contains(TEXT("Already")));
+	TestFalse(TEXT("open profile rejected"), UModelingService::AppendLoft(Wing, FTransform::Identity, { FVector2D(0, 0), FVector2D(1, 0) }, Frames).bSuccess);
+
+	// Rig: a body box and a separate flap box, the flap bound to its own bone.
+	const int32 H = MakeBox(100.f);
+	UModelingService::AppendBox(H, FTransform(FVector(0, 200, 0)), 50.f, 50.f, 50.f);
+	TestEqual(TEXT("two components"), UModelingService::GetMeshInfo(H).ConnectedComponents, 2);
+	TestEqual(TEXT("select_connected grabs the flap"), UModelingService::SelectConnected(H, TEXT("flap"), FVector(0, 200, 25)), 12);
+	TestEqual(TEXT("select_connected grabs the body"), UModelingService::SelectConnected(H, TEXT("body"), FVector(0, 0, 50)), 12);
+
+	FModelingBoneDef Root;
+	Root.Name = TEXT("root");
+	FModelingBoneDef Flap;
+	Flap.Name = TEXT("flap");
+	Flap.ParentName = TEXT("root");
+	Flap.Transform = FTransform(FVector(0, 175, 0));
+	const FModelingResult Rig = UModelingService::CreateBones(H, { Root, Flap });
+	TestTrue(FString::Printf(TEXT("create_bones: %s"), *Rig.Message), Rig.bSuccess);
+	TestTrue(TEXT("bind flap"), UModelingService::BindSelectionToBone(H, TEXT("flap"), TEXT("flap"), 1.f).bSuccess);
+	const TArray<FModelingBoneInfo> Bones = UModelingService::ListBones(H);
+	TestEqual(TEXT("two bones"), Bones.Num(), 2);
+	if (Bones.Num() == 2)
+	{
+		TestEqual(TEXT("root influences the body"), Bones[0].InfluencedVertices, 8);
+		TestEqual(TEXT("flap influences the flap"), Bones[1].InfluencedVertices, 8);
+		TestEqual(TEXT("flap parent"), Bones[1].ParentName, FString(TEXT("root")));
+		TestTrue(TEXT("flap mesh-space pose"), Bones[1].MeshTransform.GetLocation().Equals(FVector(0, 175, 0), 0.01));
+	}
+	TestFalse(TEXT("unknown bone rejected"), UModelingService::BindSelectionToBone(H, TEXT("flap"), TEXT("nope")).bSuccess);
+	TestFalse(TEXT("child before parent rejected"), UModelingService::CreateBones(Wing, { Flap, Root }).bSuccess);
+	TestFalse(TEXT("stale selection rejected"), UModelingService::BindSelectionToBone(Wing, TEXT("missing"), TEXT("root")).bSuccess);
+
+	// Save as a skeletal mesh with a freshly created skeleton, assign materials, then clean up.
+	const FString MeshPath = FString(kModelingTestDir) + TEXT("/SK_ModelingRig");
+	const FModelingResult Saved = UModelingService::SaveMeshToSkeletalMesh(H, MeshPath, TEXT(""), true, false);
+	TestTrue(FString::Printf(TEXT("save skeletal: %s"), *Saved.Message), Saved.bSuccess);
+	TestTrue(TEXT("skeletal mesh asset exists"), UEditorAssetLibrary::DoesAssetExist(MeshPath));
+	TestTrue(TEXT("skeleton asset created"), UEditorAssetLibrary::DoesAssetExist(MeshPath + TEXT("_Skeleton")));
+	if (USkeleton* Skeleton = Cast<USkeleton>(UEditorAssetLibrary::LoadAsset(MeshPath + TEXT("_Skeleton"))))
+	{
+		TestEqual(TEXT("skeleton has both bones"), Skeleton->GetReferenceSkeleton().GetRawBoneNum(), 2);
+		TestEqual(TEXT("flap bone in skeleton"), Skeleton->GetReferenceSkeleton().FindRawBoneIndex(TEXT("flap")), 1);
+	}
+	TestTrue(TEXT("set materials"), UModelingService::SetAssetMaterials(MeshPath, TEXT("/Engine/BasicShapes/BasicShapeMaterial"), false).bSuccess);
+	TestFalse(TEXT("missing material rejected"), UModelingService::SetAssetMaterials(MeshPath, TEXT("/Game/Developers/NoSuchMaterial"), false).bSuccess);
+	TestFalse(TEXT("skeletal save without weights rejected"), UModelingService::SaveMeshToSkeletalMesh(MakeBox(), FString(kModelingTestDir) + TEXT("/SK_NoWeights"), TEXT(""), true, false).bSuccess);
+	FAssetCompilingManager::Get().FinishAllCompilation();
+	UModelingService::ReleaseAllMeshes();
+	TestTrue(TEXT("test folder removed"), UEditorAssetLibrary::DeleteDirectory(kModelingTestDir));
 	return true;
 }
 

--- a/Source/VibeUE/Private/PythonAPI/ModelingServiceTests.cpp
+++ b/Source/VibeUE/Private/PythonAPI/ModelingServiceTests.cpp
@@ -8,6 +8,10 @@
 #include "EditorAssetLibrary.h"
 #include "Animation/Skeleton.h"
 #include "AssetCompilingManager.h"
+#include "HAL/FileManager.h"
+#include "ImageUtils.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
 #include "Editor.h"
 #include "GameFramework/Actor.h"
 #include "Subsystems/EditorActorSubsystem.h"
@@ -457,6 +461,103 @@ bool FVibeModelingRiggingTest::RunTest(const FString&)
 	TestTrue(TEXT("set materials"), UModelingService::SetAssetMaterials(MeshPath, TEXT("/Engine/BasicShapes/BasicShapeMaterial"), false).bSuccess);
 	TestFalse(TEXT("missing material rejected"), UModelingService::SetAssetMaterials(MeshPath, TEXT("/Game/Developers/NoSuchMaterial"), false).bSuccess);
 	TestFalse(TEXT("skeletal save without weights rejected"), UModelingService::SaveMeshToSkeletalMesh(MakeBox(), FString(kModelingTestDir) + TEXT("/SK_NoWeights"), TEXT(""), true, false).bSuccess);
+	FAssetCompilingManager::Get().FinishAllCompilation();
+	UModelingService::ReleaseAllMeshes();
+	TestTrue(TEXT("test folder removed"), UEditorAssetLibrary::DeleteDirectory(kModelingTestDir));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeModelingUVsTexturingTest, "VibeUE.Modeling.UVsTexturing", kModelingTestFlags)
+bool FVibeModelingUVsTexturingTest::RunTest(const FString&)
+{
+	FScopedModelingSession Session;
+	const FString Dir = kModelingTestDir;
+
+	// --- UV control on a two-material box: one polygroup per face, conformal unwrap, pack, verify
+	const int32 H = MakeBox(100.f);
+	UModelingService::SelectByNormalAngle(H, TEXT("top"), FVector::UpVector, 5.f);
+	UModelingService::SetMaterialID(H, TEXT("top"), 1);
+	TestTrue(TEXT("polygroups by angle"), UModelingService::ComputePolygroups(H, TEXT("Angle"), 15.f, 1).bSuccess);
+	const FModelingResult Group = UModelingService::SetPolygroup(H, TEXT("top"), -1);
+	TestTrue(FString::Printf(TEXT("set_polygroup: %s"), *Group.Message), Group.bSuccess);
+	const FModelingResult Unwrap = UModelingService::RecomputeUVs(H, 0, TEXT("Polygroups"), TEXT("SpectralConformal"));
+	TestTrue(FString::Printf(TEXT("recompute_uvs: %s"), *Unwrap.Message), Unwrap.bSuccess);
+	TestTrue(TEXT("repack"), UModelingService::LayoutUV(H, 0, TEXT("Repack"), TEXT(""), 512).bSuccess);
+	FModelingUVStats Stats = UModelingService::GetUVStats(H, 0, 256);
+	TestTrue(FString::Printf(TEXT("uv stats: %s"), *Stats.Message), Stats.bSuccess);
+	TestEqual(TEXT("one island per face"), Stats.NumIslands, 6);
+	TestEqual(TEXT("no unset triangles"), Stats.NumUnsetTriangles, 0);
+	TestTrue(TEXT("packed islands do not overlap"), Stats.OverlapFraction < 0.01f);
+	TestTrue(TEXT("packed islands cover the square"), Stats.Coverage > 0.05f);
+	TestTrue(TEXT("texel density reported"), Stats.TexelsPerCmAt1K > 0.f);
+	TestTrue(TEXT("transform_uv"), UModelingService::TransformUV(H, 0, TEXT("top"), FVector2D(0.05, 0), FVector2D(1, 1), 0.f).bSuccess);
+	TestTrue(TEXT("pack per material"), UModelingService::PackUVPerMaterial(H, 0, 512).bSuccess);
+	Stats = UModelingService::GetUVStats(H, 0, 256);
+	TestTrue(TEXT("per-material packs overlap each other by design"), Stats.OverlapFraction > 0.f);
+	FVector2D UV;
+	TestTrue(TEXT("world_to_uv finds the top face"), UModelingService::WorldToUV(H, FVector(0, 0, 100), 0, UV));
+	TestTrue(TEXT("uv inside the square"), UV.X >= -0.01 && UV.X <= 1.01 && UV.Y >= -0.01 && UV.Y <= 1.01);
+	TestFalse(TEXT("bad island source rejected"), UModelingService::RecomputeUVs(H, 0, TEXT("Vibes")).bSuccess);
+	TestFalse(TEXT("bad layout type rejected"), UModelingService::LayoutUV(H, 0, TEXT("Sideways")).bSuccess);
+	TestFalse(TEXT("missing uv layer rejected"), UModelingService::TransformUV(H, 7, TEXT(""), FVector2D::ZeroVector, FVector2D(1, 1)).bSuccess);
+
+	// --- Bakes: masks from vertex colours / material ids, the UV shell wireframe, height
+	UModelingService::SetVertexColor(H, TEXT(""), FLinearColor::Red);
+	const FModelingBakeResult Masks = UModelingService::BakeTextures(H, H, TEXT("VertexColor,MaterialID,UVShell,Height"), 64, Dir, TEXT("UVTest"));
+	TestTrue(FString::Printf(TEXT("mask bakes: %s"), *Masks.Message), Masks.bSuccess);
+	TestEqual(TEXT("four mask textures"), Masks.TexturePaths.Num(), 4);
+
+	// --- Image tools: noise, drawing, import, texture transfer
+	const FString NoisePath = Dir + TEXT("/T_Noise");
+	const FModelingResult Noise = UModelingService::CreateNoiseTexture(NoisePath, 64, 64, 4.f, 3, 0.5f, 7, false);
+	TestTrue(FString::Printf(TEXT("noise: %s"), *Noise.Message), Noise.bSuccess);
+	TestTrue(TEXT("noise asset exists"), UEditorAssetLibrary::DoesAssetExist(NoisePath));
+	TestTrue(TEXT("draw line"), UModelingService::DrawOnTexture(NoisePath, TEXT("Line"), { FVector2D(0.1, 0.1), FVector2D(0.9, 0.9) }, FLinearColor::White, 3.f, 8.f, false).bSuccess);
+	TestTrue(TEXT("draw dots"), UModelingService::DrawOnTexture(NoisePath, TEXT("Dots"), { FVector2D(0.1, 0.9), FVector2D(0.9, 0.1) }, FLinearColor::Black, 2.f, 6.f, false).bSuccess);
+	TestTrue(TEXT("draw rect"), UModelingService::DrawOnTexture(NoisePath, TEXT("Rect"), { FVector2D(0.2, 0.2), FVector2D(0.4, 0.4) }, FLinearColor::Gray, 1.f, 1.f, false).bSuccess);
+	TestFalse(TEXT("unknown shape rejected"), UModelingService::DrawOnTexture(NoisePath, TEXT("Spiral"), {}, FLinearColor::White).bSuccess);
+	TestFalse(TEXT("draw on missing texture rejected"), UModelingService::DrawOnTexture(Dir + TEXT("/T_Nope"), TEXT("Fill"), {}, FLinearColor::White).bSuccess);
+
+	const FString PngPath = FPaths::ProjectSavedDir() / TEXT("VibeUEModelingTest.png");
+	{
+		TArray<FColor> Pixels;
+		Pixels.Init(FColor(200, 40, 40, 255), 8 * 8);
+		TArray64<uint8> Png;
+		FImageUtils::PNGCompressImageArray(8, 8, Pixels, Png);
+		TestTrue(TEXT("test png written"), FFileHelper::SaveArrayToFile(Png, *PngPath));
+	}
+	const FModelingResult Imported = UModelingService::ImportTexture(PngPath, Dir + TEXT("/T_Imported"), false, TEXT("Masks"), false);
+	TestTrue(FString::Printf(TEXT("import: %s"), *Imported.Message), Imported.bSuccess);
+	TestTrue(TEXT("imported asset exists"), UEditorAssetLibrary::DoesAssetExist(Dir + TEXT("/T_Imported")));
+	TestFalse(TEXT("missing file rejected"), UModelingService::ImportTexture(PngPath + TEXT(".missing"), Dir + TEXT("/T_Nope"), false).bSuccess);
+	TestFalse(TEXT("bad compression rejected"), UModelingService::ImportTexture(PngPath, Dir + TEXT("/T_Nope"), false, TEXT("Crunchy")).bSuccess);
+
+	const FModelingBakeResult Transfer = UModelingService::BakeTextureTransfer(H, H, NoisePath, 64, Dir, TEXT("Xfer"));
+	TestTrue(FString::Printf(TEXT("texture transfer: %s"), *Transfer.Message), Transfer.bSuccess);
+	const FModelingBakeResult MultiTransfer = UModelingService::BakeTextureTransfer(H, H, NoisePath + TEXT(",") + Dir + TEXT("/T_Imported"), 64, Dir, TEXT("Xfer2"));
+	TestTrue(FString::Printf(TEXT("multi-texture transfer: %s"), *MultiTransfer.Message), MultiTransfer.bSuccess);
+	TestFalse(TEXT("missing source texture rejected"), UModelingService::BakeTextureTransfer(H, H, Dir + TEXT("/T_Nope"), 64, Dir, TEXT("X")).bSuccess);
+
+	// --- Surface detail: stamps and grooves
+	const int32 Rivet = MakeSphere(2.f);
+	const int32 RivetTris = UModelingService::GetMeshInfo(Rivet).TriangleCount;
+	const int32 Before = UModelingService::GetMeshInfo(H).TriangleCount;
+	TestTrue(TEXT("stamp at transforms"), UModelingService::AppendMeshAtTransforms(H, Rivet, { FTransform(FVector(-30, 0, 100)), FTransform(FVector(0, 0, 100)), FTransform(FVector(30, 0, 100)) }).bSuccess);
+	TestEqual(TEXT("three stamps added"), UModelingService::GetMeshInfo(H).TriangleCount, Before + 3 * RivetTris);
+	const FModelingResult Row = UModelingService::AppendMeshAlongPolyline(H, Rivet, { FVector(-40, 20, 100), FVector(40, 20, 100) }, 20.f);
+	TestTrue(FString::Printf(TEXT("stamp along polyline: %s"), *Row.Message), Row.bSuccess);
+	TestEqual(TEXT("five stamps along 80 cm at 20 cm"), UModelingService::GetMeshInfo(H).TriangleCount, Before + 8 * RivetTris);
+	TestFalse(TEXT("self stamp rejected"), UModelingService::AppendMeshAtTransforms(H, H, { FTransform::Identity }).bSuccess);
+	const int32 Slab = MakeBox(100.f);
+	const int32 SlabBefore = UModelingService::GetMeshInfo(Slab).TriangleCount;
+	const FModelingResult Groove = UModelingService::CutGrooveAlongPolyline(Slab, { FVector(-60, -30, 100), FVector(0, -30, 100), FVector(60, 0, 100) }, 2.f, 1.f);
+	TestTrue(FString::Printf(TEXT("groove: %s"), *Groove.Message), Groove.bSuccess);
+	const FModelingMeshInfo SlabInfo = UModelingService::GetMeshInfo(Slab);
+	TestTrue(TEXT("groove added geometry"), SlabInfo.TriangleCount > SlabBefore);
+	TestTrue(TEXT("grooved slab still closed"), SlabInfo.bIsClosed);
+	TestFalse(TEXT("groove needs two points"), UModelingService::CutGrooveAlongPolyline(Slab, { FVector::ZeroVector }, 2.f, 1.f).bSuccess);
+
+	IFileManager::Get().Delete(*PngPath);
 	FAssetCompilingManager::Get().FinishAllCompilation();
 	UModelingService::ReleaseAllMeshes();
 	TestTrue(TEXT("test folder removed"), UEditorAssetLibrary::DeleteDirectory(kModelingTestDir));

--- a/Source/VibeUE/Private/PythonAPI/UModelingService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UModelingService.cpp
@@ -33,6 +33,13 @@
 #include "GeometryScript/CollisionFunctions.h"
 #include "GeometryScript/CreateNewAssetUtilityFunctions.h"
 #include "GeometryScript/OpenSubdivUtilityFunctions.h"
+#include "GeometryScript/MeshSpatialFunctions.h"
+#include "GeometryScript/MeshSamplingFunctions.h"
+#include "GeometryScript/ContainmentFunctions.h"
+#include "GeometryScript/MeshComparisonFunctions.h"
+#include "GeometryScript/MeshSelectionQueryFunctions.h"
+#include "GeometryScript/SceneUtilityFunctions.h"
+#include "Components/MeshComponent.h"
 
 #include "Animation/Skeleton.h"
 #include "Components/StaticMeshComponent.h"
@@ -59,10 +66,18 @@ using namespace UE::Geometry;
 
 namespace
 {
+	/** A named selection plus the mesh counts it was made against, so a stale one can be refused. */
+	struct FStoredSelection
+	{
+		FGeometryScriptMeshSelection Selection;
+		int32 TriangleCount = 0;
+		int32 VertexCount = 0;
+	};
+
 	struct FModelingSession
 	{
 		TMap<int32, TStrongObjectPtr<UDynamicMesh>> Meshes;
-		TMap<int32, TMap<FString, FGeometryScriptMeshSelection>> Selections;
+		TMap<int32, TMap<FString, FStoredSelection>> Selections;
 		int32 NextHandle = 1;
 		bool bExitHooked = false;
 
@@ -225,10 +240,39 @@ namespace
 
 	void StoreSelection(int32 Handle, const FString& Name, const FGeometryScriptMeshSelection& Selection)
 	{
-		Session().Selections.FindOrAdd(Handle).Add(Name, Selection);
+		FStoredSelection Stored;
+		Stored.Selection = Selection;
+		Stored.TriangleCount = TriCount(FindMesh(Handle));
+		Stored.VertexCount = VertCount(FindMesh(Handle));
+		Session().Selections.FindOrAdd(Handle).Add(Name, Stored);
 	}
 
-	/** "" resolves to the whole mesh as a triangle selection. */
+	/** Every element id the selection references must still exist — GeometryScript asserts on stale ids instead of failing. */
+	bool SelectionIsValidForMesh(UDynamicMesh* Mesh, const FGeometryScriptMeshSelection& Selection)
+	{
+		FGeometryScriptIndexList IndexList;
+		EGeometryScriptIndexType ResultType = EGeometryScriptIndexType::Any;
+		UGeometryScriptLibrary_MeshSelectionFunctions::ConvertMeshSelectionToIndexList(Mesh, Selection, IndexList, ResultType, EGeometryScriptIndexType::Any);
+		if (!IndexList.List.IsValid() || ResultType == EGeometryScriptIndexType::PolygroupID || ResultType == EGeometryScriptIndexType::Any)
+		{
+			return true;
+		}
+		bool bValid = true;
+		Mesh->ProcessMesh([&](const FDynamicMesh3& M)
+		{
+			for (const int32 Id : *IndexList.List)
+			{
+				const bool bExists =
+					ResultType == EGeometryScriptIndexType::Triangle ? M.IsTriangle(Id) :
+					ResultType == EGeometryScriptIndexType::Vertex ? M.IsVertex(Id) :
+					ResultType == EGeometryScriptIndexType::Edge ? M.IsEdge(Id) : true;
+				if (!bExists) { bValid = false; return; }
+			}
+		});
+		return bValid;
+	}
+
+	/** "" resolves to the whole mesh as a triangle selection; a named selection must predate no topology change. */
 	bool ResolveSelection(int32 Handle, const FString& Name, UDynamicMesh* Mesh, FGeometryScriptMeshSelection& Out, FString& Error)
 	{
 		if (Name.IsEmpty())
@@ -236,14 +280,22 @@ namespace
 			UGeometryScriptLibrary_MeshSelectionFunctions::CreateSelectAllMeshSelection(Mesh, Out, EGeometryScriptMeshSelectionType::Triangles);
 			return true;
 		}
-		const TMap<FString, FGeometryScriptMeshSelection>* PerMesh = Session().Selections.Find(Handle);
-		const FGeometryScriptMeshSelection* Found = PerMesh ? PerMesh->Find(Name) : nullptr;
+		const TMap<FString, FStoredSelection>* PerMesh = Session().Selections.Find(Handle);
+		const FStoredSelection* Found = PerMesh ? PerMesh->Find(Name) : nullptr;
 		if (!Found)
 		{
 			Error = FString::Printf(TEXT("No selection named '%s' on handle %d (make one with select_all / select_by_normal_angle / select_in_box / ...)"), *Name, Handle);
 			return false;
 		}
-		Out = *Found;
+		const int32 Tris = TriCount(Mesh);
+		const int32 Verts = VertCount(Mesh);
+		if (Tris != Found->TriangleCount || Verts != Found->VertexCount || !SelectionIsValidForMesh(Mesh, Found->Selection))
+		{
+			Error = FString::Printf(TEXT("Selection '%s' is stale: handle %d changed since it was made (%d -> %d triangles). Re-run the select_* call after any op that changes topology."),
+				*Name, Handle, Found->TriangleCount, Tris);
+			return false;
+		}
+		Out = Found->Selection;
 		return true;
 	}
 
@@ -266,6 +318,11 @@ namespace
 	template <typename T>
 	T* LoadAssetAs(const FString& AssetPath)
 	{
+		// DoesAssetExist first: LoadAsset logs an error for a missing path, which agents (and automation) read as a failure of their own.
+		if (AssetPath.IsEmpty() || !UEditorAssetLibrary::DoesAssetExist(AssetPath))
+		{
+			return nullptr;
+		}
 		return Cast<T>(UEditorAssetLibrary::LoadAsset(AssetPath));
 	}
 
@@ -370,28 +427,47 @@ FModelingResult UModelingService::LoadMeshFromActor(const FString& ActorLabel, b
 	{
 		return Fail(-1, FString::Printf(TEXT("No level actor labeled '%s'"), *ActorLabel));
 	}
-	UStaticMeshComponent* Component = Actor->FindComponentByClass<UStaticMeshComponent>();
-	UStaticMesh* StaticMesh = Component ? Component->GetStaticMesh() : nullptr;
-	if (!StaticMesh)
-	{
-		return Fail(-1, FString::Printf(TEXT("Actor '%s' has no StaticMeshComponent with a mesh"), *ActorLabel));
-	}
+	UStaticMeshComponent* StaticComponent = Actor->FindComponentByClass<UStaticMeshComponent>();
+	UStaticMesh* StaticMesh = StaticComponent ? StaticComponent->GetStaticMesh() : nullptr;
 	int32 Handle = -1;
 	UDynamicMesh* Mesh = NewSessionMesh(Handle);
 	UGeometryScriptDebug* Debug = NewDebug();
-	if (!CopyFromStaticMesh(StaticMesh, Mesh, LODIndex, Debug))
+	if (StaticMesh)
+	{
+		if (!CopyFromStaticMesh(StaticMesh, Mesh, LODIndex, Debug))
+		{
+			ReleaseMesh(Handle);
+			return Fail(-1, FString::Printf(TEXT("Could not read %s: %s"), *StaticMesh->GetPathName(), *DebugText(Debug)));
+		}
+		if (bWorldSpace)
+		{
+			UGeometryScriptLibrary_MeshTransformFunctions::TransformMesh(Mesh, StaticComponent->GetComponentTransform(), true, Debug);
+		}
+		FModelingResult R = Ok(Handle, Mesh, FString::Printf(TEXT("Loaded %s from actor '%s'%s"), *StaticMesh->GetPathName(), *ActorLabel,
+			bWorldSpace ? TEXT(" in world space") : TEXT(" in asset space")));
+		R.AssetPath = StaticMesh->GetPathName();
+		return R;
+	}
+
+	// Anything else that renders a mesh (skeletal mesh, dynamic mesh, instanced components): copy its render geometry.
+	UMeshComponent* MeshComponent = Actor->FindComponentByClass<UMeshComponent>();
+	if (!MeshComponent)
 	{
 		ReleaseMesh(Handle);
-		return Fail(-1, FString::Printf(TEXT("Could not read %s: %s"), *StaticMesh->GetPathName(), *DebugText(Debug)));
+		return Fail(-1, FString::Printf(TEXT("Actor '%s' has no mesh component"), *ActorLabel));
 	}
-	if (bWorldSpace)
+	FGeometryScriptCopyMeshFromComponentOptions Options;
+	Options.RequestedLOD.LODIndex = LODIndex;
+	FTransform LocalToWorld;
+	EGeometryScriptOutcomePins Outcome = EGeometryScriptOutcomePins::Failure;
+	UGeometryScriptLibrary_SceneUtilityFunctions::CopyMeshFromComponent(MeshComponent, Mesh, Options, bWorldSpace, LocalToWorld, Outcome, Debug);
+	if (Outcome != EGeometryScriptOutcomePins::Success)
 	{
-		UGeometryScriptLibrary_MeshTransformFunctions::TransformMesh(Mesh, Component->GetComponentTransform(), true, Debug);
+		ReleaseMesh(Handle);
+		return Fail(-1, FString::Printf(TEXT("Could not copy geometry from '%s' (%s): %s"), *ActorLabel, *MeshComponent->GetClass()->GetName(), *DebugText(Debug)));
 	}
-	FModelingResult R = Ok(Handle, Mesh, FString::Printf(TEXT("Loaded %s from actor '%s'%s"), *StaticMesh->GetPathName(), *ActorLabel,
-		bWorldSpace ? TEXT(" in world space") : TEXT(" in asset space")));
-	R.AssetPath = StaticMesh->GetPathName();
-	return R;
+	return Ok(Handle, Mesh, FString::Printf(TEXT("Loaded %s geometry from actor '%s'%s"), *MeshComponent->GetClass()->GetName(), *ActorLabel,
+		bWorldSpace ? TEXT(" in world space") : TEXT(" in component space")));
 }
 
 FModelingResult UModelingService::CopyMesh(int32 Handle)
@@ -466,7 +542,7 @@ FModelingMeshInfo UModelingService::GetMeshInfo(int32 Handle)
 			}
 		}
 	});
-	if (const TMap<FString, FGeometryScriptMeshSelection>* PerMesh = Session().Selections.Find(Handle))
+	if (const TMap<FString, FStoredSelection>* PerMesh = Session().Selections.Find(Handle))
 	{
 		PerMesh->GetKeys(Info.Selections);
 	}
@@ -1319,13 +1395,43 @@ FModelingResult UModelingService::FlipNormals(int32 Handle)
 	return Finish(Handle, Mesh, Debug, TEXT("Flipped normals"));
 }
 
-FModelingResult UModelingService::ComputePolygroups(int32 Handle, float CreaseAngleDeg, int32 MinGroupSize)
+FModelingResult UModelingService::ComputePolygroups(int32 Handle, const FString& Method, float CreaseAngleDeg, int32 MinGroupSize)
 {
 	UDynamicMesh* Mesh = FindMesh(Handle);
 	if (!Mesh) { return NoMesh(Handle); }
 	UGeometryScriptDebug* Debug = NewDebug();
-	UGeometryScriptLibrary_MeshPolygroupFunctions::ComputePolygroupsFromAngleThreshold(Mesh, FGeometryScriptGroupLayer(), CreaseAngleDeg, MinGroupSize, Debug);
-	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Computed polygroups (crease %.1f degrees)"), CreaseAngleDeg));
+	const FGeometryScriptGroupLayer Layer;
+	if (Method.Equals(TEXT("Angle"), ESearchCase::IgnoreCase))
+	{
+		UGeometryScriptLibrary_MeshPolygroupFunctions::ComputePolygroupsFromAngleThreshold(Mesh, Layer, CreaseAngleDeg, MinGroupSize, Debug);
+	}
+	else if (Method.Equals(TEXT("UVIslands"), ESearchCase::IgnoreCase))
+	{
+		UGeometryScriptLibrary_MeshPolygroupFunctions::ConvertUVIslandsToPolygroups(Mesh, Layer, 0, Debug);
+	}
+	else if (Method.Equals(TEXT("Components"), ESearchCase::IgnoreCase))
+	{
+		UGeometryScriptLibrary_MeshPolygroupFunctions::ConvertComponentsToPolygroups(Mesh, Layer, Debug);
+	}
+	else if (Method.Equals(TEXT("Polygons"), ESearchCase::IgnoreCase))
+	{
+		UGeometryScriptLibrary_MeshPolygroupFunctions::ComputePolygroupsFromPolygonDetection(Mesh, Layer, true, false, 1.0, 1.0, 1, Debug);
+	}
+	else
+	{
+		return Fail(Handle, FString::Printf(TEXT("Unknown polygroup method '%s' (use Angle, UVIslands, Components, Polygons)"), *Method));
+	}
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Computed polygroups (%s)"), *Method));
+}
+
+FModelingResult UModelingService::RemapMaterialID(int32 Handle, int32 FromMaterialID, int32 ToMaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshMaterialFunctions::EnableMaterialIDs(Mesh, Debug);
+	UGeometryScriptLibrary_MeshMaterialFunctions::RemapMaterialIDs(Mesh, FromMaterialID, ToMaterialID, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Remapped material %d -> %d"), FromMaterialID, ToMaterialID));
 }
 
 FModelingResult UModelingService::SetMaterialID(int32 Handle, const FString& SelectionName, int32 MaterialID)
@@ -1625,6 +1731,8 @@ FModelingBakeResult UModelingService::BakeTextures(int32 TargetHandle, int32 Sou
 	}
 
 	UGeometryScriptDebug* Debug = NewDebug();
+	// The baker samples through the target's tangent frame; session meshes rarely carry tangents yet.
+	UGeometryScriptLibrary_MeshNormalsFunctions::ComputeTangents(Target, FGeometryScriptTangentsOptions(), Debug);
 	const TArray<UTexture2D*> Textures = UGeometryScriptLibrary_MeshBakeFunctions::BakeTexture(Target, FTransform::Identity, TargetOptions,
 		Source, FTransform::Identity, SourceOptions, Types, BakeOptions, Debug);
 	if (DebugHasErrors(Debug) || Textures.Num() != Types.Num())
@@ -1671,4 +1779,301 @@ FModelingResult UModelingService::SpawnStaticMeshActor(const FString& AssetPath,
 	R.AssetPath = AssetPath;
 	R.Message = FString::Printf(TEXT("Spawned '%s' (%s) at %s"), *Actor->GetActorLabel(), *Actor->GetPathName(), *Transform.GetLocation().ToCompactString());
 	return R;
+}
+
+// =========================================================================
+// More primitives
+// =========================================================================
+
+FModelingResult UModelingService::AppendCurvedStairs(int32 Handle, FTransform Transform, float StepWidth, float StepHeight, float InnerRadius,
+	float CurveAngle, int32 NumSteps, bool bFloating, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendCurvedStairs(Mesh, PrimitiveOptions(MaterialID), Transform, StepWidth, StepHeight, InnerRadius,
+		CurveAngle, NumSteps, bFloating, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Appended curved stairs"));
+}
+
+FModelingResult UModelingService::AppendSphereBox(int32 Handle, FTransform Transform, float Radius, int32 Steps, const FString& Origin, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	EGeometryScriptPrimitiveOriginMode OriginMode; FString Error;
+	if (!ParseOrigin(Origin, OriginMode, Error)) { return Fail(Handle, Error); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	const int32 S = FMath::Clamp(Steps, 1, 64);
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendSphereBox(Mesh, PrimitiveOptions(MaterialID), Transform, Radius, S, S, S, OriginMode, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Appended sphere box"));
+}
+
+FModelingResult UModelingService::AppendSweepPolyline(int32 Handle, FTransform Transform, const TArray<FVector2D>& ProfilePoints, const TArray<FTransform>& SweepPath,
+	bool bLoop, float StartScale, float EndScale, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	if (ProfilePoints.Num() < 2) { return Fail(Handle, TEXT("ProfilePoints needs at least 2 points")); }
+	if (SweepPath.Num() < 2) { return Fail(Handle, TEXT("SweepPath needs at least 2 transforms")); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	const TArray<float> NoTexParams;
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendSweepPolyline(Mesh, PrimitiveOptions(MaterialID), Transform, ProfilePoints, SweepPath,
+		NoTexParams, NoTexParams, bLoop, StartScale, EndScale, 0.f, 1.f, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Appended sweep (%d profile points along %d path frames)"), ProfilePoints.Num(), SweepPath.Num()));
+}
+
+// =========================================================================
+// More simplification
+// =========================================================================
+
+FModelingResult UModelingService::SimplifyToVertexCount(int32 Handle, int32 VertexCount, bool bAllowSeamCollapse)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptSimplifyMeshOptions Options;
+	Options.bAllowSeamCollapse = bAllowSeamCollapse;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshSimplifyFunctions::ApplySimplifyToVertexCount(Mesh, FMath::Max(4, VertexCount), Options, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Simplified toward %d vertices"), VertexCount));
+}
+
+FModelingResult UModelingService::SimplifyPlanar(int32 Handle, float AngleThresholdDeg)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptPlanarSimplifyOptions Options;
+	Options.AngleThreshold = AngleThresholdDeg;
+	UGeometryScriptDebug* Debug = NewDebug();
+	const int32 Before = TriCount(Mesh);
+	UGeometryScriptLibrary_MeshSimplifyFunctions::ApplySimplifyToPlanar(Mesh, Options, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Planar simplify (%d -> %d triangles)"), Before, TriCount(Mesh)));
+}
+
+// =========================================================================
+// Spatial queries and sampling
+// =========================================================================
+
+FModelingSurfacePoint UModelingService::RayCast(int32 Handle, FVector Origin, FVector Direction, float MaxDistance)
+{
+	FModelingSurfacePoint Result;
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { Result.Message = NoMesh(Handle).Message; return Result; }
+	if (Direction.IsNearlyZero()) { Result.Message = TEXT("Direction must be non-zero"); return Result; }
+	UGeometryScriptDebug* Debug = NewDebug();
+	FGeometryScriptDynamicMeshBVH BVH;
+	UGeometryScriptLibrary_MeshSpatial::BuildBVHForMesh(Mesh, BVH, Debug);
+	FGeometryScriptSpatialQueryOptions Options;
+	Options.MaxDistance = MaxDistance;
+	FGeometryScriptRayHitResult Hit;
+	EGeometryScriptSearchOutcomePins Outcome = EGeometryScriptSearchOutcomePins::NotFound;
+	UGeometryScriptLibrary_MeshSpatial::FindNearestRayIntersectionWithMesh(Mesh, BVH, Origin, Direction.GetSafeNormal(), Options, Hit, Outcome, Debug);
+	Result.bFound = Outcome == EGeometryScriptSearchOutcomePins::Found && Hit.bHit;
+	Result.Position = Hit.HitPosition;
+	Result.TriangleID = Hit.HitTriangleID;
+	Result.Distance = Hit.RayParameter;
+	Result.BaryCoords = Hit.HitBaryCoords;
+	Result.Message = Result.bFound ? TEXT("Hit") : (DebugText(Debug).IsEmpty() ? TEXT("No hit") : DebugText(Debug));
+	return Result;
+}
+
+FModelingSurfacePoint UModelingService::NearestPoint(int32 Handle, FVector Point, float MaxDistance)
+{
+	FModelingSurfacePoint Result;
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { Result.Message = NoMesh(Handle).Message; return Result; }
+	UGeometryScriptDebug* Debug = NewDebug();
+	FGeometryScriptDynamicMeshBVH BVH;
+	UGeometryScriptLibrary_MeshSpatial::BuildBVHForMesh(Mesh, BVH, Debug);
+	FGeometryScriptSpatialQueryOptions Options;
+	Options.MaxDistance = MaxDistance;
+	FGeometryScriptTrianglePoint Nearest;
+	EGeometryScriptSearchOutcomePins Outcome = EGeometryScriptSearchOutcomePins::NotFound;
+	UGeometryScriptLibrary_MeshSpatial::FindNearestPointOnMesh(Mesh, BVH, Point, Options, Nearest, Outcome, Debug);
+	Result.bFound = Outcome == EGeometryScriptSearchOutcomePins::Found && Nearest.bValid;
+	Result.Position = Nearest.Position;
+	Result.TriangleID = Nearest.TriangleID;
+	Result.Distance = Result.bFound ? static_cast<float>(FVector::Distance(Point, Nearest.Position)) : 0.f;
+	Result.BaryCoords = Nearest.BaryCoords;
+	Result.Message = Result.bFound ? TEXT("Found") : (DebugText(Debug).IsEmpty() ? TEXT("Nothing within MaxDistance") : DebugText(Debug));
+	return Result;
+}
+
+bool UModelingService::IsPointInside(int32 Handle, FVector Point)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return false; }
+	UGeometryScriptDebug* Debug = NewDebug();
+	FGeometryScriptDynamicMeshBVH BVH;
+	UGeometryScriptLibrary_MeshSpatial::BuildBVHForMesh(Mesh, BVH, Debug);
+	FGeometryScriptSpatialQueryOptions Options;
+	bool bInside = false;
+	EGeometryScriptContainmentOutcomePins Outcome = EGeometryScriptContainmentOutcomePins::Outside;
+	UGeometryScriptLibrary_MeshSpatial::IsPointInsideMesh(Mesh, BVH, Point, Options, bInside, Outcome, Debug);
+	return bInside;
+}
+
+TArray<FTransform> UModelingService::SampleSurfacePoints(int32 Handle, float SamplingRadius, int32 MaxSamples)
+{
+	TArray<FTransform> Samples;
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return Samples; }
+	FGeometryScriptMeshPointSamplingOptions Options;
+	Options.SamplingRadius = FMath::Max(0.01f, SamplingRadius);
+	Options.MaxNumSamples = FMath::Max(0, MaxSamples);
+	FGeometryScriptIndexList TriangleIDs;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshSamplingFunctions::ComputePointSampling(Mesh, Options, Samples, TriangleIDs, Debug);
+	return Samples;
+}
+
+bool UModelingService::SelectionBounds(int32 Handle, const FString& SelectionName, FVector& OutMin, FVector& OutMax)
+{
+	OutMin = OutMax = FVector::ZeroVector;
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return false; }
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return false; }
+	FBox Bounds(ForceInit);
+	bool bEmpty = true;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshSelectionQueryFunctions::GetMeshSelectionBoundingBox(Mesh, Selection, Bounds, bEmpty, Debug);
+	if (bEmpty) { return false; }
+	OutMin = Bounds.Min;
+	OutMax = Bounds.Max;
+	return true;
+}
+
+int32 UModelingService::SelectByPolygroup(int32 Handle, const FString& SelectionName, int32 PolygroupID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh || SelectionName.IsEmpty()) { return -1; }
+	FGeometryScriptMeshSelection Selection;
+	UGeometryScriptLibrary_MeshSelectionFunctions::SelectMeshElementsByPolygroup(Mesh, FGeometryScriptGroupLayer(), PolygroupID, Selection, EGeometryScriptMeshSelectionType::Triangles);
+	StoreSelection(Handle, SelectionName, Selection);
+	return Selection.GetNumSelected();
+}
+
+// =========================================================================
+// Hulls and comparison
+// =========================================================================
+
+namespace
+{
+	/**
+	 * Booleans, deletes, and cuts leave gaps in the vertex/triangle id space. The containment
+	 * algorithms index by id and assert on a non-compact mesh, so hull operations run on a
+	 * compacted scratch copy of the source (the session mesh itself is left untouched).
+	 */
+	UDynamicMesh* CompactedCopy(UDynamicMesh* Source, UGeometryScriptDebug* Debug)
+	{
+		UDynamicMesh* Scratch = NewScratchMesh();
+		UDynamicMesh* Out = nullptr;
+		UGeometryScriptLibrary_MeshDecompositionFunctions::CopyMeshToMesh(Source, Scratch, Out, Debug);
+		UGeometryScriptLibrary_MeshRepairFunctions::CompactMesh(Scratch, Debug);
+		return Scratch;
+	}
+}
+
+FModelingResult UModelingService::ConvexHull(int32 Handle, int32 SimplifyToFaceCount)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UDynamicMesh* Source = CompactedCopy(Mesh, Debug);
+	int32 NewHandle = -1;
+	UDynamicMesh* Hull = NewSessionMesh(NewHandle);
+	UDynamicMesh* Out = nullptr;
+	FGeometryScriptMeshSelection All;
+	UGeometryScriptLibrary_MeshSelectionFunctions::CreateSelectAllMeshSelection(Source, All, EGeometryScriptMeshSelectionType::Triangles);
+	FGeometryScriptConvexHullOptions Options;
+	Options.SimplifyToFaceCount = FMath::Max(0, SimplifyToFaceCount);
+	UGeometryScriptLibrary_ContainmentFunctions::ComputeMeshConvexHull(Source, Hull, Out, All, Options, Debug);
+	return Finish(NewHandle, Hull, Debug, FString::Printf(TEXT("Convex hull of handle %d"), Handle));
+}
+
+FModelingResult UModelingService::ConvexDecomposition(int32 Handle, int32 NumHulls)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UDynamicMesh* Source = CompactedCopy(Mesh, Debug);
+	int32 NewHandle = -1;
+	UDynamicMesh* Hulls = NewSessionMesh(NewHandle);
+	UDynamicMesh* Out = nullptr;
+	FGeometryScriptConvexDecompositionOptions Options;
+	Options.NumHulls = FMath::Clamp(NumHulls, 1, 64);
+	UGeometryScriptLibrary_ContainmentFunctions::ComputeMeshConvexDecomposition(Source, Hulls, Out, Options, Debug);
+	return Finish(NewHandle, Hulls, Debug, FString::Printf(TEXT("Convex decomposition of handle %d into %d hulls"), Handle, NumHulls));
+}
+
+FModelingResult UModelingService::SweptHull(int32 Handle, FTransform ProjectionFrame)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UDynamicMesh* Source = CompactedCopy(Mesh, Debug);
+	int32 NewHandle = -1;
+	UDynamicMesh* Hull = NewSessionMesh(NewHandle);
+	UDynamicMesh* Out = nullptr;
+	FGeometryScriptSweptHullOptions Options;
+	UGeometryScriptLibrary_ContainmentFunctions::ComputeMeshSweptHull(Source, Hull, Out, ProjectionFrame, Options, Debug);
+	return Finish(NewHandle, Hull, Debug, FString::Printf(TEXT("Swept hull of handle %d"), Handle));
+}
+
+FModelingDistanceReport UModelingService::MeasureDistance(int32 HandleA, int32 HandleB)
+{
+	FModelingDistanceReport Report;
+	UDynamicMesh* A = FindMesh(HandleA);
+	if (!A) { Report.Message = NoMesh(HandleA).Message; return Report; }
+	UDynamicMesh* B = FindMesh(HandleB);
+	if (!B) { Report.Message = NoMesh(HandleB).Message; return Report; }
+	FGeometryScriptMeasureMeshDistanceOptions Options;
+	double MaxD = 0, MinD = 0, AvgD = 0, Rms = 0;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshComparisonFunctions::MeasureDistancesBetweenMeshes(A, B, Options, MaxD, MinD, AvgD, Rms, Debug);
+	if (DebugHasErrors(Debug)) { Report.Message = DebugText(Debug); return Report; }
+	Report.bSuccess = true;
+	Report.MaxDistance = static_cast<float>(MaxD);
+	Report.MinDistance = static_cast<float>(MinD);
+	Report.AverageDistance = static_cast<float>(AvgD);
+	Report.RootMeanSquareDeviation = static_cast<float>(Rms);
+	Report.Message = FString::Printf(TEXT("max %.3f, mean %.3f, rms %.3f"), MaxD, AvgD, Rms);
+	return Report;
+}
+
+// =========================================================================
+// More skeletal
+// =========================================================================
+
+FModelingResult UModelingService::SmoothBoneWeights(int32 Handle, const FString& SkeletonPath, float Stiffness, int32 MaxInfluences)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	USkeleton* Skeleton = LoadAssetAs<USkeleton>(SkeletonPath);
+	if (!Skeleton) { return Fail(Handle, FString::Printf(TEXT("Skeleton not found: %s"), *SkeletonPath)); }
+	FGeometryScriptSmoothBoneWeightsOptions Options;
+	Options.Stiffness = Stiffness;
+	Options.MaxInfluences = FMath::Clamp(MaxInfluences, 1, 12);
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshBoneWeightFunctions::ComputeSmoothBoneWeights(Mesh, Skeleton, Options, FGeometryScriptBoneWeightProfile(), Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Smoothed bone weights against %s"), *SkeletonPath));
+}
+
+FModelingResult UModelingService::PruneBoneWeights(int32 Handle, const FString& BoneNames)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	TArray<FString> Names;
+	BoneNames.ParseIntoArray(Names, TEXT(","), true);
+	TArray<FName> Bones;
+	for (FString& Name : Names)
+	{
+		Name.TrimStartAndEndInline();
+		if (!Name.IsEmpty()) { Bones.Add(FName(*Name)); }
+	}
+	if (Bones.Num() == 0) { return Fail(Handle, TEXT("BoneNames must list at least one bone (comma-separated)")); }
+	FGeometryScriptPruneBoneWeightsOptions Options;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshBoneWeightFunctions::PruneBoneWeights(Mesh, Bones, Options, FGeometryScriptBoneWeightProfile(), Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Pruned %d bone(s) from skin weights"), Bones.Num()));
 }

--- a/Source/VibeUE/Private/PythonAPI/UModelingService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UModelingService.cpp
@@ -1,0 +1,1674 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#include "PythonAPI/UModelingService.h"
+
+#include "UDynamicMesh.h"
+#include "DynamicMesh/DynamicMesh3.h"
+#include "DynamicMesh/DynamicMeshAttributeSet.h"
+#include "GeometryScript/GeometryScriptTypes.h"
+#include "GeometryScript/GeometryScriptSelectionTypes.h"
+#include "GeometryScript/MeshPrimitiveFunctions.h"
+#include "GeometryScript/MeshBooleanFunctions.h"
+#include "GeometryScript/MeshSelectionFunctions.h"
+#include "GeometryScript/MeshModelingFunctions.h"
+#include "GeometryScript/MeshBasicEditFunctions.h"
+#include "GeometryScript/MeshRemeshFunctions.h"
+#include "GeometryScript/MeshSimplifyFunctions.h"
+#include "GeometryScript/MeshSubdivideFunctions.h"
+#include "GeometryScript/MeshDeformFunctions.h"
+#include "GeometryScript/MeshVoxelFunctions.h"
+#include "GeometryScript/MeshUVFunctions.h"
+#include "GeometryScript/MeshNormalsFunctions.h"
+#include "GeometryScript/MeshRepairFunctions.h"
+#include "GeometryScript/MeshQueryFunctions.h"
+#include "GeometryScript/MeshTransformFunctions.h"
+#include "GeometryScript/MeshDecompositionFunctions.h"
+#include "GeometryScript/MeshPolygroupFunctions.h"
+#include "GeometryScript/MeshMaterialFunctions.h"
+#include "GeometryScript/MeshVertexColorFunctions.h"
+#include "GeometryScript/MeshAssetFunctions.h"
+#include "GeometryScript/MeshBakeFunctions.h"
+#include "GeometryScript/MeshBoneWeightFunctions.h"
+#include "GeometryScript/MeshPoolFunctions.h"
+#include "GeometryScript/CollisionFunctions.h"
+#include "GeometryScript/CreateNewAssetUtilityFunctions.h"
+#include "GeometryScript/OpenSubdivUtilityFunctions.h"
+
+#include "Animation/Skeleton.h"
+#include "Components/StaticMeshComponent.h"
+#include "Editor.h"
+#include "EditorAssetLibrary.h"
+#include "Engine/SkeletalMesh.h"
+#include "Engine/StaticMesh.h"
+#include "Engine/Texture2D.h"
+#include "GameFramework/Actor.h"
+#include "Misc/CoreDelegates.h"
+#include "StaticMeshEditorSubsystem.h"
+#include "StaticMeshEditorSubsystemHelpers.h"
+#include "Subsystems/EditorActorSubsystem.h"
+#include "UObject/Package.h"
+#include "UObject/StrongObjectPtr.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogVibeModeling, Log, All);
+
+using namespace UE::Geometry;
+
+// =========================================================================
+// Session: integer handles -> UDynamicMesh (kept alive for the editor session)
+// =========================================================================
+
+namespace
+{
+	struct FModelingSession
+	{
+		TMap<int32, TStrongObjectPtr<UDynamicMesh>> Meshes;
+		TMap<int32, TMap<FString, FGeometryScriptMeshSelection>> Selections;
+		int32 NextHandle = 1;
+		bool bExitHooked = false;
+
+		void Reset()
+		{
+			Selections.Reset();
+			Meshes.Reset();
+		}
+	};
+
+	FModelingSession& Session()
+	{
+		static FModelingSession S;
+		if (!S.bExitHooked)
+		{
+			// Release the strong references before the UObject system tears down.
+			S.bExitHooked = true;
+			FCoreDelegates::OnPreExit.AddLambda([]() { Session().Reset(); });
+		}
+		return S;
+	}
+
+	UDynamicMesh* FindMesh(int32 Handle)
+	{
+		const TStrongObjectPtr<UDynamicMesh>* Found = Session().Meshes.Find(Handle);
+		return Found ? Found->Get() : nullptr;
+	}
+
+	int32 AddMesh(UDynamicMesh* Mesh)
+	{
+		const int32 Handle = Session().NextHandle++;
+		Session().Meshes.Add(Handle, TStrongObjectPtr<UDynamicMesh>(Mesh));
+		return Handle;
+	}
+
+	UDynamicMesh* NewSessionMesh(int32& OutHandle)
+	{
+		UDynamicMesh* Mesh = NewObject<UDynamicMesh>(GetTransientPackage(), NAME_None, RF_Transient);
+		OutHandle = AddMesh(Mesh);
+		return Mesh;
+	}
+
+	UDynamicMesh* NewScratchMesh()
+	{
+		return NewObject<UDynamicMesh>(GetTransientPackage(), NAME_None, RF_Transient);
+	}
+
+	int32 TriCount(UDynamicMesh* Mesh)
+	{
+		return Mesh ? Mesh->GetTriangleCount() : 0;
+	}
+
+	int32 VertCount(UDynamicMesh* Mesh)
+	{
+		int32 Count = 0;
+		if (Mesh)
+		{
+			Mesh->ProcessMesh([&Count](const FDynamicMesh3& M) { Count = M.VertexCount(); });
+		}
+		return Count;
+	}
+
+	// ---- results -----------------------------------------------------------
+
+	FModelingResult Fail(int32 Handle, const FString& Message)
+	{
+		FModelingResult R;
+		R.bSuccess = false;
+		R.Handle = Handle;
+		R.Message = Message;
+		UE_LOG(LogVibeModeling, Warning, TEXT("ModelingService failure (handle %d): %s"), Handle, *Message);
+		return R;
+	}
+
+	FModelingResult Ok(int32 Handle, UDynamicMesh* Mesh, const FString& Message)
+	{
+		FModelingResult R;
+		R.bSuccess = true;
+		R.Handle = Handle;
+		R.Message = Message;
+		R.TriangleCount = TriCount(Mesh);
+		R.VertexCount = VertCount(Mesh);
+		return R;
+	}
+
+	FModelingResult NoMesh(int32 Handle)
+	{
+		return Fail(Handle, FString::Printf(TEXT("No session mesh with handle %d (create_mesh / load_mesh_* first, or see list_meshes)"), Handle));
+	}
+
+	// ---- GeometryScript debug capture --------------------------------------
+
+	UGeometryScriptDebug* NewDebug()
+	{
+		return NewObject<UGeometryScriptDebug>(GetTransientPackage(), NAME_None, RF_Transient);
+	}
+
+	bool DebugHasErrors(const UGeometryScriptDebug* Debug)
+	{
+		if (!Debug) { return false; }
+		for (const FGeometryScriptDebugMessage& M : Debug->Messages)
+		{
+			if (M.MessageType == EGeometryScriptDebugMessageType::ErrorMessage) { return true; }
+		}
+		return false;
+	}
+
+	FString DebugText(const UGeometryScriptDebug* Debug)
+	{
+		TArray<FString> Lines;
+		if (Debug)
+		{
+			for (const FGeometryScriptDebugMessage& M : Debug->Messages)
+			{
+				Lines.Add(M.Message.ToString());
+			}
+		}
+		return FString::Join(Lines, TEXT("; "));
+	}
+
+	/** Standard end of a mutating call: errors reported by GeometryScript become a failure. */
+	FModelingResult Finish(int32 Handle, UDynamicMesh* Mesh, UGeometryScriptDebug* Debug, const FString& What)
+	{
+		if (DebugHasErrors(Debug))
+		{
+			return Fail(Handle, What + TEXT(": ") + DebugText(Debug));
+		}
+		const FString Extra = DebugText(Debug);
+		return Ok(Handle, Mesh, Extra.IsEmpty() ? What : What + TEXT(" (") + Extra + TEXT(")"));
+	}
+
+	// ---- enums by name -------------------------------------------------------
+
+	template <typename TEnum>
+	FString EnumNames()
+	{
+		TArray<FString> Names;
+		const UEnum* E = StaticEnum<TEnum>();
+		for (int32 i = 0; i < E->NumEnums() - 1; ++i)
+		{
+			Names.Add(E->GetNameStringByIndex(i));
+		}
+		return FString::Join(Names, TEXT(", "));
+	}
+
+	template <typename TEnum>
+	bool ParseEnum(const FString& Name, TEnum& Out)
+	{
+		const UEnum* E = StaticEnum<TEnum>();
+		const int64 Value = E->GetValueByNameString(Name.TrimStartAndEnd());
+		if (Value == INDEX_NONE)
+		{
+			return false;
+		}
+		Out = static_cast<TEnum>(Value);
+		return true;
+	}
+
+	// ---- selections ----------------------------------------------------------
+
+	void StoreSelection(int32 Handle, const FString& Name, const FGeometryScriptMeshSelection& Selection)
+	{
+		Session().Selections.FindOrAdd(Handle).Add(Name, Selection);
+	}
+
+	/** "" resolves to the whole mesh as a triangle selection. */
+	bool ResolveSelection(int32 Handle, const FString& Name, UDynamicMesh* Mesh, FGeometryScriptMeshSelection& Out, FString& Error)
+	{
+		if (Name.IsEmpty())
+		{
+			UGeometryScriptLibrary_MeshSelectionFunctions::CreateSelectAllMeshSelection(Mesh, Out, EGeometryScriptMeshSelectionType::Triangles);
+			return true;
+		}
+		const TMap<FString, FGeometryScriptMeshSelection>* PerMesh = Session().Selections.Find(Handle);
+		const FGeometryScriptMeshSelection* Found = PerMesh ? PerMesh->Find(Name) : nullptr;
+		if (!Found)
+		{
+			Error = FString::Printf(TEXT("No selection named '%s' on handle %d (make one with select_all / select_by_normal_angle / select_in_box / ...)"), *Name, Handle);
+			return false;
+		}
+		Out = *Found;
+		return true;
+	}
+
+	FGeometryScriptPrimitiveOptions PrimitiveOptions(int32 MaterialID)
+	{
+		FGeometryScriptPrimitiveOptions Options;
+		Options.MaterialID = MaterialID;
+		return Options;
+	}
+
+	bool ParseOrigin(const FString& Origin, EGeometryScriptPrimitiveOriginMode& Out, FString& Error)
+	{
+		if (ParseEnum(Origin, Out)) { return true; }
+		Error = FString::Printf(TEXT("Unknown origin '%s' (use %s)"), *Origin, *EnumNames<EGeometryScriptPrimitiveOriginMode>());
+		return false;
+	}
+
+	// ---- assets ----------------------------------------------------------------
+
+	template <typename T>
+	T* LoadAssetAs(const FString& AssetPath)
+	{
+		return Cast<T>(UEditorAssetLibrary::LoadAsset(AssetPath));
+	}
+
+	bool CopyFromStaticMesh(UStaticMesh* StaticMesh, UDynamicMesh* Target, int32 LODIndex, UGeometryScriptDebug* Debug)
+	{
+		FGeometryScriptCopyMeshFromAssetOptions AssetOptions;
+		FGeometryScriptMeshReadLOD ReadLOD;
+		ReadLOD.LODIndex = LODIndex;
+		EGeometryScriptOutcomePins Outcome = EGeometryScriptOutcomePins::Failure;
+		UGeometryScriptLibrary_StaticMeshFunctions::CopyMeshFromStaticMesh(StaticMesh, Target, AssetOptions, ReadLOD, Outcome, Debug);
+		return Outcome == EGeometryScriptOutcomePins::Success;
+	}
+
+	bool CopyFromSkeletalMesh(USkeletalMesh* SkeletalMesh, UDynamicMesh* Target, int32 LODIndex, UGeometryScriptDebug* Debug)
+	{
+		FGeometryScriptCopyMeshFromAssetOptions AssetOptions;
+		FGeometryScriptMeshReadLOD ReadLOD;
+		ReadLOD.LODIndex = LODIndex;
+		EGeometryScriptOutcomePins Outcome = EGeometryScriptOutcomePins::Failure;
+		UGeometryScriptLibrary_StaticMeshFunctions::CopyMeshFromSkeletalMesh(SkeletalMesh, Target, AssetOptions, ReadLOD, Outcome, Debug);
+		return Outcome == EGeometryScriptOutcomePins::Success;
+	}
+
+	void SaveIf(bool bSave, const FString& AssetPath)
+	{
+		if (bSave)
+		{
+			UEditorAssetLibrary::SaveAsset(AssetPath, false);
+		}
+	}
+
+	AActor* FindActorByLabel(const FString& Label)
+	{
+		UEditorActorSubsystem* ActorSubsystem = GEditor ? GEditor->GetEditorSubsystem<UEditorActorSubsystem>() : nullptr;
+		if (!ActorSubsystem) { return nullptr; }
+		for (AActor* Actor : ActorSubsystem->GetAllLevelActors())
+		{
+			if (Actor && Actor->GetActorLabel().Equals(Label, ESearchCase::IgnoreCase))
+			{
+				return Actor;
+			}
+		}
+		return nullptr;
+	}
+}
+
+// =========================================================================
+// Session
+// =========================================================================
+
+FModelingResult UModelingService::CreateMesh()
+{
+	int32 Handle = -1;
+	UDynamicMesh* Mesh = NewSessionMesh(Handle);
+	return Ok(Handle, Mesh, TEXT("Created empty mesh"));
+}
+
+FModelingResult UModelingService::LoadMeshFromStaticMesh(const FString& AssetPath, int32 LODIndex)
+{
+	UStaticMesh* StaticMesh = LoadAssetAs<UStaticMesh>(AssetPath);
+	if (!StaticMesh)
+	{
+		return Fail(-1, FString::Printf(TEXT("StaticMesh not found: %s"), *AssetPath));
+	}
+	int32 Handle = -1;
+	UDynamicMesh* Mesh = NewSessionMesh(Handle);
+	UGeometryScriptDebug* Debug = NewDebug();
+	if (!CopyFromStaticMesh(StaticMesh, Mesh, LODIndex, Debug))
+	{
+		ReleaseMesh(Handle);
+		return Fail(-1, FString::Printf(TEXT("Could not read LOD %d of %s: %s"), LODIndex, *AssetPath, *DebugText(Debug)));
+	}
+	FModelingResult R = Ok(Handle, Mesh, FString::Printf(TEXT("Loaded %s LOD %d"), *AssetPath, LODIndex));
+	R.AssetPath = AssetPath;
+	return R;
+}
+
+FModelingResult UModelingService::LoadMeshFromSkeletalMesh(const FString& AssetPath, int32 LODIndex)
+{
+	USkeletalMesh* SkeletalMesh = LoadAssetAs<USkeletalMesh>(AssetPath);
+	if (!SkeletalMesh)
+	{
+		return Fail(-1, FString::Printf(TEXT("SkeletalMesh not found: %s"), *AssetPath));
+	}
+	int32 Handle = -1;
+	UDynamicMesh* Mesh = NewSessionMesh(Handle);
+	UGeometryScriptDebug* Debug = NewDebug();
+	if (!CopyFromSkeletalMesh(SkeletalMesh, Mesh, LODIndex, Debug))
+	{
+		ReleaseMesh(Handle);
+		return Fail(-1, FString::Printf(TEXT("Could not read LOD %d of %s: %s"), LODIndex, *AssetPath, *DebugText(Debug)));
+	}
+	FModelingResult R = Ok(Handle, Mesh, FString::Printf(TEXT("Loaded %s LOD %d (with bone weights)"), *AssetPath, LODIndex));
+	R.AssetPath = AssetPath;
+	return R;
+}
+
+FModelingResult UModelingService::LoadMeshFromActor(const FString& ActorLabel, bool bWorldSpace, int32 LODIndex)
+{
+	AActor* Actor = FindActorByLabel(ActorLabel);
+	if (!Actor)
+	{
+		return Fail(-1, FString::Printf(TEXT("No level actor labeled '%s'"), *ActorLabel));
+	}
+	UStaticMeshComponent* Component = Actor->FindComponentByClass<UStaticMeshComponent>();
+	UStaticMesh* StaticMesh = Component ? Component->GetStaticMesh() : nullptr;
+	if (!StaticMesh)
+	{
+		return Fail(-1, FString::Printf(TEXT("Actor '%s' has no StaticMeshComponent with a mesh"), *ActorLabel));
+	}
+	int32 Handle = -1;
+	UDynamicMesh* Mesh = NewSessionMesh(Handle);
+	UGeometryScriptDebug* Debug = NewDebug();
+	if (!CopyFromStaticMesh(StaticMesh, Mesh, LODIndex, Debug))
+	{
+		ReleaseMesh(Handle);
+		return Fail(-1, FString::Printf(TEXT("Could not read %s: %s"), *StaticMesh->GetPathName(), *DebugText(Debug)));
+	}
+	if (bWorldSpace)
+	{
+		UGeometryScriptLibrary_MeshTransformFunctions::TransformMesh(Mesh, Component->GetComponentTransform(), true, Debug);
+	}
+	FModelingResult R = Ok(Handle, Mesh, FString::Printf(TEXT("Loaded %s from actor '%s'%s"), *StaticMesh->GetPathName(), *ActorLabel,
+		bWorldSpace ? TEXT(" in world space") : TEXT(" in asset space")));
+	R.AssetPath = StaticMesh->GetPathName();
+	return R;
+}
+
+FModelingResult UModelingService::CopyMesh(int32 Handle)
+{
+	UDynamicMesh* Source = FindMesh(Handle);
+	if (!Source) { return NoMesh(Handle); }
+	int32 NewHandle = -1;
+	UDynamicMesh* Target = NewSessionMesh(NewHandle);
+	UDynamicMesh* Out = nullptr;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshDecompositionFunctions::CopyMeshToMesh(Source, Target, Out, Debug);
+	return Finish(NewHandle, Target, Debug, FString::Printf(TEXT("Copied handle %d"), Handle));
+}
+
+bool UModelingService::ReleaseMesh(int32 Handle)
+{
+	Session().Selections.Remove(Handle);
+	return Session().Meshes.Remove(Handle) > 0;
+}
+
+int32 UModelingService::ReleaseAllMeshes()
+{
+	const int32 Count = Session().Meshes.Num();
+	Session().Reset();
+	return Count;
+}
+
+TArray<int32> UModelingService::ListMeshes()
+{
+	TArray<int32> Handles;
+	Session().Meshes.GetKeys(Handles);
+	Handles.Sort();
+	return Handles;
+}
+
+FModelingMeshInfo UModelingService::GetMeshInfo(int32 Handle)
+{
+	FModelingMeshInfo Info;
+	Info.Handle = Handle;
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh)
+	{
+		Info.Message = NoMesh(Handle).Message;
+		return Info;
+	}
+	Info.bSuccess = true;
+	Info.TriangleCount = TriCount(Mesh);
+	Info.bIsClosed = UGeometryScriptLibrary_MeshQueryFunctions::GetIsClosedMesh(Mesh);
+	Info.OpenBorderEdges = UGeometryScriptLibrary_MeshQueryFunctions::GetNumOpenBorderEdges(Mesh);
+	Info.ConnectedComponents = UGeometryScriptLibrary_MeshQueryFunctions::GetNumConnectedComponents(Mesh);
+	const FBox Bounds = UGeometryScriptLibrary_MeshQueryFunctions::GetMeshBoundingBox(Mesh);
+	Info.BoundsMin = Bounds.Min;
+	Info.BoundsMax = Bounds.Max;
+	UGeometryScriptLibrary_MeshQueryFunctions::GetMeshVolumeArea(Mesh, Info.SurfaceArea, Info.Volume);
+	Mesh->ProcessMesh([&Info](const FDynamicMesh3& M)
+	{
+		Info.VertexCount = M.VertexCount();
+		if (M.HasAttributes())
+		{
+			Info.NumUVLayers = M.Attributes()->NumUVLayers();
+			Info.bHasVertexColors = M.Attributes()->HasPrimaryColors();
+			if (M.Attributes()->HasMaterialID())
+			{
+				TSet<int32> Ids;
+				const FDynamicMeshMaterialAttribute* Materials = M.Attributes()->GetMaterialID();
+				for (const int32 Tid : M.TriangleIndicesItr())
+				{
+					Ids.Add(Materials->GetValue(Tid));
+				}
+				Info.MaterialIDs = Ids.Array();
+				Info.MaterialIDs.Sort();
+			}
+		}
+	});
+	if (const TMap<FString, FGeometryScriptMeshSelection>* PerMesh = Session().Selections.Find(Handle))
+	{
+		PerMesh->GetKeys(Info.Selections);
+	}
+	Info.Message = UGeometryScriptLibrary_MeshQueryFunctions::GetMeshInfoString(Mesh);
+	return Info;
+}
+
+UDynamicMesh* UModelingService::GetDynamicMesh(int32 Handle)
+{
+	return FindMesh(Handle);
+}
+
+// =========================================================================
+// Primitives
+// =========================================================================
+
+FModelingResult UModelingService::AppendBox(int32 Handle, FTransform Transform, float DimensionX, float DimensionY, float DimensionZ,
+	int32 StepsX, int32 StepsY, int32 StepsZ, const FString& Origin, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	EGeometryScriptPrimitiveOriginMode OriginMode; FString Error;
+	if (!ParseOrigin(Origin, OriginMode, Error)) { return Fail(Handle, Error); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendBox(Mesh, PrimitiveOptions(MaterialID), Transform, DimensionX, DimensionY, DimensionZ,
+		StepsX, StepsY, StepsZ, OriginMode, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Appended box"));
+}
+
+FModelingResult UModelingService::AppendSphere(int32 Handle, FTransform Transform, float Radius, int32 StepsPhi, int32 StepsTheta,
+	const FString& Origin, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	EGeometryScriptPrimitiveOriginMode OriginMode; FString Error;
+	if (!ParseOrigin(Origin, OriginMode, Error)) { return Fail(Handle, Error); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendSphereLatLong(Mesh, PrimitiveOptions(MaterialID), Transform, Radius, StepsPhi, StepsTheta, OriginMode, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Appended sphere"));
+}
+
+FModelingResult UModelingService::AppendCylinder(int32 Handle, FTransform Transform, float Radius, float Height, int32 RadialSteps,
+	int32 HeightSteps, bool bCapped, const FString& Origin, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	EGeometryScriptPrimitiveOriginMode OriginMode; FString Error;
+	if (!ParseOrigin(Origin, OriginMode, Error)) { return Fail(Handle, Error); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendCylinder(Mesh, PrimitiveOptions(MaterialID), Transform, Radius, Height, RadialSteps, HeightSteps,
+		bCapped, OriginMode, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Appended cylinder"));
+}
+
+FModelingResult UModelingService::AppendCone(int32 Handle, FTransform Transform, float BaseRadius, float TopRadius, float Height,
+	int32 RadialSteps, int32 HeightSteps, bool bCapped, const FString& Origin, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	EGeometryScriptPrimitiveOriginMode OriginMode; FString Error;
+	if (!ParseOrigin(Origin, OriginMode, Error)) { return Fail(Handle, Error); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendCone(Mesh, PrimitiveOptions(MaterialID), Transform, BaseRadius, TopRadius, Height, RadialSteps,
+		HeightSteps, bCapped, OriginMode, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Appended cone"));
+}
+
+FModelingResult UModelingService::AppendCapsule(int32 Handle, FTransform Transform, float Radius, float LineLength, int32 HemisphereSteps,
+	int32 CircleSteps, const FString& Origin, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	EGeometryScriptPrimitiveOriginMode OriginMode; FString Error;
+	if (!ParseOrigin(Origin, OriginMode, Error)) { return Fail(Handle, Error); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendCapsule(Mesh, PrimitiveOptions(MaterialID), Transform, Radius, LineLength, HemisphereSteps,
+		CircleSteps, 0, OriginMode, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Appended capsule"));
+}
+
+FModelingResult UModelingService::AppendTorus(int32 Handle, FTransform Transform, float MajorRadius, float MinorRadius, int32 MajorSteps,
+	int32 MinorSteps, const FString& Origin, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	EGeometryScriptPrimitiveOriginMode OriginMode; FString Error;
+	if (!ParseOrigin(Origin, OriginMode, Error)) { return Fail(Handle, Error); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	FGeometryScriptRevolveOptions RevolveOptions;
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendTorus(Mesh, PrimitiveOptions(MaterialID), Transform, RevolveOptions, MajorRadius, MinorRadius,
+		MajorSteps, MinorSteps, OriginMode, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Appended torus"));
+}
+
+FModelingResult UModelingService::AppendRectangle(int32 Handle, FTransform Transform, float DimensionX, float DimensionY, int32 StepsWidth,
+	int32 StepsHeight, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendRectangleXY(Mesh, PrimitiveOptions(MaterialID), Transform, DimensionX, DimensionY, StepsWidth, StepsHeight, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Appended rectangle"));
+}
+
+FModelingResult UModelingService::AppendDisc(int32 Handle, FTransform Transform, float Radius, int32 AngleSteps, int32 SpokeSteps,
+	float StartAngle, float EndAngle, float HoleRadius, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendDisc(Mesh, PrimitiveOptions(MaterialID), Transform, Radius, AngleSteps, SpokeSteps, StartAngle, EndAngle, HoleRadius, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Appended disc"));
+}
+
+FModelingResult UModelingService::AppendStairs(int32 Handle, FTransform Transform, float StepWidth, float StepHeight, float StepDepth,
+	int32 NumSteps, bool bFloating, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendLinearStairs(Mesh, PrimitiveOptions(MaterialID), Transform, StepWidth, StepHeight, StepDepth, NumSteps, bFloating, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Appended stairs"));
+}
+
+FModelingResult UModelingService::AppendExtrudePolygon(int32 Handle, FTransform Transform, const TArray<FVector2D>& PolygonPoints, float Height,
+	int32 HeightSteps, bool bCapped, const FString& Origin, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	if (PolygonPoints.Num() < 3) { return Fail(Handle, TEXT("PolygonPoints needs at least 3 points")); }
+	EGeometryScriptPrimitiveOriginMode OriginMode; FString Error;
+	if (!ParseOrigin(Origin, OriginMode, Error)) { return Fail(Handle, Error); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendSimpleExtrudePolygon(Mesh, PrimitiveOptions(MaterialID), Transform, PolygonPoints, Height, HeightSteps,
+		bCapped, OriginMode, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Appended extruded polygon"));
+}
+
+FModelingResult UModelingService::AppendRevolvePolygon(int32 Handle, FTransform Transform, const TArray<FVector2D>& ProfilePoints, float Radius,
+	int32 Steps, float RevolveDegrees, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	if (ProfilePoints.Num() < 3) { return Fail(Handle, TEXT("ProfilePoints needs at least 3 points")); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	FGeometryScriptRevolveOptions RevolveOptions;
+	RevolveOptions.RevolveDegrees = RevolveDegrees;
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendRevolvePolygon(Mesh, PrimitiveOptions(MaterialID), Transform, ProfilePoints, RevolveOptions, Radius, Steps, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Appended revolved profile"));
+}
+
+FModelingResult UModelingService::AppendMesh(int32 Handle, int32 OtherHandle, FTransform Transform)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UDynamicMesh* Other = FindMesh(OtherHandle);
+	if (!Other) { return NoMesh(OtherHandle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshBasicEditFunctions::AppendMesh(Mesh, Other, Transform, false, FGeometryScriptAppendMeshOptions(), Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Appended handle %d"), OtherHandle));
+}
+
+// =========================================================================
+// Booleans
+// =========================================================================
+
+FModelingResult UModelingService::Boolean(int32 TargetHandle, int32 ToolHandle, const FString& Operation, FTransform ToolTransform,
+	bool bFillHoles, bool bSimplifyOutput)
+{
+	UDynamicMesh* Target = FindMesh(TargetHandle);
+	if (!Target) { return NoMesh(TargetHandle); }
+	UDynamicMesh* Tool = FindMesh(ToolHandle);
+	if (!Tool) { return NoMesh(ToolHandle); }
+	EGeometryScriptBooleanOperation Op;
+	if (!ParseEnum(Operation, Op))
+	{
+		return Fail(TargetHandle, FString::Printf(TEXT("Unknown boolean operation '%s' (use %s)"), *Operation, *EnumNames<EGeometryScriptBooleanOperation>()));
+	}
+	FGeometryScriptMeshBooleanOptions Options;
+	Options.bFillHoles = bFillHoles;
+	Options.bSimplifyOutput = bSimplifyOutput;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshBooleanFunctions::ApplyMeshBoolean(Target, FTransform::Identity, Tool, ToolTransform, Op, Options, Debug);
+	return Finish(TargetHandle, Target, Debug, FString::Printf(TEXT("Boolean %s with handle %d"), *Operation, ToolHandle));
+}
+
+FModelingResult UModelingService::SelfUnion(int32 Handle, bool bFillHoles, bool bTrimFlaps)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelfUnionOptions Options;
+	Options.bFillHoles = bFillHoles;
+	Options.bTrimFlaps = bTrimFlaps;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshBooleanFunctions::ApplyMeshSelfUnion(Mesh, Options, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Self union"));
+}
+
+FModelingResult UModelingService::PlaneCut(int32 Handle, FTransform CutFrame, bool bFillHoles, bool bFlipCutSide)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshPlaneCutOptions Options;
+	Options.bFillHoles = bFillHoles;
+	Options.bFlipCutSide = bFlipCutSide;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshBooleanFunctions::ApplyMeshPlaneCut(Mesh, CutFrame, Options, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Plane cut"));
+}
+
+FModelingResult UModelingService::Mirror(int32 Handle, FTransform MirrorFrame, bool bApplyPlaneCut, bool bWeldAlongPlane, bool bFlipCutSide)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshMirrorOptions Options;
+	Options.bApplyPlaneCut = bApplyPlaneCut;
+	Options.bWeldAlongPlane = bWeldAlongPlane;
+	Options.bFlipCutSide = bFlipCutSide;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshBooleanFunctions::ApplyMeshMirror(Mesh, MirrorFrame, Options, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Mirror"));
+}
+
+// =========================================================================
+// Selections
+// =========================================================================
+
+int32 UModelingService::SelectAll(int32 Handle, const FString& SelectionName, const FString& SelectionType)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh || SelectionName.IsEmpty()) { return -1; }
+	EGeometryScriptMeshSelectionType Type = EGeometryScriptMeshSelectionType::Triangles;
+	if (!SelectionType.IsEmpty() && !ParseEnum(SelectionType, Type))
+	{
+		UE_LOG(LogVibeModeling, Warning, TEXT("Unknown selection type '%s' (use %s)"), *SelectionType, *EnumNames<EGeometryScriptMeshSelectionType>());
+		return -1;
+	}
+	FGeometryScriptMeshSelection Selection;
+	UGeometryScriptLibrary_MeshSelectionFunctions::CreateSelectAllMeshSelection(Mesh, Selection, Type);
+	StoreSelection(Handle, SelectionName, Selection);
+	return Selection.GetNumSelected();
+}
+
+int32 UModelingService::SelectByNormalAngle(int32 Handle, const FString& SelectionName, FVector Normal, float MaxAngleDeg, bool bInvert)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh || SelectionName.IsEmpty()) { return -1; }
+	FGeometryScriptMeshSelection Selection;
+	UGeometryScriptLibrary_MeshSelectionFunctions::SelectMeshElementsByNormalAngle(Mesh, Selection, Normal.GetSafeNormal(), MaxAngleDeg,
+		EGeometryScriptMeshSelectionType::Triangles, bInvert, 3);
+	StoreSelection(Handle, SelectionName, Selection);
+	return Selection.GetNumSelected();
+}
+
+int32 UModelingService::SelectInBox(int32 Handle, const FString& SelectionName, FVector BoxMin, FVector BoxMax, bool bInvert)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh || SelectionName.IsEmpty()) { return -1; }
+	FGeometryScriptMeshSelection Selection;
+	UGeometryScriptLibrary_MeshSelectionFunctions::SelectMeshElementsInBox(Mesh, Selection, FBox(BoxMin, BoxMax), EGeometryScriptMeshSelectionType::Triangles, bInvert, 3);
+	StoreSelection(Handle, SelectionName, Selection);
+	return Selection.GetNumSelected();
+}
+
+int32 UModelingService::SelectInSphere(int32 Handle, const FString& SelectionName, FVector Center, float Radius, bool bInvert)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh || SelectionName.IsEmpty()) { return -1; }
+	FGeometryScriptMeshSelection Selection;
+	UGeometryScriptLibrary_MeshSelectionFunctions::SelectMeshElementsInSphere(Mesh, Selection, Center, Radius, EGeometryScriptMeshSelectionType::Triangles, bInvert, 3);
+	StoreSelection(Handle, SelectionName, Selection);
+	return Selection.GetNumSelected();
+}
+
+int32 UModelingService::SelectByMaterialID(int32 Handle, const FString& SelectionName, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh || SelectionName.IsEmpty()) { return -1; }
+	TArray<int32> TriangleIDs;
+	Mesh->ProcessMesh([&TriangleIDs, MaterialID](const FDynamicMesh3& M)
+	{
+		if (M.HasAttributes() && M.Attributes()->HasMaterialID())
+		{
+			const FDynamicMeshMaterialAttribute* Materials = M.Attributes()->GetMaterialID();
+			for (const int32 Tid : M.TriangleIndicesItr())
+			{
+				if (Materials->GetValue(Tid) == MaterialID)
+				{
+					TriangleIDs.Add(Tid);
+				}
+			}
+		}
+	});
+	FGeometryScriptMeshSelection Selection;
+	UGeometryScriptLibrary_MeshSelectionFunctions::ConvertIndexArrayToMeshSelection(Mesh, TriangleIDs, EGeometryScriptMeshSelectionType::Triangles, Selection);
+	StoreSelection(Handle, SelectionName, Selection);
+	return Selection.GetNumSelected();
+}
+
+int32 UModelingService::ExpandContractSelection(int32 Handle, const FString& SelectionName, const FString& NewSelectionName, int32 Iterations, bool bContract)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh || NewSelectionName.IsEmpty()) { return -1; }
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { UE_LOG(LogVibeModeling, Warning, TEXT("%s"), *Error); return -1; }
+	FGeometryScriptMeshSelection NewSelection;
+	UGeometryScriptLibrary_MeshSelectionFunctions::ExpandContractMeshSelection(Mesh, Selection, NewSelection, Iterations, bContract, false);
+	StoreSelection(Handle, NewSelectionName, NewSelection);
+	return NewSelection.GetNumSelected();
+}
+
+int32 UModelingService::InvertSelection(int32 Handle, const FString& SelectionName, const FString& NewSelectionName)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh || NewSelectionName.IsEmpty()) { return -1; }
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { UE_LOG(LogVibeModeling, Warning, TEXT("%s"), *Error); return -1; }
+	FGeometryScriptMeshSelection NewSelection;
+	UGeometryScriptLibrary_MeshSelectionFunctions::InvertMeshSelection(Mesh, Selection, NewSelection, false);
+	StoreSelection(Handle, NewSelectionName, NewSelection);
+	return NewSelection.GetNumSelected();
+}
+
+int32 UModelingService::SelectionCount(int32 Handle, const FString& SelectionName)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return -1; }
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return -1; }
+	return Selection.GetNumSelected();
+}
+
+bool UModelingService::ClearSelections(int32 Handle)
+{
+	return Session().Selections.Remove(Handle) > 0;
+}
+
+// =========================================================================
+// Poly-edit operations
+// =========================================================================
+
+FModelingResult UModelingService::ExtrudeFaces(int32 Handle, const FString& SelectionName, float Distance, FVector Direction)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	FGeometryScriptMeshLinearExtrudeOptions Options;
+	Options.Distance = Distance;
+	if (Direction.IsNearlyZero())
+	{
+		Options.DirectionMode = EGeometryScriptLinearExtrudeDirection::AverageFaceNormal;
+	}
+	else
+	{
+		Options.DirectionMode = EGeometryScriptLinearExtrudeDirection::FixedDirection;
+		Options.Direction = Direction.GetSafeNormal();
+	}
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshModelingFunctions::ApplyMeshLinearExtrudeFaces(Mesh, Options, Selection, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Extruded %d faces by %.2f"), Selection.GetNumSelected(), Distance));
+}
+
+FModelingResult UModelingService::OffsetFaces(int32 Handle, const FString& SelectionName, float Distance)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	FGeometryScriptMeshOffsetFacesOptions Options;
+	Options.Distance = Distance;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshModelingFunctions::ApplyMeshOffsetFaces(Mesh, Options, Selection, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Offset %d faces by %.2f"), Selection.GetNumSelected(), Distance));
+}
+
+FModelingResult UModelingService::InsetFaces(int32 Handle, const FString& SelectionName, float Distance, float Softness)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	FGeometryScriptMeshInsetOutsetFacesOptions Options;
+	Options.Distance = Distance;
+	Options.Softness = Softness;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshModelingFunctions::ApplyMeshInsetOutsetFaces(Mesh, Options, Selection, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Inset %d faces by %.2f"), Selection.GetNumSelected(), Distance));
+}
+
+FModelingResult UModelingService::OutsetFaces(int32 Handle, const FString& SelectionName, float Distance, float Softness)
+{
+	// GeometryScript's inset/outset op uses the sign of the distance: negative = outset.
+	FModelingResult R = InsetFaces(Handle, SelectionName, -FMath::Abs(Distance), Softness);
+	if (R.bSuccess) { R.Message = R.Message.Replace(TEXT("Inset"), TEXT("Outset")); }
+	return R;
+}
+
+FModelingResult UModelingService::DeleteFaces(int32 Handle, const FString& SelectionName)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	int32 NumDeleted = 0;
+	UGeometryScriptLibrary_MeshBasicEditFunctions::DeleteSelectedTrianglesFromMesh(Mesh, Selection, NumDeleted, false);
+	return Ok(Handle, Mesh, FString::Printf(TEXT("Deleted %d triangles"), NumDeleted));
+}
+
+FModelingResult UModelingService::TranslateSelection(int32 Handle, const FString& SelectionName, FVector Delta)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshTransformFunctions::TranslateMeshSelection(Mesh, Selection, Delta, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Translated selection"));
+}
+
+FModelingResult UModelingService::BevelPolygroups(int32 Handle, float Distance, int32 Subdivisions, float RoundWeight)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshBevelOptions Options;
+	Options.BevelDistance = Distance;
+	Options.Subdivisions = Subdivisions;
+	Options.RoundWeight = RoundWeight;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshModelingFunctions::ApplyMeshPolygroupBevel(Mesh, Options, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Beveled polygroup edges by %.2f"), Distance));
+}
+
+FModelingResult UModelingService::OffsetMesh(int32 Handle, float Distance)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshOffsetOptions Options;
+	Options.OffsetDistance = Distance;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshModelingFunctions::ApplyMeshOffset(Mesh, Options, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Offset surface by %.2f"), Distance));
+}
+
+FModelingResult UModelingService::ShellMesh(int32 Handle, float Thickness)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshOffsetOptions Options;
+	Options.OffsetDistance = Thickness;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshModelingFunctions::ApplyMeshShell(Mesh, Options, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Shelled with thickness %.2f"), Thickness));
+}
+
+// =========================================================================
+// Mesh processing
+// =========================================================================
+
+FModelingResult UModelingService::Remesh(int32 Handle, int32 TargetTriangleCount, float EdgeLength, bool bReprojectToInput)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptRemeshOptions RemeshOptions;
+	RemeshOptions.bReprojectToInputMesh = bReprojectToInput;
+	FGeometryScriptUniformRemeshOptions UniformOptions;
+	if (EdgeLength > 0.f)
+	{
+		UniformOptions.TargetType = EGeometryScriptUniformRemeshTargetType::TargetEdgeLength;
+		UniformOptions.TargetEdgeLength = EdgeLength;
+	}
+	else
+	{
+		UniformOptions.TargetType = EGeometryScriptUniformRemeshTargetType::TriangleCount;
+		UniformOptions.TargetTriangleCount = FMath::Max(4, TargetTriangleCount);
+	}
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_RemeshingFunctions::ApplyUniformRemesh(Mesh, RemeshOptions, UniformOptions, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Remeshed"));
+}
+
+FModelingResult UModelingService::SimplifyToTriangleCount(int32 Handle, int32 TriangleCount, bool bAllowSeamCollapse)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptSimplifyMeshOptions Options;
+	Options.bAllowSeamCollapse = bAllowSeamCollapse;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshSimplifyFunctions::ApplySimplifyToTriangleCount(Mesh, FMath::Max(4, TriangleCount), Options, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Simplified toward %d triangles"), TriangleCount));
+}
+
+FModelingResult UModelingService::SimplifyToTolerance(int32 Handle, float Tolerance, bool bAllowSeamCollapse)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptSimplifyMeshOptions Options;
+	Options.bAllowSeamCollapse = bAllowSeamCollapse;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshSimplifyFunctions::ApplySimplifyToTolerance(Mesh, Tolerance, Options, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Simplified to tolerance %.3f"), Tolerance));
+}
+
+FModelingResult UModelingService::Subdivide(int32 Handle, int32 Level, const FString& Method)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	Level = FMath::Clamp(Level, 1, 6);
+	UGeometryScriptDebug* Debug = NewDebug();
+	const FString M = Method.TrimStartAndEnd();
+	UDynamicMesh* Result = Mesh;
+	if (M.Equals(TEXT("PN"), ESearchCase::IgnoreCase))
+	{
+		FGeometryScriptPNTessellateOptions Options;
+		Result = UGeometryScriptLibrary_MeshSubdivideFunctions::ApplyPNTessellation(Mesh, Options, Level, Debug);
+	}
+	else if (M.Equals(TEXT("Uniform"), ESearchCase::IgnoreCase))
+	{
+		Result = UGeometryScriptLibrary_MeshSubdivideFunctions::ApplyUniformTessellation(Mesh, Level, Debug);
+	}
+	else if (M.Equals(TEXT("CatmullClark"), ESearchCase::IgnoreCase))
+	{
+		Result = UGeometryScriptLibrary_OpenSubdivFunctions::ApplyPolygroupCatmullClarkSubD(Mesh, Level, FGeometryScriptGroupLayer(), Debug);
+	}
+	else if (M.Equals(TEXT("Loop"), ESearchCase::IgnoreCase))
+	{
+		Result = UGeometryScriptLibrary_OpenSubdivFunctions::ApplyTriangleLoopSubD(Mesh, Level, Debug);
+	}
+	else
+	{
+		return Fail(Handle, FString::Printf(TEXT("Unknown subdivide method '%s' (use PN, Uniform, CatmullClark, Loop)"), *Method));
+	}
+	if (Result && Result != Mesh)
+	{
+		UDynamicMesh* Out = nullptr;
+		UGeometryScriptLibrary_MeshDecompositionFunctions::CopyMeshToMesh(Result, Mesh, Out, Debug);
+	}
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Subdivided (%s, level %d)"), *M, Level));
+}
+
+FModelingResult UModelingService::Smooth(int32 Handle, const FString& SelectionName, int32 Iterations, float Alpha)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	FGeometryScriptIterativeMeshSmoothingOptions Options;
+	Options.NumIterations = FMath::Max(1, Iterations);
+	Options.Alpha = Alpha;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshDeformFunctions::ApplyIterativeSmoothingToMesh(Mesh, Selection, Options, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Smoothed (%d iterations)"), Iterations));
+}
+
+FModelingResult UModelingService::FillHoles(int32 Handle)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptFillHolesOptions Options;
+	int32 NumFilled = 0, NumFailed = 0;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshRepairFunctions::FillAllMeshHoles(Mesh, Options, NumFilled, NumFailed, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Filled %d holes (%d failed)"), NumFilled, NumFailed));
+}
+
+FModelingResult UModelingService::WeldEdges(int32 Handle, float Tolerance)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptWeldEdgesOptions Options;
+	Options.Tolerance = Tolerance;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshRepairFunctions::WeldMeshEdges(Mesh, Options, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Welded edges"));
+}
+
+FModelingResult UModelingService::Repair(int32 Handle, float MinComponentVolume, int32 MinComponentTriangles)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	const int32 Before = TriCount(Mesh);
+	FGeometryScriptDegenerateTriangleOptions DegenerateOptions;
+	UGeometryScriptLibrary_MeshRepairFunctions::RepairMeshDegenerateGeometry(Mesh, DegenerateOptions, Debug);
+	FGeometryScriptRemoveSmallComponentOptions SmallOptions;
+	SmallOptions.MinVolume = MinComponentVolume;
+	SmallOptions.MinTriangleCount = MinComponentTriangles;
+	UGeometryScriptLibrary_MeshRepairFunctions::RemoveSmallComponents(Mesh, SmallOptions, Debug);
+	UGeometryScriptLibrary_MeshRepairFunctions::CompactMesh(Mesh, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Repaired (%d -> %d triangles)"), Before, TriCount(Mesh)));
+}
+
+FModelingResult UModelingService::RemoveHiddenTriangles(int32 Handle)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptRemoveHiddenTrianglesOptions Options;
+	UGeometryScriptDebug* Debug = NewDebug();
+	const int32 Before = TriCount(Mesh);
+	UGeometryScriptLibrary_MeshRepairFunctions::RemoveHiddenTriangles(Mesh, Options, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Removed %d hidden triangles"), Before - TriCount(Mesh)));
+}
+
+FModelingSplitResult UModelingService::SplitByComponents(int32 Handle)
+{
+	FModelingSplitResult Result;
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh)
+	{
+		Result.Message = NoMesh(Handle).Message;
+		return Result;
+	}
+	UDynamicMeshPool* Pool = UGeometryScriptLibrary_MeshPoolFunctions::GetGlobalMeshPool();
+	TArray<UDynamicMesh*> Parts;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshDecompositionFunctions::SplitMeshByComponents(Mesh, Parts, Pool, Debug);
+	if (DebugHasErrors(Debug))
+	{
+		Result.Message = DebugText(Debug);
+		return Result;
+	}
+	TArray<TPair<int32, int32>> HandlesByTriangles; // (triangle count, handle)
+	for (UDynamicMesh* Part : Parts)
+	{
+		if (!Part) { continue; }
+		int32 NewHandle = -1;
+		UDynamicMesh* Target = NewSessionMesh(NewHandle);
+		UDynamicMesh* Out = nullptr;
+		UGeometryScriptLibrary_MeshDecompositionFunctions::CopyMeshToMesh(Part, Target, Out, Debug);
+		HandlesByTriangles.Emplace(TriCount(Target), NewHandle);
+		if (Pool) { Pool->ReturnMesh(Part); }
+	}
+	HandlesByTriangles.Sort([](const TPair<int32, int32>& A, const TPair<int32, int32>& B) { return A.Key > B.Key; });
+	for (const TPair<int32, int32>& Entry : HandlesByTriangles)
+	{
+		Result.Handles.Add(Entry.Value);
+	}
+	Result.bSuccess = true;
+	Result.Message = FString::Printf(TEXT("Split into %d components (largest first); source handle %d unchanged"), Result.Handles.Num(), Handle);
+	return Result;
+}
+
+// =========================================================================
+// Deformation
+// =========================================================================
+
+FModelingResult UModelingService::Bend(int32 Handle, FTransform Orientation, float AngleDeg, float Extent, bool bBidirectional)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptBendWarpOptions Options;
+	Options.bBidirectional = bBidirectional;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshDeformFunctions::ApplyBendWarpToMesh(Mesh, Options, Orientation, AngleDeg, Extent, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Bent %.1f degrees"), AngleDeg));
+}
+
+FModelingResult UModelingService::Twist(int32 Handle, FTransform Orientation, float AngleDeg, float Extent, bool bBidirectional)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptTwistWarpOptions Options;
+	Options.bBidirectional = bBidirectional;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshDeformFunctions::ApplyTwistWarpToMesh(Mesh, Options, Orientation, AngleDeg, Extent, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Twisted %.1f degrees"), AngleDeg));
+}
+
+FModelingResult UModelingService::Flare(int32 Handle, FTransform Orientation, float PercentX, float PercentY, float Extent)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptFlareWarpOptions Options;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshDeformFunctions::ApplyFlareWarpToMesh(Mesh, Options, Orientation, PercentX, PercentY, Extent, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Flared"));
+}
+
+FModelingResult UModelingService::Noise(int32 Handle, const FString& SelectionName, float Magnitude, float Frequency, int32 RandomSeed)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	FGeometryScriptPerlinNoiseOptions Options;
+	Options.BaseLayer.Magnitude = Magnitude;
+	Options.BaseLayer.Frequency = Frequency;
+	Options.BaseLayer.RandomSeed = RandomSeed;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshDeformFunctions::ApplyPerlinNoiseToMesh2(Mesh, Selection, Options, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Applied noise (magnitude %.2f, frequency %.3f)"), Magnitude, Frequency));
+}
+
+FModelingResult UModelingService::DisplaceFromTexture(int32 Handle, const FString& SelectionName, const FString& TexturePath, float Magnitude, int32 UVLayer)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UTexture2D* Texture = LoadAssetAs<UTexture2D>(TexturePath);
+	if (!Texture) { return Fail(Handle, FString::Printf(TEXT("Texture2D not found: %s"), *TexturePath)); }
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	FGeometryScriptDisplaceFromTextureOptions Options;
+	Options.Magnitude = Magnitude;
+	FGeometryScriptAdaptiveTessellationOptions TessellationOptions;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshDeformFunctions::ApplyDisplaceFromTextureMap(Mesh, Texture, Selection, Options, TessellationOptions, UVLayer, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Displaced from %s"), *TexturePath));
+}
+
+// =========================================================================
+// Voxel operations
+// =========================================================================
+
+FModelingResult UModelingService::VoxelSolidify(int32 Handle, int32 GridResolution, float WindingThreshold)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptSolidifyOptions Options;
+	Options.GridParameters.SizeMethod = EGeometryScriptGridSizingMethod::GridResolution;
+	Options.GridParameters.GridResolution = FMath::Clamp(GridResolution, 8, 512);
+	Options.WindingThreshold = WindingThreshold;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshVoxelFunctions::ApplyMeshSolidify(Mesh, Options, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Solidified at grid %d"), GridResolution));
+}
+
+FModelingResult UModelingService::VoxelMorphology(int32 Handle, const FString& Operation, float Distance, int32 GridResolution)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMorphologyOptions Options;
+	if (!ParseEnum(Operation, Options.Operation))
+	{
+		return Fail(Handle, FString::Printf(TEXT("Unknown morphology operation '%s' (use %s)"), *Operation, *EnumNames<EGeometryScriptMorphologicalOpType>()));
+	}
+	Options.Distance = Distance;
+	Options.SDFGridParameters.SizeMethod = EGeometryScriptGridSizingMethod::GridResolution;
+	Options.SDFGridParameters.GridResolution = FMath::Clamp(GridResolution, 8, 512);
+	Options.MeshGridParameters = Options.SDFGridParameters;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshVoxelFunctions::ApplyMeshMorphology(Mesh, Options, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Morphology %s by %.2f"), *Operation, Distance));
+}
+
+// =========================================================================
+// UVs, normals, groups, materials, colors
+// =========================================================================
+
+FModelingResult UModelingService::AutoUV(int32 Handle, const FString& Method, int32 UVLayer)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	if (GetMeshInfo(Handle).NumUVLayers <= UVLayer)
+	{
+		UGeometryScriptLibrary_MeshUVFunctions::SetNumUVSets(Mesh, UVLayer + 1, Debug);
+	}
+	if (Method.Equals(TEXT("XAtlas"), ESearchCase::IgnoreCase))
+	{
+		FGeometryScriptXAtlasOptions Options;
+		UGeometryScriptLibrary_MeshUVFunctions::AutoGenerateXAtlasMeshUVs(Mesh, UVLayer, Options, Debug);
+	}
+	else if (Method.Equals(TEXT("PatchBuilder"), ESearchCase::IgnoreCase))
+	{
+		FGeometryScriptPatchBuilderOptions Options;
+		UGeometryScriptLibrary_MeshUVFunctions::AutoGeneratePatchBuilderMeshUVs(Mesh, UVLayer, Options, Debug);
+	}
+	else
+	{
+		return Fail(Handle, FString::Printf(TEXT("Unknown UV method '%s' (use XAtlas or PatchBuilder)"), *Method));
+	}
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Generated UVs (%s) in layer %d"), *Method, UVLayer));
+}
+
+FModelingResult UModelingService::ProjectUV(int32 Handle, const FString& Method, FTransform ProjectorTransform, int32 UVLayer, const FString& SelectionName)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	if (GetMeshInfo(Handle).NumUVLayers <= UVLayer)
+	{
+		UGeometryScriptLibrary_MeshUVFunctions::SetNumUVSets(Mesh, UVLayer + 1, Debug);
+	}
+	if (Method.Equals(TEXT("Planar"), ESearchCase::IgnoreCase))
+	{
+		UGeometryScriptLibrary_MeshUVFunctions::SetMeshUVsFromPlanarProjection(Mesh, UVLayer, ProjectorTransform, Selection, Debug);
+	}
+	else if (Method.Equals(TEXT("Box"), ESearchCase::IgnoreCase))
+	{
+		UGeometryScriptLibrary_MeshUVFunctions::SetMeshUVsFromBoxProjection(Mesh, UVLayer, ProjectorTransform, Selection, 2, Debug);
+	}
+	else if (Method.Equals(TEXT("Cylinder"), ESearchCase::IgnoreCase))
+	{
+		UGeometryScriptLibrary_MeshUVFunctions::SetMeshUVsFromCylinderProjection(Mesh, UVLayer, ProjectorTransform, Selection, 45.f, Debug);
+	}
+	else
+	{
+		return Fail(Handle, FString::Printf(TEXT("Unknown projection '%s' (use Planar, Box, Cylinder)"), *Method));
+	}
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Projected %s UVs into layer %d"), *Method, UVLayer));
+}
+
+FModelingResult UModelingService::RepackUV(int32 Handle, int32 UVLayer, int32 TextureResolution)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptRepackUVsOptions Options;
+	Options.TargetImageWidth = FMath::Max(64, TextureResolution);
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshUVFunctions::RepackMeshUVs(Mesh, UVLayer, Options, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Repacked UV layer %d"), UVLayer));
+}
+
+FModelingResult UModelingService::SetNumUVLayers(int32 Handle, int32 NumLayers)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshUVFunctions::SetNumUVSets(Mesh, FMath::Clamp(NumLayers, 1, 8), Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Set %d UV layers"), NumLayers));
+}
+
+FModelingResult UModelingService::RecomputeNormals(int32 Handle, float HardAngleDeg)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	FGeometryScriptCalculateNormalsOptions CalculateOptions;
+	if (HardAngleDeg < 0.f)
+	{
+		UGeometryScriptLibrary_MeshNormalsFunctions::SetPerVertexNormals(Mesh, Debug);
+		UGeometryScriptLibrary_MeshNormalsFunctions::RecomputeNormals(Mesh, CalculateOptions, false, Debug);
+		return Finish(Handle, Mesh, Debug, TEXT("Recomputed smooth normals"));
+	}
+	FGeometryScriptSplitNormalsOptions SplitOptions;
+	SplitOptions.bSplitByOpeningAngle = true;
+	SplitOptions.OpeningAngleDeg = HardAngleDeg;
+	UGeometryScriptLibrary_MeshNormalsFunctions::ComputeSplitNormals(Mesh, SplitOptions, CalculateOptions, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Recomputed normals (hard edges over %.1f degrees)"), HardAngleDeg));
+}
+
+FModelingResult UModelingService::FlipNormals(int32 Handle)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshNormalsFunctions::FlipNormals(Mesh, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Flipped normals"));
+}
+
+FModelingResult UModelingService::ComputePolygroups(int32 Handle, float CreaseAngleDeg, int32 MinGroupSize)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshPolygroupFunctions::ComputePolygroupsFromAngleThreshold(Mesh, FGeometryScriptGroupLayer(), CreaseAngleDeg, MinGroupSize, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Computed polygroups (crease %.1f degrees)"), CreaseAngleDeg));
+}
+
+FModelingResult UModelingService::SetMaterialID(int32 Handle, const FString& SelectionName, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshMaterialFunctions::EnableMaterialIDs(Mesh, Debug);
+	UGeometryScriptLibrary_MeshMaterialFunctions::SetMaterialIDForMeshSelection(Mesh, Selection, MaterialID, false, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Set material ID %d on %d triangles"), MaterialID, Selection.GetNumSelected()));
+}
+
+FModelingResult UModelingService::SetVertexColor(int32 Handle, const FString& SelectionName, FLinearColor Color)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	FGeometryScriptColorFlags Flags;
+	if (SelectionName.IsEmpty())
+	{
+		UGeometryScriptLibrary_MeshVertexColorFunctions::SetMeshConstantVertexColor(Mesh, Color, Flags, false, Debug);
+		return Finish(Handle, Mesh, Debug, TEXT("Set constant vertex color"));
+	}
+	FGeometryScriptMeshSelection Selection; FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	if (!GetMeshInfo(Handle).bHasVertexColors)
+	{
+		UGeometryScriptLibrary_MeshVertexColorFunctions::SetMeshConstantVertexColor(Mesh, FLinearColor::White, Flags, false, Debug);
+	}
+	UGeometryScriptLibrary_MeshVertexColorFunctions::SetMeshSelectionVertexColor(Mesh, Selection, Color, Flags, false, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Set vertex color on selection '%s'"), *SelectionName));
+}
+
+// =========================================================================
+// Transform
+// =========================================================================
+
+FModelingResult UModelingService::TransformMesh(int32 Handle, FTransform Transform)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshTransformFunctions::TransformMesh(Mesh, Transform, true, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Transformed"));
+}
+
+FModelingResult UModelingService::TranslateMesh(int32 Handle, FVector Translation)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshTransformFunctions::TranslateMesh(Mesh, Translation, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Translated"));
+}
+
+FModelingResult UModelingService::RotateMesh(int32 Handle, FRotator Rotation, FVector Origin)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshTransformFunctions::RotateMesh(Mesh, Rotation, Origin, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Rotated"));
+}
+
+FModelingResult UModelingService::ScaleMesh(int32 Handle, FVector Scale, FVector Origin)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshTransformFunctions::ScaleMesh(Mesh, Scale, Origin, true, Debug);
+	return Finish(Handle, Mesh, Debug, TEXT("Scaled"));
+}
+
+FModelingResult UModelingService::RecenterMesh(int32 Handle, const FString& Mode)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	const FBox Bounds = UGeometryScriptLibrary_MeshQueryFunctions::GetMeshBoundingBox(Mesh);
+	FVector Shift;
+	if (Mode.Equals(TEXT("Bounds"), ESearchCase::IgnoreCase))
+	{
+		Shift = -Bounds.GetCenter();
+	}
+	else if (Mode.Equals(TEXT("Base"), ESearchCase::IgnoreCase))
+	{
+		const FVector Center = Bounds.GetCenter();
+		Shift = FVector(-Center.X, -Center.Y, -Bounds.Min.Z);
+	}
+	else
+	{
+		return Fail(Handle, FString::Printf(TEXT("Unknown recenter mode '%s' (use Bounds or Base)"), *Mode));
+	}
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshTransformFunctions::TranslateMesh(Mesh, Shift, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Recentered (%s), shifted by %s"), *Mode, *Shift.ToCompactString()));
+}
+
+// =========================================================================
+// Assets, collision, LODs, baking, placement
+// =========================================================================
+
+FModelingResult UModelingService::SaveMeshToStaticMesh(int32 Handle, const FString& AssetPath, bool bReplaceExisting, bool bEnableCollision,
+	bool bEnableNanite, bool bSaveAsset)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	if (TriCount(Mesh) == 0) { return Fail(Handle, TEXT("Mesh is empty; nothing to save")); }
+	if (!AssetPath.StartsWith(TEXT("/"))) { return Fail(Handle, TEXT("AssetPath must be a content path like /Game/Props/SM_Crate")); }
+
+	UGeometryScriptDebug* Debug = NewDebug();
+	EGeometryScriptOutcomePins Outcome = EGeometryScriptOutcomePins::Failure;
+	UStaticMesh* StaticMesh = nullptr;
+	FString What;
+	if (UEditorAssetLibrary::DoesAssetExist(AssetPath))
+	{
+		StaticMesh = LoadAssetAs<UStaticMesh>(AssetPath);
+		if (!StaticMesh) { return Fail(Handle, FString::Printf(TEXT("%s exists but is not a StaticMesh"), *AssetPath)); }
+		if (!bReplaceExisting) { return Fail(Handle, FString::Printf(TEXT("%s already exists (pass replace_existing=True to overwrite LOD0)"), *AssetPath)); }
+		FGeometryScriptCopyMeshToAssetOptions Options;
+		FGeometryScriptMeshWriteLOD WriteLOD;
+		WriteLOD.LODIndex = 0;
+		UGeometryScriptLibrary_StaticMeshFunctions::CopyMeshToStaticMesh(Mesh, StaticMesh, Options, WriteLOD, Outcome, true, Debug);
+		What = FString::Printf(TEXT("Replaced LOD0 of %s"), *AssetPath);
+	}
+	else
+	{
+		FGeometryScriptCreateNewStaticMeshAssetOptions Options;
+		Options.bEnableCollision = bEnableCollision;
+		Options.bEnableNanite = bEnableNanite;
+		StaticMesh = UGeometryScriptLibrary_CreateNewAssetFunctions::CreateNewStaticMeshAssetFromMesh(Mesh, AssetPath, Options, Outcome, Debug);
+		What = FString::Printf(TEXT("Created %s"), *AssetPath);
+	}
+	if (Outcome != EGeometryScriptOutcomePins::Success || !StaticMesh)
+	{
+		return Fail(Handle, FString::Printf(TEXT("Saving to %s failed: %s"), *AssetPath, *DebugText(Debug)));
+	}
+	SaveIf(bSaveAsset, StaticMesh->GetPathName());
+	FModelingResult R = Ok(Handle, Mesh, What);
+	R.AssetPath = StaticMesh->GetPathName();
+	return R;
+}
+
+FModelingResult UModelingService::SaveMeshToSkeletalMesh(int32 Handle, const FString& AssetPath, const FString& SkeletonPath, bool bReplaceExisting, bool bSaveAsset)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	if (TriCount(Mesh) == 0) { return Fail(Handle, TEXT("Mesh is empty; nothing to save")); }
+	USkeleton* Skeleton = LoadAssetAs<USkeleton>(SkeletonPath);
+	if (!Skeleton) { return Fail(Handle, FString::Printf(TEXT("Skeleton not found: %s"), *SkeletonPath)); }
+
+	UGeometryScriptDebug* Debug = NewDebug();
+	EGeometryScriptOutcomePins Outcome = EGeometryScriptOutcomePins::Failure;
+	USkeletalMesh* SkeletalMesh = nullptr;
+	FString What;
+	if (UEditorAssetLibrary::DoesAssetExist(AssetPath))
+	{
+		SkeletalMesh = LoadAssetAs<USkeletalMesh>(AssetPath);
+		if (!SkeletalMesh) { return Fail(Handle, FString::Printf(TEXT("%s exists but is not a SkeletalMesh"), *AssetPath)); }
+		if (!bReplaceExisting) { return Fail(Handle, FString::Printf(TEXT("%s already exists (pass replace_existing=True to overwrite LOD0)"), *AssetPath)); }
+		FGeometryScriptCopyMeshToAssetOptions Options;
+		FGeometryScriptMeshWriteLOD WriteLOD;
+		WriteLOD.LODIndex = 0;
+		UGeometryScriptLibrary_StaticMeshFunctions::CopyMeshToSkeletalMesh(Mesh, SkeletalMesh, Options, WriteLOD, Outcome, Debug);
+		What = FString::Printf(TEXT("Replaced LOD0 of %s"), *AssetPath);
+	}
+	else
+	{
+		FGeometryScriptCreateNewSkeletalMeshAssetOptions Options;
+		SkeletalMesh = UGeometryScriptLibrary_CreateNewAssetFunctions::CreateNewSkeletalMeshAssetFromMesh(Mesh, Skeleton, AssetPath, Options, Outcome, Debug);
+		What = FString::Printf(TEXT("Created %s"), *AssetPath);
+	}
+	if (Outcome != EGeometryScriptOutcomePins::Success || !SkeletalMesh)
+	{
+		return Fail(Handle, FString::Printf(TEXT("Saving to %s failed: %s"), *AssetPath, *DebugText(Debug)));
+	}
+	SaveIf(bSaveAsset, SkeletalMesh->GetPathName());
+	FModelingResult R = Ok(Handle, Mesh, What);
+	R.AssetPath = SkeletalMesh->GetPathName();
+	return R;
+}
+
+FModelingResult UModelingService::TransferBoneWeights(int32 Handle, const FString& SourceSkeletalMeshPath, int32 SourceLODIndex)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	USkeletalMesh* SkeletalMesh = LoadAssetAs<USkeletalMesh>(SourceSkeletalMeshPath);
+	if (!SkeletalMesh) { return Fail(Handle, FString::Printf(TEXT("SkeletalMesh not found: %s"), *SourceSkeletalMeshPath)); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UDynamicMesh* Source = NewScratchMesh();
+	if (!CopyFromSkeletalMesh(SkeletalMesh, Source, SourceLODIndex, Debug))
+	{
+		return Fail(Handle, FString::Printf(TEXT("Could not read %s: %s"), *SourceSkeletalMeshPath, *DebugText(Debug)));
+	}
+	UGeometryScriptLibrary_MeshBoneWeightFunctions::TransferBoneWeightsFromMesh(Source, Mesh, FGeometryScriptTransferBoneWeightsOptions(), FGeometryScriptMeshSelection(), Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Transferred bone weights from %s"), *SourceSkeletalMeshPath));
+}
+
+FModelingResult UModelingService::GenerateCollision(const FString& AssetPath, const FString& Method, int32 MaxConvexHulls, int32 ConvexHullTargetFaceCount, bool bSaveAsset)
+{
+	UStaticMesh* StaticMesh = LoadAssetAs<UStaticMesh>(AssetPath);
+	if (!StaticMesh) { return Fail(-1, FString::Printf(TEXT("StaticMesh not found: %s"), *AssetPath)); }
+	FGeometryScriptCollisionFromMeshOptions Options;
+	if (!ParseEnum(Method, Options.Method))
+	{
+		return Fail(-1, FString::Printf(TEXT("Unknown collision method '%s' (use %s)"), *Method, *EnumNames<EGeometryScriptCollisionGenerationMethod>()));
+	}
+	Options.MaxConvexHullsPerMesh = FMath::Max(1, MaxConvexHulls);
+	Options.ConvexHullTargetFaceCount = FMath::Max(4, ConvexHullTargetFaceCount);
+	UGeometryScriptDebug* Debug = NewDebug();
+	UDynamicMesh* Scratch = NewScratchMesh();
+	if (!CopyFromStaticMesh(StaticMesh, Scratch, 0, Debug))
+	{
+		return Fail(-1, FString::Printf(TEXT("Could not read %s: %s"), *AssetPath, *DebugText(Debug)));
+	}
+	UGeometryScriptLibrary_CollisionFunctions::SetStaticMeshCollisionFromMesh(Scratch, StaticMesh, Options, FGeometryScriptSetStaticMeshCollisionOptions(), Debug);
+	if (DebugHasErrors(Debug))
+	{
+		return Fail(-1, FString::Printf(TEXT("Collision generation failed: %s"), *DebugText(Debug)));
+	}
+	SaveIf(bSaveAsset, AssetPath);
+	FModelingResult R = Ok(-1, Scratch, FString::Printf(TEXT("Generated %s collision on %s"), *Method, *AssetPath));
+	R.AssetPath = AssetPath;
+	return R;
+}
+
+FModelingResult UModelingService::SetLODs(const FString& AssetPath, const TArray<float>& PercentTrianglesPerLOD, bool bAutoComputeScreenSize, bool bSaveAsset)
+{
+	UStaticMesh* StaticMesh = LoadAssetAs<UStaticMesh>(AssetPath);
+	if (!StaticMesh) { return Fail(-1, FString::Printf(TEXT("StaticMesh not found: %s"), *AssetPath)); }
+	if (PercentTrianglesPerLOD.Num() == 0) { return Fail(-1, TEXT("Give one PercentTriangles entry per LOD, e.g. [1.0, 0.5, 0.25]")); }
+	UStaticMeshEditorSubsystem* Subsystem = GEditor ? GEditor->GetEditorSubsystem<UStaticMeshEditorSubsystem>() : nullptr;
+	if (!Subsystem) { return Fail(-1, TEXT("StaticMeshEditorSubsystem unavailable")); }
+	FStaticMeshReductionOptions Options;
+	Options.bAutoComputeLODScreenSize = bAutoComputeScreenSize;
+	for (int32 i = 0; i < PercentTrianglesPerLOD.Num(); ++i)
+	{
+		FStaticMeshReductionSettings Settings;
+		Settings.PercentTriangles = FMath::Clamp(PercentTrianglesPerLOD[i], 0.01f, 1.f);
+		Settings.ScreenSize = 1.f / FMath::Pow(2.f, static_cast<float>(i));
+		Options.ReductionSettings.Add(Settings);
+	}
+	const int32 NumLODs = Subsystem->SetLods(StaticMesh, Options);
+	if (NumLODs < 0)
+	{
+		return Fail(-1, FString::Printf(TEXT("SetLods failed on %s"), *AssetPath));
+	}
+	SaveIf(bSaveAsset, AssetPath);
+	FModelingResult R;
+	R.bSuccess = true;
+	R.AssetPath = AssetPath;
+	R.Message = FString::Printf(TEXT("%s now has %d LODs"), *AssetPath, NumLODs);
+	return R;
+}
+
+FModelingBakeResult UModelingService::BakeTextures(int32 TargetHandle, int32 SourceHandle, const FString& BakeTypes, int32 Resolution, const FString& OutputFolder,
+	const FString& BaseName, int32 TargetUVLayer, int32 SamplesPerPixel)
+{
+	FModelingBakeResult Result;
+	UDynamicMesh* Target = FindMesh(TargetHandle);
+	if (!Target) { Result.Message = NoMesh(TargetHandle).Message; return Result; }
+	UDynamicMesh* Source = FindMesh(SourceHandle);
+	if (!Source) { Result.Message = NoMesh(SourceHandle).Message; return Result; }
+	if (!OutputFolder.StartsWith(TEXT("/")) || BaseName.IsEmpty()) { Result.Message = TEXT("OutputFolder must be a content path (e.g. /Game/Textures) and BaseName non-empty"); return Result; }
+
+	TArray<FString> TypeNames;
+	BakeTypes.ParseIntoArray(TypeNames, TEXT(","), true);
+	TArray<FGeometryScriptBakeTypeOptions> Types;
+	TArray<FString> Suffixes;
+	for (FString Name : TypeNames)
+	{
+		Name.TrimStartAndEndInline();
+		if (Name.Equals(TEXT("TangentNormal"), ESearchCase::IgnoreCase)) { Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypeTangentNormal()); Suffixes.Add(TEXT("N")); }
+		else if (Name.Equals(TEXT("ObjectNormal"), ESearchCase::IgnoreCase)) { Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypeObjectNormal()); Suffixes.Add(TEXT("ON")); }
+		else if (Name.Equals(TEXT("FaceNormal"), ESearchCase::IgnoreCase)) { Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypeFaceNormal()); Suffixes.Add(TEXT("FN")); }
+		else if (Name.Equals(TEXT("BentNormal"), ESearchCase::IgnoreCase)) { Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypeBentNormal()); Suffixes.Add(TEXT("BN")); }
+		else if (Name.Equals(TEXT("AmbientOcclusion"), ESearchCase::IgnoreCase)) { Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypeAmbientOcclusion()); Suffixes.Add(TEXT("AO")); }
+		else if (Name.Equals(TEXT("Curvature"), ESearchCase::IgnoreCase)) { Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypeCurvature()); Suffixes.Add(TEXT("Curv")); }
+		else if (Name.Equals(TEXT("Position"), ESearchCase::IgnoreCase)) { Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypePosition()); Suffixes.Add(TEXT("Pos")); }
+		else { Result.Message = FString::Printf(TEXT("Unknown bake type '%s' (use TangentNormal, ObjectNormal, FaceNormal, BentNormal, AmbientOcclusion, Curvature, Position)"), *Name); return Result; }
+	}
+	if (Types.Num() == 0) { Result.Message = TEXT("No bake types given"); return Result; }
+
+	FGeometryScriptBakeTargetMeshOptions TargetOptions;
+	TargetOptions.TargetUVLayer = TargetUVLayer;
+	FGeometryScriptBakeSourceMeshOptions SourceOptions;
+	FGeometryScriptBakeTextureOptions BakeOptions;
+	if (!ParseEnum(FString::Printf(TEXT("Resolution%d"), Resolution), BakeOptions.Resolution))
+	{
+		Result.Message = FString::Printf(TEXT("Unsupported resolution %d (use a power of two from 16 to 8192)"), Resolution);
+		return Result;
+	}
+	if (!ParseEnum(FString::Printf(TEXT("Sample%d"), SamplesPerPixel), BakeOptions.SamplesPerPixel))
+	{
+		BakeOptions.SamplesPerPixel = EGeometryScriptBakeSamplesPerPixel::Sample1;
+	}
+
+	UGeometryScriptDebug* Debug = NewDebug();
+	const TArray<UTexture2D*> Textures = UGeometryScriptLibrary_MeshBakeFunctions::BakeTexture(Target, FTransform::Identity, TargetOptions,
+		Source, FTransform::Identity, SourceOptions, Types, BakeOptions, Debug);
+	if (DebugHasErrors(Debug) || Textures.Num() != Types.Num())
+	{
+		Result.Message = FString::Printf(TEXT("Bake failed: %s"), *DebugText(Debug));
+		return Result;
+	}
+	for (int32 i = 0; i < Textures.Num(); ++i)
+	{
+		if (!Textures[i]) { continue; }
+		FGeometryScriptCreateNewTexture2DAssetOptions TextureOptions;
+		TextureOptions.bOverwriteIfExists = true;
+		EGeometryScriptOutcomePins Outcome = EGeometryScriptOutcomePins::Failure;
+		const FString AssetPath = OutputFolder / FString::Printf(TEXT("T_%s_%s"), *BaseName, *Suffixes[i]);
+		UTexture2D* Saved = UGeometryScriptLibrary_CreateNewAssetFunctions::CreateNewTexture2DAsset(Textures[i], AssetPath, TextureOptions, Outcome, Debug);
+		if (Outcome != EGeometryScriptOutcomePins::Success || !Saved)
+		{
+			Result.Message = FString::Printf(TEXT("Could not save %s: %s"), *AssetPath, *DebugText(Debug));
+			return Result;
+		}
+		UEditorAssetLibrary::SaveAsset(Saved->GetPathName(), false);
+		Result.TexturePaths.Add(Saved->GetPathName());
+	}
+	Result.bSuccess = true;
+	Result.Message = FString::Printf(TEXT("Baked %d texture(s) at %d"), Result.TexturePaths.Num(), Resolution);
+	return Result;
+}
+
+FModelingResult UModelingService::SpawnStaticMeshActor(const FString& AssetPath, FTransform Transform, const FString& ActorLabel)
+{
+	UStaticMesh* StaticMesh = LoadAssetAs<UStaticMesh>(AssetPath);
+	if (!StaticMesh) { return Fail(-1, FString::Printf(TEXT("StaticMesh not found: %s"), *AssetPath)); }
+	UEditorActorSubsystem* ActorSubsystem = GEditor ? GEditor->GetEditorSubsystem<UEditorActorSubsystem>() : nullptr;
+	if (!ActorSubsystem) { return Fail(-1, TEXT("EditorActorSubsystem unavailable")); }
+	AActor* Actor = ActorSubsystem->SpawnActorFromObject(StaticMesh, Transform.GetLocation(), Transform.Rotator(), false);
+	if (!Actor) { return Fail(-1, FString::Printf(TEXT("Could not spawn an actor for %s"), *AssetPath)); }
+	Actor->SetActorScale3D(Transform.GetScale3D());
+	if (!ActorLabel.IsEmpty())
+	{
+		Actor->SetActorLabel(ActorLabel);
+	}
+	FModelingResult R;
+	R.bSuccess = true;
+	R.AssetPath = AssetPath;
+	R.Message = FString::Printf(TEXT("Spawned '%s' (%s) at %s"), *Actor->GetActorLabel(), *Actor->GetPathName(), *Transform.GetLocation().ToCompactString());
+	return R;
+}

--- a/Source/VibeUE/Private/PythonAPI/UModelingService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UModelingService.cpp
@@ -55,6 +55,12 @@
 #include "Subsystems/EditorActorSubsystem.h"
 #include "UObject/Package.h"
 #include "UObject/StrongObjectPtr.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "DynamicMesh/DynamicBoneAttribute.h"
+#include "DynamicMesh/DynamicVertexSkinWeightsAttribute.h"
+#include "Engine/SkinnedAssetCommon.h"
+#include "Materials/Material.h"
+#include "SkeletalMeshAttributes.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LogVibeModeling, Log, All);
 
@@ -1583,14 +1589,63 @@ FModelingResult UModelingService::SaveMeshToSkeletalMesh(int32 Handle, const FSt
 	UDynamicMesh* Mesh = FindMesh(Handle);
 	if (!Mesh) { return NoMesh(Handle); }
 	if (TriCount(Mesh) == 0) { return Fail(Handle, TEXT("Mesh is empty; nothing to save")); }
-	USkeleton* Skeleton = LoadAssetAs<USkeleton>(SkeletonPath);
-	if (!Skeleton) { return Fail(Handle, FString::Printf(TEXT("Skeleton not found: %s"), *SkeletonPath)); }
+	if (!AssetPath.StartsWith(TEXT("/"))) { return Fail(Handle, FString::Printf(TEXT("AssetPath must be a full package path like /Game/Folder/SK_Name (got '%s')"), *AssetPath)); }
+
+	bool bMeshHasBones = false;
+	bool bMeshHasWeights = false;
+	int32 MaxMaterialID = 0;
+	Mesh->ProcessMesh([&](const FDynamicMesh3& M)
+	{
+		if (!M.HasAttributes()) { return; }
+		bMeshHasBones = M.Attributes()->HasBones();
+		bMeshHasWeights = M.Attributes()->GetSkinWeightsAttributes().Num() > 0;
+		if (M.Attributes()->HasMaterialID())
+		{
+			const FDynamicMeshMaterialAttribute* MaterialIDs = M.Attributes()->GetMaterialID();
+			for (const int32 Tid : M.TriangleIndicesItr()) { MaxMaterialID = FMath::Max(MaxMaterialID, MaterialIDs->GetValue(Tid)); }
+		}
+	});
+	if (!bMeshHasWeights)
+	{
+		return Fail(Handle, TEXT("Mesh has no skin weights: run create_bones + bind_selection_to_bone (or transfer_bone_weights from a skeletal mesh) first"));
+	}
+
+	const bool bExists = UEditorAssetLibrary::DoesAssetExist(AssetPath);
+	USkeleton* Skeleton = nullptr;
+	FString SkeletonNote;
+	if (!SkeletonPath.IsEmpty())
+	{
+		Skeleton = LoadAssetAs<USkeleton>(SkeletonPath);
+		if (!Skeleton) { return Fail(Handle, FString::Printf(TEXT("Skeleton not found: %s"), *SkeletonPath)); }
+	}
+	else if (!bExists)
+	{
+		if (!bMeshHasBones)
+		{
+			return Fail(Handle, TEXT("No SkeletonPath and the mesh has no bones: pass an existing skeleton, or define bones with create_bones so one can be created"));
+		}
+		// Create an empty Skeleton next to the mesh; CreateSkeletalMeshAsset merges the mesh's bones into it.
+		const FString NewSkeletonPath = AssetPath + TEXT("_Skeleton");
+		if (UEditorAssetLibrary::DoesAssetExist(NewSkeletonPath))
+		{
+			Skeleton = LoadAssetAs<USkeleton>(NewSkeletonPath);
+			if (!Skeleton) { return Fail(Handle, FString::Printf(TEXT("%s exists but is not a Skeleton"), *NewSkeletonPath)); }
+		}
+		else
+		{
+			UPackage* Package = CreatePackage(*NewSkeletonPath);
+			Skeleton = NewObject<USkeleton>(Package, *FPackageName::GetLongPackageAssetName(NewSkeletonPath), RF_Public | RF_Standalone);
+			FAssetRegistryModule::AssetCreated(Skeleton);
+			Package->MarkPackageDirty();
+		}
+		SkeletonNote = FString::Printf(TEXT(" with skeleton %s"), *NewSkeletonPath);
+	}
 
 	UGeometryScriptDebug* Debug = NewDebug();
 	EGeometryScriptOutcomePins Outcome = EGeometryScriptOutcomePins::Failure;
 	USkeletalMesh* SkeletalMesh = nullptr;
 	FString What;
-	if (UEditorAssetLibrary::DoesAssetExist(AssetPath))
+	if (bExists)
 	{
 		SkeletalMesh = LoadAssetAs<USkeletalMesh>(AssetPath);
 		if (!SkeletalMesh) { return Fail(Handle, FString::Printf(TEXT("%s exists but is not a SkeletalMesh"), *AssetPath)); }
@@ -1604,14 +1659,26 @@ FModelingResult UModelingService::SaveMeshToSkeletalMesh(int32 Handle, const FSt
 	else
 	{
 		FGeometryScriptCreateNewSkeletalMeshAssetOptions Options;
+		// Bones authored on the mesh (create_bones, or copied from a source skeletal mesh) define the reference skeleton.
+		Options.bUseMeshBoneProportions = bMeshHasBones;
+		// One slot per material ID so multi-material meshes keep their sections; set_asset_materials fills them in.
+		for (int32 i = 0; i <= MaxMaterialID; ++i)
+		{
+			Options.Materials.Add(*FString::Printf(TEXT("Slot%d"), i), UMaterial::GetDefaultMaterial(MD_Surface));
+		}
 		SkeletalMesh = UGeometryScriptLibrary_CreateNewAssetFunctions::CreateNewSkeletalMeshAssetFromMesh(Mesh, Skeleton, AssetPath, Options, Outcome, Debug);
-		What = FString::Printf(TEXT("Created %s"), *AssetPath);
+		if (SkeletalMesh && Skeleton && !Skeleton->GetPreviewMesh())
+		{
+			Skeleton->SetPreviewMesh(SkeletalMesh);
+		}
+		What = FString::Printf(TEXT("Created %s%s (%d material slot(s))"), *AssetPath, *SkeletonNote, MaxMaterialID + 1);
 	}
 	if (Outcome != EGeometryScriptOutcomePins::Success || !SkeletalMesh)
 	{
 		return Fail(Handle, FString::Printf(TEXT("Saving to %s failed: %s"), *AssetPath, *DebugText(Debug)));
 	}
 	SaveIf(bSaveAsset, SkeletalMesh->GetPathName());
+	if (Skeleton) { SaveIf(bSaveAsset, Skeleton->GetPathName()); }
 	FModelingResult R = Ok(Handle, Mesh, What);
 	R.AssetPath = SkeletalMesh->GetPathName();
 	return R;
@@ -1755,6 +1822,7 @@ FModelingBakeResult UModelingService::BakeTextures(int32 TargetHandle, int32 Sou
 			Result.Message = FString::Printf(TEXT("Could not save %s: %s"), *AssetPath, *DebugText(Debug));
 			return Result;
 		}
+		Saved->BlockOnAnyAsyncBuild();   // the texture compiles asynchronously; finish it so a save or delete right after cannot race it
 		UEditorAssetLibrary::SaveAsset(Saved->GetPathName(), false);
 		Result.TexturePaths.Add(Saved->GetPathName());
 	}
@@ -2078,4 +2146,326 @@ FModelingResult UModelingService::PruneBoneWeights(int32 Handle, const FString& 
 	UGeometryScriptDebug* Debug = NewDebug();
 	UGeometryScriptLibrary_MeshBoneWeightFunctions::PruneBoneWeights(Mesh, Bones, Options, FGeometryScriptBoneWeightProfile(), Debug);
 	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Pruned %d bone(s) from skin weights"), Bones.Num()));
+}
+
+// =========================================================================
+// Lofts, orientation, connected pieces
+// =========================================================================
+
+FModelingResult UModelingService::EnsureOutward(int32 Handle)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	float Area = 0.f, Volume = 0.f;
+	UGeometryScriptLibrary_MeshQueryFunctions::GetMeshVolumeArea(Mesh, Area, Volume);
+	if (Volume >= 0.f)
+	{
+		return Ok(Handle, Mesh, FString::Printf(TEXT("Already outward-facing (volume %.1f)"), Volume));
+	}
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshNormalsFunctions::FlipNormals(Mesh, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Flipped an inward-facing mesh (volume was %.1f)"), Volume));
+}
+
+FModelingResult UModelingService::AppendLoft(int32 Handle, FTransform Transform, const TArray<FVector2D>& ProfilePoints, const TArray<FTransform>& Frames, int32 MaterialID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	if (ProfilePoints.Num() < 3) { return Fail(Handle, TEXT("ProfilePoints needs at least 3 points (a closed profile)")); }
+	if (Frames.Num() < 2) { return Fail(Handle, TEXT("Frames needs at least 2 transforms")); }
+	UGeometryScriptDebug* Debug = NewDebug();
+
+	// Closed-polygon sweep with caps, built in scratch so the orientation fix can only touch the new part.
+	// The generator maps profile X to each frame's Y axis and profile Y to its Z axis, scaled by the frame's Y/Z scale.
+	UDynamicMesh* Part = NewScratchMesh();
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendSweepPolygon(Part, PrimitiveOptions(MaterialID), Transform, ProfilePoints, Frames,
+		false, true, 1.f, 1.f, 0.f, 1.f, Debug);
+	float Area = 0.f, Volume = 0.f;
+	UGeometryScriptLibrary_MeshQueryFunctions::GetMeshVolumeArea(Part, Area, Volume);
+	if (Volume < 0.f)
+	{
+		UGeometryScriptLibrary_MeshNormalsFunctions::FlipNormals(Part, Debug);
+	}
+	UGeometryScriptLibrary_MeshBasicEditFunctions::AppendMesh(Mesh, Part, FTransform::Identity, false, FGeometryScriptAppendMeshOptions(), Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Appended loft (%d-point profile through %d frames%s)"),
+		ProfilePoints.Num(), Frames.Num(), Volume < 0.f ? TEXT(", flipped outward") : TEXT("")));
+}
+
+int32 UModelingService::SelectConnected(int32 Handle, const FString& SelectionName, FVector Point)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh || SelectionName.IsEmpty()) { return -1; }
+	UGeometryScriptDebug* Debug = NewDebug();
+	FGeometryScriptDynamicMeshBVH BVH;
+	UGeometryScriptLibrary_MeshSpatial::BuildBVHForMesh(Mesh, BVH, Debug);
+	FGeometryScriptTrianglePoint Nearest;
+	EGeometryScriptSearchOutcomePins Outcome = EGeometryScriptSearchOutcomePins::NotFound;
+	UGeometryScriptLibrary_MeshSpatial::FindNearestPointOnMesh(Mesh, BVH, Point, FGeometryScriptSpatialQueryOptions(), Nearest, Outcome, Debug);
+	FGeometryScriptMeshSelection Selection;
+	if (Outcome == EGeometryScriptSearchOutcomePins::Found && Nearest.bValid)
+	{
+		FGeometryScriptMeshSelection Seed;
+		UGeometryScriptLibrary_MeshSelectionFunctions::ConvertIndexArrayToMeshSelection(Mesh, TArray<int32>{ Nearest.TriangleID }, EGeometryScriptMeshSelectionType::Triangles, Seed);
+		UGeometryScriptLibrary_MeshSelectionFunctions::ExpandMeshSelectionToConnected(Mesh, Seed, Selection, EGeometryScriptTopologyConnectionType::Geometric);
+	}
+	StoreSelection(Handle, SelectionName, Selection);
+	return Selection.GetNumSelected();
+}
+
+// =========================================================================
+// Rigging: bones and skin weights authored on the mesh
+// =========================================================================
+
+namespace
+{
+	using FSkinWeights = FDynamicMeshVertexSkinWeightsAttribute;
+	using UE::AnimationCore::FBoneWeight;
+	using UE::AnimationCore::FBoneWeights;
+
+	/** Mesh-space reference pose of every bone (poses are stored relative to the parent, parents precede children). */
+	TArray<FTransform> BoneMeshTransforms(const FDynamicMeshAttributeSet* Attributes)
+	{
+		TArray<FTransform> Out;
+		const int32 Num = Attributes->GetNumBones();
+		Out.SetNum(Num);
+		for (int32 i = 0; i < Num; ++i)
+		{
+			const int32 Parent = Attributes->GetBoneParentIndices()->GetValue(i);
+			const FTransform& Local = Attributes->GetBonePoses()->GetValue(i);
+			Out[i] = (Parent >= 0 && Parent < i) ? Local * Out[Parent] : Local;
+		}
+		return Out;
+	}
+
+	int32 FindBoneIndexByName(const FDynamicMeshAttributeSet* Attributes, const FName Name)
+	{
+		for (int32 i = 0; i < Attributes->GetNumBones(); ++i)
+		{
+			if (Attributes->GetBoneNames()->GetValue(i) == Name) { return i; }
+		}
+		return INDEX_NONE;
+	}
+
+	FSkinWeights* DefaultSkinWeights(FDynamicMesh3& M)
+	{
+		return M.HasAttributes() ? M.Attributes()->GetSkinWeightsAttribute(FSkeletalMeshAttributes::DefaultSkinWeightProfileName) : nullptr;
+	}
+}
+
+FModelingResult UModelingService::CreateBones(int32 Handle, const TArray<FModelingBoneDef>& Bones)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	if (Bones.Num() == 0) { return Fail(Handle, TEXT("Bones is empty: pass at least a root bone")); }
+
+	TMap<FName, int32> IndexByName;
+	TArray<FName> Names;
+	TArray<int32> ParentIndices;
+	for (int32 i = 0; i < Bones.Num(); ++i)
+	{
+		const FName Name(*Bones[i].Name.TrimStartAndEnd());
+		if (Name.IsNone()) { return Fail(Handle, FString::Printf(TEXT("Bone %d has no name"), i)); }
+		if (IndexByName.Contains(Name)) { return Fail(Handle, FString::Printf(TEXT("Duplicate bone name '%s'"), *Name.ToString())); }
+		const FString ParentName = Bones[i].ParentName.TrimStartAndEnd();
+		int32 Parent = INDEX_NONE;
+		if (i == 0)
+		{
+			if (!ParentName.IsEmpty() && ParentName != TEXT("None"))
+			{
+				return Fail(Handle, FString::Printf(TEXT("The first bone ('%s') is the root and cannot have a parent"), *Name.ToString()));
+			}
+		}
+		else
+		{
+			const int32* Found = ParentName.IsEmpty() ? nullptr : IndexByName.Find(FName(*ParentName));
+			if (!Found)
+			{
+				return Fail(Handle, FString::Printf(TEXT("Bone '%s' needs a parent listed before it (got '%s'); only the first bone is a root"), *Name.ToString(), *ParentName));
+			}
+			Parent = *Found;
+		}
+		IndexByName.Add(Name, i);
+		Names.Add(Name);
+		ParentIndices.Add(Parent);
+	}
+
+	Mesh->EditMesh([&](FDynamicMesh3& M)
+	{
+		M.EnableAttributes();
+		FDynamicMeshAttributeSet* Attributes = M.Attributes();
+		Attributes->DisableBones();
+		Attributes->EnableBones(Bones.Num());
+		TArray<FTransform> MeshSpace;
+		for (int32 i = 0; i < Bones.Num(); ++i)
+		{
+			const FTransform& World = Bones[i].Transform;
+			MeshSpace.Add(World);
+			const int32 Parent = ParentIndices[i];
+			Attributes->GetBoneNames()->SetValue(i, Names[i]);
+			Attributes->GetBoneParentIndices()->SetValue(i, Parent);
+			Attributes->GetBonePoses()->SetValue(i, Parent >= 0 ? World.GetRelativeTransform(MeshSpace[Parent]) : World);
+		}
+	});
+
+	// A fresh default profile with everything on the root, so the mesh is a valid skeletal mesh immediately.
+	bool bProfileExisted = false;
+	UGeometryScriptLibrary_MeshBoneWeightFunctions::MeshCreateBoneWeights(Mesh, bProfileExisted, true, FGeometryScriptBoneWeightProfile());
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshBoneWeightFunctions::SetAllVertexBoneWeights(Mesh, TArray<FGeometryScriptBoneWeight>{ FGeometryScriptBoneWeight(0, 1.f) }, FGeometryScriptBoneWeightProfile(), Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Created %d bone(s) rooted at '%s'; every vertex bound to the root (bind_selection_to_bone to assign pieces)"), Bones.Num(), *Names[0].ToString()));
+}
+
+FModelingResult UModelingService::BindSelectionToBone(int32 Handle, const FString& SelectionName, const FString& BoneName, float Weight)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelection Selection;
+	FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+
+	int32 NumBones = 0;
+	int32 BoneIndex = INDEX_NONE;
+	const FName Bone(*BoneName.TrimStartAndEnd());
+	Mesh->ProcessMesh([&](const FDynamicMesh3& M)
+	{
+		if (M.HasAttributes() && M.Attributes()->HasBones())
+		{
+			NumBones = M.Attributes()->GetNumBones();
+			BoneIndex = FindBoneIndexByName(M.Attributes(), Bone);
+		}
+	});
+	if (NumBones == 0) { return Fail(Handle, TEXT("Mesh has no bones: run create_bones first (or load a skeletal mesh)")); }
+	if (BoneIndex == INDEX_NONE) { return Fail(Handle, FString::Printf(TEXT("No bone named '%s' (see list_bones)"), *BoneName)); }
+
+	bool bProfileExisted = false;
+	UGeometryScriptLibrary_MeshBoneWeightFunctions::MeshCreateBoneWeights(Mesh, bProfileExisted, false, FGeometryScriptBoneWeightProfile());
+
+	FGeometryScriptIndexList Vertices;
+	EGeometryScriptIndexType ResultType = EGeometryScriptIndexType::Any;
+	UGeometryScriptLibrary_MeshSelectionFunctions::ConvertMeshSelectionToIndexList(Mesh, Selection, Vertices, ResultType, EGeometryScriptIndexType::Vertex);
+	if (!Vertices.List.IsValid() || ResultType != EGeometryScriptIndexType::Vertex)
+	{
+		return Fail(Handle, FString::Printf(TEXT("Selection '%s' could not be converted to vertices"), *SelectionName));
+	}
+
+	const float W = FMath::Clamp(Weight, 0.f, 1.f);
+	int32 Count = 0;
+	Mesh->EditMesh([&](FDynamicMesh3& M)
+	{
+		FSkinWeights* Skin = DefaultSkinWeights(M);
+		if (!Skin) { return; }
+		for (const int32 Vid : *Vertices.List)
+		{
+			if (!M.IsVertex(Vid)) { continue; }
+			TArray<FBoneWeight> NewWeights;
+			if (W < 1.f)
+			{
+				FBoneWeights Existing;
+				Skin->GetValue(Vid, Existing);
+				for (int32 k = 0; k < Existing.Num(); ++k)
+				{
+					const FBoneWeight& Old = Existing[k];
+					if (Old.GetBoneIndex() != BoneIndex && Old.GetWeight() > 0.f)
+					{
+						NewWeights.Add(FBoneWeight(Old.GetBoneIndex(), Old.GetWeight() * (1.f - W)));
+					}
+				}
+			}
+			NewWeights.Add(FBoneWeight(static_cast<FBoneIndexType>(BoneIndex), W));
+			Skin->SetValue(Vid, FBoneWeights::Create(NewWeights));
+			++Count;
+		}
+	});
+	return Ok(Handle, Mesh, FString::Printf(TEXT("Bound %d vertices to '%s' (weight %.2f)"), Count, *Bone.ToString(), W));
+}
+
+TArray<FModelingBoneInfo> UModelingService::ListBones(int32 Handle)
+{
+	TArray<FModelingBoneInfo> Out;
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return Out; }
+	Mesh->ProcessMesh([&Out](const FDynamicMesh3& M)
+	{
+		if (!M.HasAttributes() || !M.Attributes()->HasBones()) { return; }
+		const FDynamicMeshAttributeSet* Attributes = M.Attributes();
+		const TArray<FTransform> MeshSpace = BoneMeshTransforms(Attributes);
+		Out.SetNum(Attributes->GetNumBones());
+		for (int32 i = 0; i < Out.Num(); ++i)
+		{
+			const int32 Parent = Attributes->GetBoneParentIndices()->GetValue(i);
+			Out[i].Index = i;
+			Out[i].Name = Attributes->GetBoneNames()->GetValue(i).ToString();
+			Out[i].ParentName = (Parent >= 0 && Parent < Out.Num()) ? Attributes->GetBoneNames()->GetValue(Parent).ToString() : FString();
+			Out[i].LocalTransform = Attributes->GetBonePoses()->GetValue(i);
+			Out[i].MeshTransform = MeshSpace[i];
+		}
+		if (const FSkinWeights* Skin = Attributes->GetSkinWeightsAttribute(FSkeletalMeshAttributes::DefaultSkinWeightProfileName))
+		{
+			FBoneWeights Weights;
+			for (const int32 Vid : M.VertexIndicesItr())
+			{
+				Skin->GetValue(Vid, Weights);
+				for (int32 k = 0; k < Weights.Num(); ++k)
+				{
+					const int32 BoneIndex = Weights[k].GetBoneIndex();
+					if (Weights[k].GetWeight() > 0.f && BoneIndex < Out.Num()) { ++Out[BoneIndex].InfluencedVertices; }
+				}
+			}
+		}
+	});
+	return Out;
+}
+
+FModelingResult UModelingService::SetAssetMaterials(const FString& AssetPath, const FString& MaterialPaths, bool bSaveAsset)
+{
+	TArray<FString> Paths;
+	MaterialPaths.ParseIntoArray(Paths, TEXT(","), true);
+	TArray<UMaterialInterface*> Materials;
+	for (FString& Path : Paths)
+	{
+		Path.TrimStartAndEndInline();
+		if (Path.IsEmpty()) { continue; }
+		UMaterialInterface* Material = LoadAssetAs<UMaterialInterface>(Path);
+		if (!Material) { return Fail(-1, FString::Printf(TEXT("Material not found: %s"), *Path)); }
+		Materials.Add(Material);
+	}
+	if (Materials.Num() == 0) { return Fail(-1, TEXT("MaterialPaths must list at least one material asset path (comma-separated, in slot order)")); }
+
+	UObject* Asset = UEditorAssetLibrary::DoesAssetExist(AssetPath) ? UEditorAssetLibrary::LoadAsset(AssetPath) : nullptr;
+	if (UStaticMesh* StaticMesh = Cast<UStaticMesh>(Asset))
+	{
+		TArray<FStaticMaterial> Slots = StaticMesh->GetStaticMaterials();
+		Slots.SetNum(FMath::Max(Slots.Num(), Materials.Num()));
+		for (int32 i = 0; i < Materials.Num(); ++i)
+		{
+			Slots[i].MaterialInterface = Materials[i];
+			if (Slots[i].MaterialSlotName.IsNone()) { Slots[i].MaterialSlotName = *FString::Printf(TEXT("Slot%d"), i); }
+		}
+		StaticMesh->SetStaticMaterials(Slots);
+		StaticMesh->MarkPackageDirty();
+		StaticMesh->PostEditChange();
+	}
+	else if (USkeletalMesh* SkeletalMesh = Cast<USkeletalMesh>(Asset))
+	{
+		TArray<FSkeletalMaterial> Slots = SkeletalMesh->GetMaterials();
+		Slots.SetNum(FMath::Max(Slots.Num(), Materials.Num()));
+		for (int32 i = 0; i < Materials.Num(); ++i)
+		{
+			Slots[i].MaterialInterface = Materials[i];
+			if (Slots[i].MaterialSlotName.IsNone()) { Slots[i].MaterialSlotName = *FString::Printf(TEXT("Slot%d"), i); }
+		}
+		SkeletalMesh->SetMaterials(Slots);
+		SkeletalMesh->MarkPackageDirty();
+		SkeletalMesh->PostEditChange();
+	}
+	else
+	{
+		return Fail(-1, FString::Printf(TEXT("%s is not a StaticMesh or SkeletalMesh asset"), *AssetPath));
+	}
+	SaveIf(bSaveAsset, AssetPath);
+	FModelingResult R;
+	R.bSuccess = true;
+	R.AssetPath = AssetPath;
+	R.Message = FString::Printf(TEXT("Assigned %d material slot(s) on %s"), Materials.Num(), *AssetPath);
+	return R;
 }

--- a/Source/VibeUE/Private/PythonAPI/UModelingService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UModelingService.cpp
@@ -180,7 +180,7 @@ namespace
 		if (!Debug) { return false; }
 		for (const FGeometryScriptDebugMessage& M : Debug->Messages)
 		{
-			if (M.MessageType == EGeometryScriptDebugMessageType::ErrorMessage) { return true; }
+			if (M.MessageType == EGeometryScriptDebugMessageType::ErrorMessage || M.Message.ToString().Contains(TEXT("cannot be run"))) { return true; }
 		}
 		return false;
 	}
@@ -1296,6 +1296,8 @@ FModelingResult UModelingService::AutoUV(int32 Handle, const FString& Method, in
 	UDynamicMesh* Mesh = FindMesh(Handle);
 	if (!Mesh) { return NoMesh(Handle); }
 	UGeometryScriptDebug* Debug = NewDebug();
+	// Booleans, deletes, and cuts leave id gaps; XAtlas refuses a non-compact mesh, so compact first.
+	UGeometryScriptLibrary_MeshRepairFunctions::CompactMesh(Mesh, Debug);
 	if (GetMeshInfo(Handle).NumUVLayers <= UVLayer)
 	{
 		UGeometryScriptLibrary_MeshUVFunctions::SetNumUVSets(Mesh, UVLayer + 1, Debug);

--- a/Source/VibeUE/Private/PythonAPI/UModelingService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UModelingService.cpp
@@ -56,6 +56,13 @@
 #include "UObject/Package.h"
 #include "UObject/StrongObjectPtr.h"
 #include "AssetRegistry/AssetRegistryModule.h"
+#include "AssetImportTask.h"
+#include "AssetToolsModule.h"
+#include "IAssetTools.h"
+#include "Math/RandomStream.h"
+#include "Misc/Paths.h"
+#include "Modules/ModuleManager.h"
+#include "Selections/MeshConnectedComponents.h"
 #include "DynamicMesh/DynamicBoneAttribute.h"
 #include "DynamicMesh/DynamicVertexSkinWeightsAttribute.h"
 #include "Engine/SkinnedAssetCommon.h"
@@ -1757,6 +1764,59 @@ FModelingResult UModelingService::SetLODs(const FString& AssetPath, const TArray
 	return R;
 }
 
+namespace
+{
+	/** Shared tail of every bake: run the baker, then save one Texture2D asset per requested type (T_<BaseName>_<Suffix>). */
+	FModelingBakeResult RunBake(UDynamicMesh* Target, UDynamicMesh* Source, const TArray<FGeometryScriptBakeTypeOptions>& Types, const TArray<FString>& Suffixes,
+		int32 Resolution, const FString& OutputFolder, const FString& BaseName, int32 TargetUVLayer, int32 SamplesPerPixel)
+	{
+		FModelingBakeResult Result;
+		FGeometryScriptBakeTargetMeshOptions TargetOptions;
+		TargetOptions.TargetUVLayer = TargetUVLayer;
+		FGeometryScriptBakeSourceMeshOptions SourceOptions;
+		FGeometryScriptBakeTextureOptions BakeOptions;
+		if (!ParseEnum(FString::Printf(TEXT("Resolution%d"), Resolution), BakeOptions.Resolution))
+		{
+			Result.Message = FString::Printf(TEXT("Unsupported resolution %d (use a power of two from 16 to 8192)"), Resolution);
+			return Result;
+		}
+		if (!ParseEnum(FString::Printf(TEXT("Sample%d"), SamplesPerPixel), BakeOptions.SamplesPerPixel))
+		{
+			BakeOptions.SamplesPerPixel = EGeometryScriptBakeSamplesPerPixel::Sample1;
+		}
+		UGeometryScriptDebug* Debug = NewDebug();
+		// The baker samples through the target's tangent frame; session meshes rarely carry tangents yet.
+		UGeometryScriptLibrary_MeshNormalsFunctions::ComputeTangents(Target, FGeometryScriptTangentsOptions(), Debug);
+		const TArray<UTexture2D*> Textures = UGeometryScriptLibrary_MeshBakeFunctions::BakeTexture(Target, FTransform::Identity, TargetOptions,
+			Source, FTransform::Identity, SourceOptions, Types, BakeOptions, Debug);
+		if (DebugHasErrors(Debug) || Textures.Num() != Types.Num())
+		{
+			Result.Message = FString::Printf(TEXT("Bake failed: %s"), *DebugText(Debug));
+			return Result;
+		}
+		for (int32 i = 0; i < Textures.Num(); ++i)
+		{
+			if (!Textures[i]) { continue; }
+			FGeometryScriptCreateNewTexture2DAssetOptions TextureOptions;
+			TextureOptions.bOverwriteIfExists = true;
+			EGeometryScriptOutcomePins Outcome = EGeometryScriptOutcomePins::Failure;
+			const FString AssetPath = OutputFolder / FString::Printf(TEXT("T_%s_%s"), *BaseName, *Suffixes[i]);
+			UTexture2D* Saved = UGeometryScriptLibrary_CreateNewAssetFunctions::CreateNewTexture2DAsset(Textures[i], AssetPath, TextureOptions, Outcome, Debug);
+			if (Outcome != EGeometryScriptOutcomePins::Success || !Saved)
+			{
+				Result.Message = FString::Printf(TEXT("Could not save %s: %s"), *AssetPath, *DebugText(Debug));
+				return Result;
+			}
+			Saved->BlockOnAnyAsyncBuild();   // the texture compiles asynchronously; finish it so a save or delete right after cannot race it
+			UEditorAssetLibrary::SaveAsset(Saved->GetPathName(), false);
+			Result.TexturePaths.Add(Saved->GetPathName());
+		}
+		Result.bSuccess = true;
+		Result.Message = FString::Printf(TEXT("Baked %d texture(s) at %d"), Result.TexturePaths.Num(), Resolution);
+		return Result;
+	}
+}
+
 FModelingBakeResult UModelingService::BakeTextures(int32 TargetHandle, int32 SourceHandle, const FString& BakeTypes, int32 Resolution, const FString& OutputFolder,
 	const FString& BaseName, int32 TargetUVLayer, int32 SamplesPerPixel)
 {
@@ -1781,54 +1841,54 @@ FModelingBakeResult UModelingService::BakeTextures(int32 TargetHandle, int32 Sou
 		else if (Name.Equals(TEXT("AmbientOcclusion"), ESearchCase::IgnoreCase)) { Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypeAmbientOcclusion()); Suffixes.Add(TEXT("AO")); }
 		else if (Name.Equals(TEXT("Curvature"), ESearchCase::IgnoreCase)) { Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypeCurvature()); Suffixes.Add(TEXT("Curv")); }
 		else if (Name.Equals(TEXT("Position"), ESearchCase::IgnoreCase)) { Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypePosition()); Suffixes.Add(TEXT("Pos")); }
-		else { Result.Message = FString::Printf(TEXT("Unknown bake type '%s' (use TangentNormal, ObjectNormal, FaceNormal, BentNormal, AmbientOcclusion, Curvature, Position)"), *Name); return Result; }
-	}
-	if (Types.Num() == 0) { Result.Message = TEXT("No bake types given"); return Result; }
-
-	FGeometryScriptBakeTargetMeshOptions TargetOptions;
-	TargetOptions.TargetUVLayer = TargetUVLayer;
-	FGeometryScriptBakeSourceMeshOptions SourceOptions;
-	FGeometryScriptBakeTextureOptions BakeOptions;
-	if (!ParseEnum(FString::Printf(TEXT("Resolution%d"), Resolution), BakeOptions.Resolution))
-	{
-		Result.Message = FString::Printf(TEXT("Unsupported resolution %d (use a power of two from 16 to 8192)"), Resolution);
-		return Result;
-	}
-	if (!ParseEnum(FString::Printf(TEXT("Sample%d"), SamplesPerPixel), BakeOptions.SamplesPerPixel))
-	{
-		BakeOptions.SamplesPerPixel = EGeometryScriptBakeSamplesPerPixel::Sample1;
-	}
-
-	UGeometryScriptDebug* Debug = NewDebug();
-	// The baker samples through the target's tangent frame; session meshes rarely carry tangents yet.
-	UGeometryScriptLibrary_MeshNormalsFunctions::ComputeTangents(Target, FGeometryScriptTangentsOptions(), Debug);
-	const TArray<UTexture2D*> Textures = UGeometryScriptLibrary_MeshBakeFunctions::BakeTexture(Target, FTransform::Identity, TargetOptions,
-		Source, FTransform::Identity, SourceOptions, Types, BakeOptions, Debug);
-	if (DebugHasErrors(Debug) || Textures.Num() != Types.Num())
-	{
-		Result.Message = FString::Printf(TEXT("Bake failed: %s"), *DebugText(Debug));
-		return Result;
-	}
-	for (int32 i = 0; i < Textures.Num(); ++i)
-	{
-		if (!Textures[i]) { continue; }
-		FGeometryScriptCreateNewTexture2DAssetOptions TextureOptions;
-		TextureOptions.bOverwriteIfExists = true;
-		EGeometryScriptOutcomePins Outcome = EGeometryScriptOutcomePins::Failure;
-		const FString AssetPath = OutputFolder / FString::Printf(TEXT("T_%s_%s"), *BaseName, *Suffixes[i]);
-		UTexture2D* Saved = UGeometryScriptLibrary_CreateNewAssetFunctions::CreateNewTexture2DAsset(Textures[i], AssetPath, TextureOptions, Outcome, Debug);
-		if (Outcome != EGeometryScriptOutcomePins::Success || !Saved)
+		else if (Name.Equals(TEXT("VertexColor"), ESearchCase::IgnoreCase)) { Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypeVertexColor()); Suffixes.Add(TEXT("VC")); }
+		else if (Name.Equals(TEXT("MaterialID"), ESearchCase::IgnoreCase)) { Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypeMaterialID()); Suffixes.Add(TEXT("ID")); }
+		else if (Name.Equals(TEXT("UVShell"), ESearchCase::IgnoreCase)) { Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypeUVShell(TargetUVLayer, 1.f, FLinearColor::White, FLinearColor(0.25f, 0.25f, 0.25f), FLinearColor::Black)); Suffixes.Add(TEXT("UV")); }
+		else if (Name.Equals(TEXT("Height"), ESearchCase::IgnoreCase)) { Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypeHeight()); Suffixes.Add(TEXT("H")); }
+		else
 		{
-			Result.Message = FString::Printf(TEXT("Could not save %s: %s"), *AssetPath, *DebugText(Debug));
+			Result.Message = FString::Printf(TEXT("Unknown bake type '%s' (use TangentNormal, ObjectNormal, FaceNormal, BentNormal, AmbientOcclusion, Curvature, Position, VertexColor, MaterialID, UVShell, Height; textures via bake_texture_transfer)"), *Name);
 			return Result;
 		}
-		Saved->BlockOnAnyAsyncBuild();   // the texture compiles asynchronously; finish it so a save or delete right after cannot race it
-		UEditorAssetLibrary::SaveAsset(Saved->GetPathName(), false);
-		Result.TexturePaths.Add(Saved->GetPathName());
 	}
-	Result.bSuccess = true;
-	Result.Message = FString::Printf(TEXT("Baked %d texture(s) at %d"), Result.TexturePaths.Num(), Resolution);
-	return Result;
+	if (Types.Num() == 0) { Result.Message = TEXT("No bake types given"); return Result; }
+	return RunBake(Target, Source, Types, Suffixes, Resolution, OutputFolder, BaseName, TargetUVLayer, SamplesPerPixel);
+}
+
+FModelingBakeResult UModelingService::BakeTextureTransfer(int32 TargetHandle, int32 SourceHandle, const FString& SourceTexturePaths, int32 Resolution, const FString& OutputFolder,
+	const FString& BaseName, int32 TargetUVLayer, int32 SourceUVLayer, int32 SamplesPerPixel)
+{
+	FModelingBakeResult Result;
+	UDynamicMesh* Target = FindMesh(TargetHandle);
+	if (!Target) { Result.Message = NoMesh(TargetHandle).Message; return Result; }
+	UDynamicMesh* Source = FindMesh(SourceHandle);
+	if (!Source) { Result.Message = NoMesh(SourceHandle).Message; return Result; }
+	if (!OutputFolder.StartsWith(TEXT("/")) || BaseName.IsEmpty()) { Result.Message = TEXT("OutputFolder must be a content path (e.g. /Game/Textures) and BaseName non-empty"); return Result; }
+	TArray<FString> Paths;
+	SourceTexturePaths.ParseIntoArray(Paths, TEXT(","), true);
+	TArray<UTexture2D*> Textures;
+	for (FString& Path : Paths)
+	{
+		Path.TrimStartAndEndInline();
+		if (Path.IsEmpty()) { continue; }
+		UTexture2D* Texture = LoadAssetAs<UTexture2D>(Path);
+		if (!Texture) { Result.Message = FString::Printf(TEXT("Texture2D not found: %s"), *Path); return Result; }
+		Textures.Add(Texture);
+	}
+	if (Textures.Num() == 0) { Result.Message = TEXT("SourceTexturePaths must list at least one Texture2D asset (comma-separated, in source material-ID order for several)"); return Result; }
+	TArray<FGeometryScriptBakeTypeOptions> Types;
+	TArray<FString> Suffixes;
+	if (Textures.Num() == 1)
+	{
+		Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypeTexture(Textures[0], SourceUVLayer));
+		Suffixes.Add(TEXT("Tex"));
+	}
+	else
+	{
+		Types.Add(UGeometryScriptLibrary_MeshBakeFunctions::MakeBakeTypeMultiTexture(Textures, SourceUVLayer));
+		Suffixes.Add(TEXT("MultiTex"));
+	}
+	return RunBake(Target, Source, Types, Suffixes, Resolution, OutputFolder, BaseName, TargetUVLayer, SamplesPerPixel);
 }
 
 FModelingResult UModelingService::SpawnStaticMeshActor(const FString& AssetPath, FTransform Transform, const FString& ActorLabel)
@@ -2467,5 +2527,557 @@ FModelingResult UModelingService::SetAssetMaterials(const FString& AssetPath, co
 	R.bSuccess = true;
 	R.AssetPath = AssetPath;
 	R.Message = FString::Printf(TEXT("Assigned %d material slot(s) on %s"), Materials.Num(), *AssetPath);
+	return R;
+}
+
+// =========================================================================
+// UV control
+// =========================================================================
+
+namespace
+{
+	FGeometryScriptGroupLayer DefaultGroupLayer()
+	{
+		FGeometryScriptGroupLayer Layer;
+		Layer.bDefaultLayer = true;
+		return Layer;
+	}
+
+	/** Case-insensitive enum lookup so "Polygroups" finds PolyGroups. */
+	template <typename TEnum>
+	bool ParseEnumLoose(const FString& Name, TEnum& Out)
+	{
+		const UEnum* E = StaticEnum<TEnum>();
+		const FString Wanted = Name.TrimStartAndEnd();
+		for (int32 i = 0; i < E->NumEnums() - 1; ++i)
+		{
+			if (E->GetNameStringByIndex(i).Equals(Wanted, ESearchCase::IgnoreCase))
+			{
+				Out = static_cast<TEnum>(E->GetValueByIndex(i));
+				return true;
+			}
+		}
+		return false;
+	}
+
+	int32 NumUVLayers(UDynamicMesh* Mesh)
+	{
+		int32 Num = 0;
+		Mesh->ProcessMesh([&Num](const FDynamicMesh3& M) { Num = M.HasAttributes() ? M.Attributes()->NumUVLayers() : 0; });
+		return Num;
+	}
+
+	FGeometryScriptMeshSelection SelectionForMaterial(UDynamicMesh* Mesh, int32 MaterialID)
+	{
+		TArray<int32> TriangleIDs;
+		Mesh->ProcessMesh([&](const FDynamicMesh3& M)
+		{
+			if (!M.HasAttributes() || !M.Attributes()->HasMaterialID()) { return; }
+			const FDynamicMeshMaterialAttribute* Materials = M.Attributes()->GetMaterialID();
+			for (const int32 Tid : M.TriangleIndicesItr())
+			{
+				if (Materials->GetValue(Tid) == MaterialID) { TriangleIDs.Add(Tid); }
+			}
+		});
+		FGeometryScriptMeshSelection Selection;
+		UGeometryScriptLibrary_MeshSelectionFunctions::ConvertIndexArrayToMeshSelection(Mesh, TriangleIDs, EGeometryScriptMeshSelectionType::Triangles, Selection);
+		return Selection;
+	}
+}
+
+FModelingResult UModelingService::SetPolygroup(int32 Handle, const FString& SelectionName, int32 GroupID)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelection Selection;
+	FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	Mesh->EditMesh([](FDynamicMesh3& M)
+	{
+		if (!M.HasTriangleGroups()) { M.EnableTriangleGroups(0); }
+	});
+	UGeometryScriptDebug* Debug = NewDebug();
+	int32 SetID = 0;
+	UGeometryScriptLibrary_MeshPolygroupFunctions::SetPolygroupForMeshSelection(Mesh, DefaultGroupLayer(), Selection, SetID, FMath::Max(0, GroupID), GroupID < 0, false);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Selection '%s' is now polygroup %d"), *SelectionName, SetID));
+}
+
+FModelingResult UModelingService::RecomputeUVs(int32 Handle, int32 UVLayer, const FString& IslandSource, const FString& Method, const FString& SelectionName, bool bAlignIslandsWithAxes)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelection Selection;
+	FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	FGeometryScriptRecomputeUVsOptions Options;
+	if (!ParseEnumLoose(IslandSource, Options.IslandSource))
+	{
+		return Fail(Handle, FString::Printf(TEXT("Unknown island source '%s' (use %s)"), *IslandSource, *EnumNames<EGeometryScriptUVIslandSource>()));
+	}
+	if (!ParseEnumLoose(Method, Options.Method))
+	{
+		return Fail(Handle, FString::Printf(TEXT("Unknown unwrap method '%s' (use %s)"), *Method, *EnumNames<EGeometryScriptUVFlattenMethod>()));
+	}
+	Options.GroupLayer = DefaultGroupLayer();
+	Options.bAutoAlignIslandsWithAxes = bAlignIslandsWithAxes;
+	if (UVLayer >= NumUVLayers(Mesh)) { SetNumUVLayers(Handle, UVLayer + 1); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshUVFunctions::RecomputeMeshUVs(Mesh, UVLayer, Options, Selection, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Recomputed UV layer %d from %s (%s) - islands are not packed yet, run layout_uv"), UVLayer, *IslandSource, *Method));
+}
+
+FModelingResult UModelingService::TransformUV(int32 Handle, int32 UVLayer, const FString& SelectionName, FVector2D Translation, FVector2D Scale, float RotationDeg, FVector2D Origin)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelection Selection;
+	FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	if (UVLayer < 0 || UVLayer >= NumUVLayers(Mesh)) { return Fail(Handle, FString::Printf(TEXT("UV layer %d does not exist (mesh has %d)"), UVLayer, NumUVLayers(Mesh))); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	if (!Scale.Equals(FVector2D(1, 1)))
+	{
+		UGeometryScriptLibrary_MeshUVFunctions::ScaleMeshUVs(Mesh, UVLayer, Scale, Origin, Selection, Debug);
+	}
+	if (!FMath::IsNearlyZero(RotationDeg))
+	{
+		UGeometryScriptLibrary_MeshUVFunctions::RotateMeshUVs(Mesh, UVLayer, RotationDeg, Origin, Selection, Debug);
+	}
+	if (!Translation.IsNearlyZero())
+	{
+		UGeometryScriptLibrary_MeshUVFunctions::TranslateMeshUVs(Mesh, UVLayer, Translation, Selection, Debug);
+	}
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Transformed UVs of '%s' in layer %d"), *SelectionName, UVLayer));
+}
+
+FModelingResult UModelingService::LayoutUV(int32 Handle, int32 UVLayer, const FString& LayoutType, const FString& SelectionName, int32 TextureResolution, float Scale, FVector2D Translation)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	FGeometryScriptMeshSelection Selection;
+	FString Error;
+	if (!ResolveSelection(Handle, SelectionName, Mesh, Selection, Error)) { return Fail(Handle, Error); }
+	if (UVLayer < 0 || UVLayer >= NumUVLayers(Mesh)) { return Fail(Handle, FString::Printf(TEXT("UV layer %d does not exist (mesh has %d)"), UVLayer, NumUVLayers(Mesh))); }
+	FGeometryScriptLayoutUVsOptions Options;
+	if (!ParseEnumLoose(LayoutType, Options.LayoutType))
+	{
+		return Fail(Handle, FString::Printf(TEXT("Unknown layout type '%s' (use %s)"), *LayoutType, *EnumNames<EGeometryScriptUVLayoutType>()));
+	}
+	Options.TextureResolution = FMath::Clamp(TextureResolution, 16, 16384);
+	Options.Scale = Scale;
+	Options.Translation = Translation;
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshUVFunctions::LayoutMeshUVs(Mesh, UVLayer, Options, Selection, Debug);
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("%s layout of UV layer %d"), *LayoutType, UVLayer));
+}
+
+FModelingResult UModelingService::PackUVPerMaterial(int32 Handle, int32 UVLayer, int32 TextureResolution)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	if (UVLayer < 0 || UVLayer >= NumUVLayers(Mesh)) { return Fail(Handle, FString::Printf(TEXT("UV layer %d does not exist (mesh has %d)"), UVLayer, NumUVLayers(Mesh))); }
+	TSet<int32> MaterialIDs;
+	Mesh->ProcessMesh([&MaterialIDs](const FDynamicMesh3& M)
+	{
+		if (!M.HasAttributes() || !M.Attributes()->HasMaterialID()) { return; }
+		for (const int32 Tid : M.TriangleIndicesItr()) { MaterialIDs.Add(M.Attributes()->GetMaterialID()->GetValue(Tid)); }
+	});
+	if (MaterialIDs.Num() == 0) { return Fail(Handle, TEXT("Mesh has no material IDs (set_material_id first) - use layout_uv for a single-material pack")); }
+	FGeometryScriptLayoutUVsOptions Options;
+	Options.LayoutType = EGeometryScriptUVLayoutType::Repack;
+	Options.TextureResolution = FMath::Clamp(TextureResolution, 16, 16384);
+	UGeometryScriptDebug* Debug = NewDebug();
+	for (const int32 MaterialID : MaterialIDs)
+	{
+		UGeometryScriptLibrary_MeshUVFunctions::LayoutMeshUVs(Mesh, UVLayer, Options, SelectionForMaterial(Mesh, MaterialID), Debug);
+	}
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Packed UV layer %d separately for %d material ID(s) - each slot now uses the full 0-1 range"), UVLayer, MaterialIDs.Num()));
+}
+
+FModelingUVStats UModelingService::GetUVStats(int32 Handle, int32 UVLayer, int32 GridResolution)
+{
+	FModelingUVStats Stats;
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { Stats.Message = NoMesh(Handle).Message; return Stats; }
+	if (UVLayer < 0 || UVLayer >= NumUVLayers(Mesh)) { Stats.Message = FString::Printf(TEXT("UV layer %d does not exist (mesh has %d)"), UVLayer, NumUVLayers(Mesh)); return Stats; }
+
+	FGeometryScriptMeshSelection All;
+	UGeometryScriptLibrary_MeshSelectionFunctions::CreateSelectAllMeshSelection(Mesh, All, EGeometryScriptMeshSelectionType::Triangles);
+	double MeshArea = 0.0, UVArea = 0.0;
+	FBox MeshBounds(ForceInit);
+	FBox2D UVBounds(ForceInit);
+	bool bValid = false, bUnset = false;
+	UGeometryScriptLibrary_MeshUVFunctions::GetMeshUVSizeInfo(Mesh, UVLayer, All, MeshArea, UVArea, MeshBounds, UVBounds, bValid, bUnset, true, nullptr);
+	Stats.MeshArea = static_cast<float>(MeshArea);
+	Stats.UVArea = static_cast<float>(UVArea);
+	Stats.UVBoundsMin = UVBounds.Min;
+	Stats.UVBoundsMax = UVBounds.Max;
+	Stats.TexelsPerCmAt1K = MeshArea > 0.0 ? static_cast<float>(FMath::Sqrt(UVArea / MeshArea) * 1024.0) : 0.f;
+
+	const int32 Res = FMath::Clamp(GridResolution, 16, 4096);
+	TArray<uint8> Hits;
+	Hits.SetNumZeroed(Res * Res);
+	Mesh->ProcessMesh([&](const FDynamicMesh3& M)
+	{
+		const FDynamicMeshUVOverlay* UV = M.Attributes()->GetUVLayer(UVLayer);
+		if (!UV) { return; }
+		FMeshConnectedComponents Components(&M);
+		Components.FindConnectedTriangles([UV](int32 T0, int32 T1) { return UV->AreTrianglesConnected(T0, T1); });
+		Stats.NumIslands = Components.Num();
+		for (const int32 Tid : M.TriangleIndicesItr())
+		{
+			if (!UV->IsSetTriangle(Tid)) { ++Stats.NumUnsetTriangles; continue; }
+			FVector2f A, B, C;
+			UV->GetTriElements(Tid, A, B, C);
+			const FVector2f P0 = A * Res, P1 = B * Res, P2 = C * Res;
+			const int32 X0 = FMath::Clamp(FMath::FloorToInt(FMath::Min3(P0.X, P1.X, P2.X)), 0, Res - 1), X1 = FMath::Clamp(FMath::CeilToInt(FMath::Max3(P0.X, P1.X, P2.X)), 0, Res - 1);
+			const int32 Y0 = FMath::Clamp(FMath::FloorToInt(FMath::Min3(P0.Y, P1.Y, P2.Y)), 0, Res - 1), Y1 = FMath::Clamp(FMath::CeilToInt(FMath::Max3(P0.Y, P1.Y, P2.Y)), 0, Res - 1);
+			const float Area = (P1.X - P0.X) * (P2.Y - P0.Y) - (P2.X - P0.X) * (P1.Y - P0.Y);
+			if (FMath::Abs(Area) < 1e-6f) { continue; }
+			for (int32 Y = Y0; Y <= Y1; ++Y)
+			{
+				for (int32 X = X0; X <= X1; ++X)
+				{
+					const FVector2f P(X + 0.5f, Y + 0.5f);
+					const float W0 = ((P1.X - P.X) * (P2.Y - P.Y) - (P2.X - P.X) * (P1.Y - P.Y)) / Area;
+					const float W1 = ((P2.X - P.X) * (P0.Y - P.Y) - (P0.X - P.X) * (P2.Y - P.Y)) / Area;
+					const float W2 = 1.f - W0 - W1;
+					if (W0 >= 0.f && W1 >= 0.f && W2 >= 0.f)
+					{
+						uint8& Cell = Hits[Y * Res + X];
+						if (Cell < 255) { ++Cell; }
+					}
+				}
+			}
+		}
+	});
+	int32 Covered = 0, Overlapped = 0;
+	for (const uint8 Cell : Hits)
+	{
+		if (Cell > 0) { ++Covered; }
+		if (Cell > 1) { ++Overlapped; }
+	}
+	Stats.Coverage = static_cast<float>(Covered) / static_cast<float>(Res * Res);
+	Stats.OverlapFraction = Covered > 0 ? static_cast<float>(Overlapped) / static_cast<float>(Covered) : 0.f;
+	Stats.bSuccess = true;
+	Stats.Message = FString::Printf(TEXT("%d island(s), %.0f%% of 0-1 covered, %.1f%% overlapping, %d unset triangle(s), %.2f texels/cm at 1K"),
+		Stats.NumIslands, Stats.Coverage * 100.f, Stats.OverlapFraction * 100.f, Stats.NumUnsetTriangles, Stats.TexelsPerCmAt1K);
+	return Stats;
+}
+
+bool UModelingService::WorldToUV(int32 Handle, FVector Point, int32 UVLayer, FVector2D& OutUV)
+{
+	OutUV = FVector2D::ZeroVector;
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh || UVLayer < 0 || UVLayer >= NumUVLayers(Mesh)) { return false; }
+	UGeometryScriptDebug* Debug = NewDebug();
+	FGeometryScriptDynamicMeshBVH BVH;
+	UGeometryScriptLibrary_MeshSpatial::BuildBVHForMesh(Mesh, BVH, Debug);
+	FGeometryScriptTrianglePoint Nearest;
+	EGeometryScriptSearchOutcomePins Outcome = EGeometryScriptSearchOutcomePins::NotFound;
+	UGeometryScriptLibrary_MeshSpatial::FindNearestPointOnMesh(Mesh, BVH, Point, FGeometryScriptSpatialQueryOptions(), Nearest, Outcome, Debug);
+	if (Outcome != EGeometryScriptSearchOutcomePins::Found || !Nearest.bValid) { return false; }
+	bool bFound = false;
+	Mesh->ProcessMesh([&](const FDynamicMesh3& M)
+	{
+		const FDynamicMeshUVOverlay* UV = M.Attributes()->GetUVLayer(UVLayer);
+		if (!UV || !UV->IsSetTriangle(Nearest.TriangleID)) { return; }
+		FVector2f A, B, C;
+		UV->GetTriElements(Nearest.TriangleID, A, B, C);
+		const FVector2f Result = A * static_cast<float>(Nearest.BaryCoords.X) + B * static_cast<float>(Nearest.BaryCoords.Y) + C * static_cast<float>(Nearest.BaryCoords.Z);
+		OutUV = FVector2D(Result.X, Result.Y);
+		bFound = true;
+	});
+	return bFound;
+}
+
+// =========================================================================
+// Image tools
+// =========================================================================
+
+namespace
+{
+	bool ParseCompression(const FString& Name, TextureCompressionSettings& Out)
+	{
+		const FString N = Name.TrimStartAndEnd();
+		if (N.Equals(TEXT("Default"), ESearchCase::IgnoreCase)) { Out = TC_Default; return true; }
+		if (N.Equals(TEXT("Normalmap"), ESearchCase::IgnoreCase)) { Out = TC_Normalmap; return true; }
+		if (N.Equals(TEXT("Masks"), ESearchCase::IgnoreCase)) { Out = TC_Masks; return true; }
+		if (N.Equals(TEXT("Grayscale"), ESearchCase::IgnoreCase)) { Out = TC_Grayscale; return true; }
+		if (N.Equals(TEXT("HDR"), ESearchCase::IgnoreCase)) { Out = TC_HDR; return true; }
+		return false;
+	}
+
+	/** Perlin fBm that wraps at the image borders (blend of the four torus-shifted lookups). */
+	float TileableNoise(float U, float V, float Cells, const FVector2D& Offset)
+	{
+		const FVector2D P(U * Cells, V * Cells);
+		const float N00 = FMath::PerlinNoise2D(P + Offset);
+		const float N10 = FMath::PerlinNoise2D(P - FVector2D(Cells, 0) + Offset);
+		const float N01 = FMath::PerlinNoise2D(P - FVector2D(0, Cells) + Offset);
+		const float N11 = FMath::PerlinNoise2D(P - FVector2D(Cells, Cells) + Offset);
+		return FMath::Lerp(FMath::Lerp(N00, N10, U), FMath::Lerp(N01, N11, U), V);
+	}
+
+	void FinishTextureEdit(UTexture2D* Texture, bool bSaveAsset)
+	{
+		Texture->UpdateResource();
+		Texture->PostEditChange();
+		Texture->MarkPackageDirty();
+		Texture->BlockOnAnyAsyncBuild();
+		SaveIf(bSaveAsset, Texture->GetPathName());
+	}
+}
+
+FModelingResult UModelingService::ImportTexture(const FString& FilePath, const FString& AssetPath, bool bSRGB, const FString& Compression, bool bSaveAsset)
+{
+	if (!FPaths::FileExists(FilePath)) { return Fail(-1, FString::Printf(TEXT("File not found: %s"), *FilePath)); }
+	if (!AssetPath.StartsWith(TEXT("/"))) { return Fail(-1, FString::Printf(TEXT("AssetPath must be a content path like /Game/Textures/T_Name (got '%s')"), *AssetPath)); }
+	TextureCompressionSettings Settings = TC_Default;
+	if (!ParseCompression(Compression, Settings)) { return Fail(-1, FString::Printf(TEXT("Unknown compression '%s' (use Default, Normalmap, Masks, Grayscale, HDR)"), *Compression)); }
+
+	UAssetImportTask* Task = NewObject<UAssetImportTask>();
+	Task->Filename = FilePath;
+	Task->DestinationPath = FPackageName::GetLongPackagePath(AssetPath);
+	Task->DestinationName = FPackageName::GetLongPackageAssetName(AssetPath);
+	Task->bAutomated = true;
+	Task->bReplaceExisting = true;
+	Task->bSave = false;
+	FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get().ImportAssetTasks({ Task });
+	UTexture2D* Texture = Task->GetObjects().Num() > 0 ? Cast<UTexture2D>(Task->GetObjects()[0]) : nullptr;
+	if (!Texture) { return Fail(-1, FString::Printf(TEXT("Import of %s produced no Texture2D (unsupported format?)"), *FilePath)); }
+	Texture->SRGB = bSRGB;
+	Texture->CompressionSettings = Settings;
+	if (Settings == TC_Normalmap)
+	{
+		Texture->SRGB = false;
+		Texture->LODGroup = TEXTUREGROUP_WorldNormalMap;
+	}
+	FinishTextureEdit(Texture, bSaveAsset);
+	FModelingResult R;
+	R.bSuccess = true;
+	R.AssetPath = Texture->GetPathName();
+	R.Message = FString::Printf(TEXT("Imported %s as %s (%dx%d, %s, sRGB %s)"), *FPaths::GetCleanFilename(FilePath), *R.AssetPath, Texture->GetSizeX(), Texture->GetSizeY(), *Compression, bSRGB ? TEXT("on") : TEXT("off"));
+	return R;
+}
+
+FModelingResult UModelingService::CreateNoiseTexture(const FString& AssetPath, int32 Width, int32 Height, float Scale, int32 Octaves, float Persistence, int32 Seed, bool bSaveAsset)
+{
+	if (!AssetPath.StartsWith(TEXT("/"))) { return Fail(-1, FString::Printf(TEXT("AssetPath must be a content path like /Game/Textures/T_Name (got '%s')"), *AssetPath)); }
+	const int32 W = FMath::Clamp(Width, 4, 8192), H = FMath::Clamp(Height, 4, 8192);
+	const int32 NumOctaves = FMath::Clamp(Octaves, 1, 10);
+	const float Cells = FMath::Max(1.f, Scale);
+	FRandomStream Random(Seed);
+	const FVector2D Offset(Random.FRandRange(0.f, 1000.f), Random.FRandRange(0.f, 1000.f));
+
+	TArray<uint8> Pixels;
+	Pixels.SetNumUninitialized(W * H * 4);
+	for (int32 Y = 0; Y < H; ++Y)
+	{
+		for (int32 X = 0; X < W; ++X)
+		{
+			float Value = 0.f, Amplitude = 1.f, Total = 0.f, Frequency = Cells;
+			for (int32 O = 0; O < NumOctaves; ++O)
+			{
+				Value += Amplitude * TileableNoise(static_cast<float>(X) / W, static_cast<float>(Y) / H, Frequency, Offset * (O + 1));
+				Total += Amplitude;
+				Amplitude *= Persistence;
+				Frequency *= 2.f;
+			}
+			const uint8 Gray = static_cast<uint8>(FMath::Clamp(FMath::RoundToInt((0.5f + 0.5f * Value / Total) * 255.f), 0, 255));
+			uint8* P = &Pixels[(Y * W + X) * 4];
+			P[0] = Gray; P[1] = Gray; P[2] = Gray; P[3] = 255;
+		}
+	}
+
+	UTexture2D* Texture = UEditorAssetLibrary::DoesAssetExist(AssetPath) ? LoadAssetAs<UTexture2D>(AssetPath) : nullptr;
+	if (!Texture)
+	{
+		if (UEditorAssetLibrary::DoesAssetExist(AssetPath)) { return Fail(-1, FString::Printf(TEXT("%s exists and is not a Texture2D"), *AssetPath)); }
+		UPackage* Package = CreatePackage(*AssetPath);
+		Texture = NewObject<UTexture2D>(Package, *FPackageName::GetLongPackageAssetName(AssetPath), RF_Public | RF_Standalone);
+		FAssetRegistryModule::AssetCreated(Texture);
+	}
+	Texture->Source.Init(W, H, 1, 1, TSF_BGRA8, Pixels.GetData());
+	Texture->SRGB = false;
+	Texture->CompressionSettings = TC_Grayscale;
+	FinishTextureEdit(Texture, bSaveAsset);
+	FModelingResult R;
+	R.bSuccess = true;
+	R.AssetPath = Texture->GetPathName();
+	R.Message = FString::Printf(TEXT("Noise texture %dx%d (%d octaves, %.0f cells, seed %d) at %s"), W, H, NumOctaves, Cells, Seed, *R.AssetPath);
+	return R;
+}
+
+FModelingResult UModelingService::DrawOnTexture(const FString& AssetPath, const FString& Shape, const TArray<FVector2D>& Points, FLinearColor Color, float ThicknessPx, float SpacingPx, bool bSaveAsset)
+{
+	UTexture2D* Texture = LoadAssetAs<UTexture2D>(AssetPath);
+	if (!Texture) { return Fail(-1, FString::Printf(TEXT("Texture2D not found: %s"), *AssetPath)); }
+	FTextureSource& Source = Texture->Source;
+	if (!Source.IsValid()) { return Fail(-1, FString::Printf(TEXT("%s has no editable source data"), *AssetPath)); }
+	const ETextureSourceFormat Format = Source.GetFormat();
+	if (Format != TSF_BGRA8 && Format != TSF_G8)
+	{
+		return Fail(-1, FString::Printf(TEXT("%s is not an 8-bit texture (BGRA8 or G8); draw into an imported PNG or a create_noise_texture result"), *AssetPath));
+	}
+	const FString Kind = Shape.TrimStartAndEnd();
+	const bool bLine = Kind.Equals(TEXT("Line"), ESearchCase::IgnoreCase), bDots = Kind.Equals(TEXT("Dots"), ESearchCase::IgnoreCase),
+		bRect = Kind.Equals(TEXT("Rect"), ESearchCase::IgnoreCase), bFill = Kind.Equals(TEXT("Fill"), ESearchCase::IgnoreCase);
+	if (!bLine && !bDots && !bRect && !bFill) { return Fail(-1, FString::Printf(TEXT("Unknown shape '%s' (use Line, Dots, Rect, Fill)"), *Shape)); }
+	if ((bLine || bDots) && Points.Num() < 2) { return Fail(-1, TEXT("Line and Dots need at least 2 points")); }
+	if (bRect && Points.Num() < 2) { return Fail(-1, TEXT("Rect needs 2 points (opposite corners)")); }
+
+	const int32 W = static_cast<int32>(Source.GetSizeX()), H = static_cast<int32>(Source.GetSizeY());
+	const FColor Pixel = Color.ToFColor(Texture->SRGB);
+	const uint8 Gray = static_cast<uint8>(FMath::Clamp(FMath::RoundToInt(0.299f * Pixel.R + 0.587f * Pixel.G + 0.114f * Pixel.B), 0, 255));
+	uint8* Data = Source.LockMip(0, 0, 0);
+	if (!Data) { return Fail(-1, FString::Printf(TEXT("Could not lock %s for writing"), *AssetPath)); }
+	int64 Painted = 0;
+	auto Plot = [&](int32 X, int32 Y)
+	{
+		if (X < 0 || Y < 0 || X >= W || Y >= H) { return; }
+		if (Format == TSF_BGRA8)
+		{
+			uint8* P = Data + (static_cast<int64>(Y) * W + X) * 4;
+			P[0] = Pixel.B; P[1] = Pixel.G; P[2] = Pixel.R; P[3] = Pixel.A;
+		}
+		else
+		{
+			Data[static_cast<int64>(Y) * W + X] = Gray;
+		}
+		++Painted;
+	};
+	auto Disc = [&](const FVector2D& Center, float Radius)
+	{
+		const float R = FMath::Max(0.5f, Radius);
+		for (int32 Y = FMath::FloorToInt(Center.Y - R); Y <= FMath::CeilToInt(Center.Y + R); ++Y)
+		{
+			for (int32 X = FMath::FloorToInt(Center.X - R); X <= FMath::CeilToInt(Center.X + R); ++X)
+			{
+				if (FVector2D::DistSquared(FVector2D(X + 0.5f, Y + 0.5f), Center) <= R * R) { Plot(X, Y); }
+			}
+		}
+	};
+	auto ToPixels = [&](const FVector2D& UV) { return FVector2D(UV.X * W, UV.Y * H); };
+
+	if (bFill)
+	{
+		for (int32 Y = 0; Y < H; ++Y) { for (int32 X = 0; X < W; ++X) { Plot(X, Y); } }
+	}
+	else if (bRect)
+	{
+		const FVector2D A = ToPixels(Points[0]), B = ToPixels(Points[1]);
+		for (int32 Y = FMath::FloorToInt(FMath::Min(A.Y, B.Y)); Y < FMath::CeilToInt(FMath::Max(A.Y, B.Y)); ++Y)
+		{
+			for (int32 X = FMath::FloorToInt(FMath::Min(A.X, B.X)); X < FMath::CeilToInt(FMath::Max(A.X, B.X)); ++X) { Plot(X, Y); }
+		}
+	}
+	else
+	{
+		const float Radius = FMath::Max(0.5f, ThicknessPx * 0.5f);
+		const float Step = bDots ? FMath::Max(1.f, SpacingPx) : 0.5f;
+		float Carry = 0.f;   // distance already travelled since the last stamp, carried across segments
+		bool bFirst = true;
+		for (int32 i = 0; i + 1 < Points.Num(); ++i)
+		{
+			const FVector2D A = ToPixels(Points[i]), B = ToPixels(Points[i + 1]);
+			const float Length = FVector2D::Distance(A, B);
+			if (Length < KINDA_SMALL_NUMBER) { continue; }
+			const FVector2D Dir = (B - A) / Length;
+			float T = bFirst ? 0.f : Step - Carry;
+			bFirst = false;
+			for (; T <= Length; T += Step) { Disc(A + Dir * T, Radius); }
+			Carry = Length - (T - Step);
+		}
+		if (bLine) { Disc(ToPixels(Points.Last()), Radius); }
+	}
+	Source.UnlockMip(0, 0, 0);
+	FinishTextureEdit(Texture, bSaveAsset);
+	FModelingResult R;
+	R.bSuccess = true;
+	R.AssetPath = Texture->GetPathName();
+	R.Message = FString::Printf(TEXT("Drew %s on %s (%lld pixel writes)"), *Kind, *AssetPath, Painted);
+	return R;
+}
+
+// =========================================================================
+// Surface detail helpers
+// =========================================================================
+
+FModelingResult UModelingService::AppendMeshAtTransforms(int32 Handle, int32 OtherHandle, const TArray<FTransform>& Transforms)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	UDynamicMesh* Other = FindMesh(OtherHandle);
+	if (!Other) { return NoMesh(OtherHandle); }
+	if (Handle == OtherHandle) { return Fail(Handle, TEXT("A mesh cannot be stamped into itself - copy_mesh it first")); }
+	if (Transforms.Num() == 0) { return Fail(Handle, TEXT("Transforms is empty")); }
+	UGeometryScriptDebug* Debug = NewDebug();
+	for (const FTransform& T : Transforms)
+	{
+		UGeometryScriptLibrary_MeshBasicEditFunctions::AppendMesh(Mesh, Other, T, true, FGeometryScriptAppendMeshOptions(), Debug);
+	}
+	return Finish(Handle, Mesh, Debug, FString::Printf(TEXT("Stamped handle %d at %d transform(s)"), OtherHandle, Transforms.Num()));
+}
+
+FModelingResult UModelingService::AppendMeshAlongPolyline(int32 Handle, int32 OtherHandle, const TArray<FVector>& Points, float Spacing, FVector UpVector, float Scale)
+{
+	if (Points.Num() < 2) { return Fail(Handle, TEXT("Points needs at least 2 positions")); }
+	if (Spacing <= 0.f) { return Fail(Handle, TEXT("Spacing must be positive")); }
+	const FVector Up = UpVector.IsNearlyZero() ? FVector::UpVector : UpVector.GetSafeNormal();
+	TArray<FTransform> Transforms;
+	float Carry = 0.f;
+	bool bFirst = true;
+	for (int32 i = 0; i + 1 < Points.Num(); ++i)
+	{
+		const float Length = static_cast<float>(FVector::Distance(Points[i], Points[i + 1]));
+		if (Length < KINDA_SMALL_NUMBER) { continue; }
+		const FVector Dir = (Points[i + 1] - Points[i]) / Length;
+		const FQuat Rotation = FRotationMatrix::MakeFromXZ(Dir, Up).ToQuat();
+		float T = bFirst ? 0.f : Spacing - Carry;
+		bFirst = false;
+		for (; T <= Length + KINDA_SMALL_NUMBER; T += Spacing)
+		{
+			Transforms.Add(FTransform(Rotation, Points[i] + Dir * T, FVector(Scale)));
+		}
+		Carry = Length - (T - Spacing);
+	}
+	if (Transforms.Num() == 0) { return Fail(Handle, TEXT("Polyline is shorter than one Spacing")); }
+	FModelingResult R = AppendMeshAtTransforms(Handle, OtherHandle, Transforms);
+	if (R.bSuccess) { R.Message = FString::Printf(TEXT("Stamped handle %d %d time(s) along a %d-point polyline every %.1f"), OtherHandle, Transforms.Num(), Points.Num(), Spacing); }
+	return R;
+}
+
+FModelingResult UModelingService::CutGrooveAlongPolyline(int32 Handle, const TArray<FVector>& Points, float Width, float Depth, FVector UpVector)
+{
+	UDynamicMesh* Mesh = FindMesh(Handle);
+	if (!Mesh) { return NoMesh(Handle); }
+	if (Points.Num() < 2) { return Fail(Handle, TEXT("Points needs at least 2 positions")); }
+	if (Width <= 0.f || Depth <= 0.f) { return Fail(Handle, TEXT("Width and Depth must be positive")); }
+	const FVector Up = UpVector.IsNearlyZero() ? FVector::UpVector : UpVector.GetSafeNormal();
+
+	// One frame per point, X along the path (averaged at interior corners), Z along Up; the profile lives in the frame's YZ plane.
+	TArray<FTransform> Frames;
+	for (int32 i = 0; i < Points.Num(); ++i)
+	{
+		FVector Dir = FVector::ZeroVector;
+		if (i > 0) { Dir += (Points[i] - Points[i - 1]).GetSafeNormal(); }
+		if (i + 1 < Points.Num()) { Dir += (Points[i + 1] - Points[i]).GetSafeNormal(); }
+		if (Dir.IsNearlyZero()) { continue; }
+		Frames.Add(FTransform(FRotationMatrix::MakeFromXZ(Dir.GetSafeNormal(), Up).ToQuat(), Points[i]));
+	}
+	if (Frames.Num() < 2) { return Fail(Handle, TEXT("Polyline has fewer than 2 distinct points")); }
+	const TArray<FVector2D> Profile = { FVector2D(-Width * 0.5, -Depth), FVector2D(Width * 0.5, -Depth), FVector2D(Width * 0.5, Depth), FVector2D(-Width * 0.5, Depth) };
+
+	int32 ToolHandle = -1;
+	UDynamicMesh* Tool = NewSessionMesh(ToolHandle);
+	UGeometryScriptDebug* Debug = NewDebug();
+	UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendSweepPolygon(Tool, PrimitiveOptions(0), FTransform::Identity, Profile, Frames, false, true, 1.f, 1.f, 0.f, 1.f, Debug);
+	float Area = 0.f, Volume = 0.f;
+	UGeometryScriptLibrary_MeshQueryFunctions::GetMeshVolumeArea(Tool, Area, Volume);
+	if (Volume < 0.f) { UGeometryScriptLibrary_MeshNormalsFunctions::FlipNormals(Tool, Debug); }
+	FModelingResult R = Boolean(Handle, ToolHandle, TEXT("Subtract"), FTransform::Identity, true, true);
+	ReleaseMesh(ToolHandle);
+	if (R.bSuccess) { R.Message = FString::Printf(TEXT("Cut a %.1f x %.1f groove along a %d-point polyline"), Width, Depth, Points.Num()); }
 	return R;
 }

--- a/Source/VibeUE/Public/PythonAPI/UModelingService.h
+++ b/Source/VibeUE/Public/PythonAPI/UModelingService.h
@@ -178,6 +178,51 @@ struct FModelingBakeResult
 	TArray<FString> TexturePaths;
 };
 
+/** One bone for CreateBones. Transform is in mesh space (the space the vertices are in); an empty ParentName makes it the root. */
+USTRUCT(BlueprintType)
+struct FModelingBoneDef
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FString Name;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FString ParentName;
+
+	/** Bone frame in mesh space. Point its X axis along a hinge line and the control surface deflects by rolling the bone. */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FTransform Transform;
+};
+
+/** A bone on a session mesh: hierarchy, reference pose, and how many vertices it influences. */
+USTRUCT(BlueprintType)
+struct FModelingBoneInfo
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	int32 Index = -1;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FString Name;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FString ParentName;
+
+	/** Reference pose relative to the parent bone. */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FTransform LocalTransform;
+
+	/** Reference pose in mesh space. */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FTransform MeshTransform;
+
+	/** Vertices carrying a non-zero weight on this bone. */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	int32 InfluencedVertices = 0;
+};
+
 /**
  * Programmatic mesh modeling — the operator half of Unreal's Modeling Mode, driven without a
  * viewport. Meshes live in an in-editor session as integer handles wrapping a UDynamicMesh:
@@ -529,9 +574,17 @@ public:
 	static FModelingResult SaveMeshToStaticMesh(int32 Handle, const FString& AssetPath, bool bReplaceExisting = true, bool bEnableCollision = true,
 		bool bEnableNanite = false, bool bSaveAsset = true);
 
-	/** Write the mesh (with its bone weights) to a SkeletalMesh asset bound to SkeletonPath. */
+	/**
+	 * Write the mesh (with its bone weights) to a SkeletalMesh asset. SkeletonPath "" creates a new Skeleton asset at
+	 * <AssetPath>_Skeleton from the bones on the mesh (CreateBones); an existing skeleton is bound as-is. One material slot
+	 * is made per material ID — assign materials afterwards with SetAssetMaterials.
+	 */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Save Mesh To Skeletal Mesh"))
-	static FModelingResult SaveMeshToSkeletalMesh(int32 Handle, const FString& AssetPath, const FString& SkeletonPath, bool bReplaceExisting = true, bool bSaveAsset = true);
+	static FModelingResult SaveMeshToSkeletalMesh(int32 Handle, const FString& AssetPath, const FString& SkeletonPath = TEXT(""), bool bReplaceExisting = true, bool bSaveAsset = true);
+
+	/** Assign material slots on a StaticMesh or SkeletalMesh asset: comma-separated material asset paths, in slot order. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Set Asset Materials"))
+	static FModelingResult SetAssetMaterials(const FString& AssetPath, const FString& MaterialPaths, bool bSaveAsset = true);
 
 	/** Copy skin weights from a SkeletalMesh asset onto this mesh by closest surface point (re-skin a modified body). */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Transfer Bone Weights"))
@@ -568,7 +621,7 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Sphere Box"))
 	static FModelingResult AppendSphereBox(int32 Handle, FTransform Transform, float Radius = 50.f, int32 Steps = 6, const FString& Origin = TEXT("Center"), int32 MaterialID = 0);
 
-	/** Sweep a 2D profile (XY, open polyline) along a path of transforms: pipes, rails, cables, trim. */
+	/** Sweep an OPEN 2D polyline along a path of transforms: rails, trim, ribbons, gutters. The profile lies in each frame's local YZ plane and is scaled by the frame's scale; bLoop closes the PATH (last frame back to the first), not the profile. For closed, capped solids use AppendLoft. */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Sweep Polyline"))
 	static FModelingResult AppendSweepPolyline(int32 Handle, FTransform Transform, const TArray<FVector2D>& ProfilePoints, const TArray<FTransform>& SweepPath,
 		bool bLoop = false, float StartScale = 1.f, float EndScale = 1.f, int32 MaterialID = 0);
@@ -643,4 +696,42 @@ public:
 	/** Remove bones (comma-separated names) from the skin weights, renormalizing the rest. */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Prune Bone Weights"))
 	static FModelingResult PruneBoneWeights(int32 Handle, const FString& BoneNames);
+
+	// =====================================================================
+	// Lofts, orientation, connected pieces
+	// =====================================================================
+
+	/**
+	 * Solid made by sweeping a closed 2D profile through a list of frames and capping both ends — wings, fins, hulls,
+	 * tapered beams. The profile lies in each frame's local YZ plane (profile X along the frame's Y axis, profile Y along
+	 * its Z axis) and is multiplied by the frame's scale, so chord and taper go in Frames[i].Scale. A wing running out
+	 * along +Y with its chord toward -X: root and tip frames with rotation (roll 0, pitch 0, yaw 90). The result is always
+	 * closed and outward-facing regardless of the winding the sweep produced.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Loft"))
+	static FModelingResult AppendLoft(int32 Handle, FTransform Transform, const TArray<FVector2D>& ProfilePoints, const TArray<FTransform>& Frames, int32 MaterialID = 0);
+
+	/** Flip the mesh when its enclosed volume is negative (normals facing inward). Run on any closed part before booleans — an inside-out part is silently discarded by SelfUnion. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Ensure Outward"))
+	static FModelingResult EnsureOutward(int32 Handle);
+
+	/** Select the whole connected piece of geometry nearest to Point — a control surface isolated by slot cuts, a bolt on a plate. Returns the triangle count. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Select Connected"))
+	static int32 SelectConnected(int32 Handle, const FString& SelectionName, FVector Point);
+
+	// =====================================================================
+	// Rigging: bones and skin weights authored on the mesh itself
+	// =====================================================================
+
+	/** Replace the mesh's bone hierarchy. The first bone is the root; every other bone names a parent listed before it. Every vertex starts bound to the root. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Create Bones"))
+	static FModelingResult CreateBones(int32 Handle, const TArray<FModelingBoneDef>& Bones);
+
+	/** Bind the vertices of a selection ("" = all) to a bone. Weight 1 replaces their weights; a lower weight blends with what is there. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Bind Selection To Bone"))
+	static FModelingResult BindSelectionToBone(int32 Handle, const FString& SelectionName, const FString& BoneName, float Weight = 1.f);
+
+	/** Bones on the mesh with their reference poses and influenced-vertex counts — check a rig before saving it. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "List Bones"))
+	static TArray<FModelingBoneInfo> ListBones(int32 Handle);
 };

--- a/Source/VibeUE/Public/PythonAPI/UModelingService.h
+++ b/Source/VibeUE/Public/PythonAPI/UModelingService.h
@@ -178,6 +178,51 @@ struct FModelingBakeResult
 	TArray<FString> TexturePaths;
 };
 
+/** Health of a UV layer (GetUVStats): what an unwrap looks like before you bake or paint on it. */
+USTRUCT(BlueprintType)
+struct FModelingUVStats
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	bool bSuccess = false;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FString Message;
+
+	/** Connected UV islands (shells). */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	int32 NumIslands = 0;
+
+	/** Triangles with no UVs assigned in this layer. */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	int32 NumUnsetTriangles = 0;
+
+	/** Fraction of the 0-1 square covered by at least one island. */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	float Coverage = 0.f;
+
+	/** Fraction of covered texels claimed by two or more islands (0 = no overlaps). */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	float OverlapFraction = 0.f;
+
+	/** Texels per centimetre at a 1024 texture (multiply by resolution/1024). */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	float TexelsPerCmAt1K = 0.f;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	float MeshArea = 0.f;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	float UVArea = 0.f;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FVector2D UVBoundsMin = FVector2D::ZeroVector;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FVector2D UVBoundsMax = FVector2D::ZeroVector;
+};
+
 /** One bone for CreateBones. Transform is in mesh space (the space the vertices are in); an empty ParentName makes it the root. */
 USTRUCT(BlueprintType)
 struct FModelingBoneDef
@@ -734,4 +779,77 @@ public:
 	/** Bones on the mesh with their reference poses and influenced-vertex counts — check a rig before saving it. */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "List Bones"))
 	static TArray<FModelingBoneInfo> ListBones(int32 Handle);
+
+	// =====================================================================
+	// UV control: islands you define, layouts you can verify
+	// =====================================================================
+
+	/** Give every triangle of a selection one polygroup: GroupID >= 0 sets that id, -1 allocates a new group. Polygroups are the island source for RecomputeUVs("Polygroups") and PatchBuilder. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Set Polygroup"))
+	static FModelingResult SetPolygroup(int32 Handle, const FString& SelectionName, int32 GroupID = -1);
+
+	/** Flatten each island with a conformal unwrap. IslandSource: "Polygroups" (one island per group — define them with SetPolygroup / ComputePolygroups) or "UVIslands" (re-flatten the existing islands). Method: "SpectralConformal" (default), "Conformal", "ExpMap". */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Recompute UVs", ScriptName = "recompute_uvs;recompute_u_vs"))
+	static FModelingResult RecomputeUVs(int32 Handle, int32 UVLayer = 0, const FString& IslandSource = TEXT("Polygroups"), const FString& Method = TEXT("SpectralConformal"),
+		const FString& SelectionName = TEXT(""), bool bAlignIslandsWithAxes = true);
+
+	/** Move / scale / rotate the UVs of a selection ("" = all) in UV space: scale and rotation are about Origin (0.5,0.5 = texture centre). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Transform UV", ScriptName = "transform_uv;transform_uv"))
+	static FModelingResult TransformUV(int32 Handle, int32 UVLayer, const FString& SelectionName, FVector2D Translation, FVector2D Scale, float RotationDeg = 0.f, FVector2D Origin = FVector2D(0.5, 0.5));
+
+	/** LayoutType: "Repack" (pack islands into 0-1 for TextureResolution), "Stack" (all islands on top of each other), "Normalize" (scale to unit texel density), "Transform" (Scale + Translation). Works on a selection's islands. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Layout UV", ScriptName = "layout_uv;layout_uv"))
+	static FModelingResult LayoutUV(int32 Handle, int32 UVLayer = 0, const FString& LayoutType = TEXT("Repack"), const FString& SelectionName = TEXT(""), int32 TextureResolution = 2048,
+		float Scale = 1.f, FVector2D Translation = FVector2D::ZeroVector);
+
+	/** Pack the islands of each material ID into their own full 0-1 range so every material slot gets its own texture set at full resolution. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Pack UV Per Material", ScriptName = "pack_uv_per_material;pack_uv_per_material"))
+	static FModelingResult PackUVPerMaterial(int32 Handle, int32 UVLayer = 0, int32 TextureResolution = 2048);
+
+	/** Islands, coverage, overlap and texel density of a UV layer — check an unwrap before baking or painting. GridResolution is the raster used for coverage/overlap. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Get UV Stats", ScriptName = "get_uv_stats;get_uv_stats"))
+	static FModelingUVStats GetUVStats(int32 Handle, int32 UVLayer = 0, int32 GridResolution = 512);
+
+	/** UV coordinate of the surface point nearest to a mesh-space position (where a marking lands on the texture). Returns false when the mesh has no UVs there. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "World To UV", ScriptName = "world_to_uv;world_to_uv"))
+	static bool WorldToUV(int32 Handle, FVector Point, int32 UVLayer, FVector2D& OutUV);
+
+	// =====================================================================
+	// More bakes and image tools
+	// =====================================================================
+
+	/** Transfer textures from SourceHandle's UVs onto TargetHandle's: one path = a plain texture bake, several (comma-separated, in source material-ID order) = a multi-texture bake. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Bake Texture Transfer"))
+	static FModelingBakeResult BakeTextureTransfer(int32 TargetHandle, int32 SourceHandle, const FString& SourceTexturePaths, int32 Resolution, const FString& OutputFolder,
+		const FString& BaseName, int32 TargetUVLayer = 0, int32 SourceUVLayer = 0, int32 SamplesPerPixel = 1);
+
+	/** Import an image file (png, jpg, tga, exr, ...) as a Texture2D asset. Compression: "Default", "Normalmap", "Masks", "Grayscale", "HDR". */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Import Texture"))
+	static FModelingResult ImportTexture(const FString& FilePath, const FString& AssetPath, bool bSRGB = true, const FString& Compression = TEXT("Default"), bool bSaveAsset = true);
+
+	/** Tileable fractal (Perlin fBm) grayscale texture — grunge, wear masks, height detail. Scale is the number of noise cells across the image. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Create Noise Texture"))
+	static FModelingResult CreateNoiseTexture(const FString& AssetPath, int32 Width = 1024, int32 Height = 1024, float Scale = 8.f, int32 Octaves = 4, float Persistence = 0.5f,
+		int32 Seed = 0, bool bSaveAsset = true);
+
+	/** Draw into an existing 8-bit texture in UV space (0-1, V down). Shape: "Line" (polyline through Points), "Dots" (discs every SpacingPx along the polyline), "Rect" (Points[0]..Points[1] filled), "Fill" (whole texture). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Draw On Texture"))
+	static FModelingResult DrawOnTexture(const FString& AssetPath, const FString& Shape, const TArray<FVector2D>& Points, FLinearColor Color, float ThicknessPx = 2.f,
+		float SpacingPx = 8.f, bool bSaveAsset = true);
+
+	// =====================================================================
+	// Surface detail helpers
+	// =====================================================================
+
+	/** Stamp another session mesh at every transform (pair with SampleSurfacePoints for scattered rivets, bolts, fasteners). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Mesh At Transforms"))
+	static FModelingResult AppendMeshAtTransforms(int32 Handle, int32 OtherHandle, const TArray<FTransform>& Transforms);
+
+	/** Stamp another session mesh every Spacing along a polyline, X axis along the line and Z along UpVector — rivet rows, fastener lines, light strips. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Mesh Along Polyline"))
+	static FModelingResult AppendMeshAlongPolyline(int32 Handle, int32 OtherHandle, const TArray<FVector>& Points, float Spacing = 10.f, FVector UpVector = FVector::UpVector, float Scale = 1.f);
+
+	/** Cut a rectangular groove (Width across, Depth into the surface along -UpVector, and as far out along +UpVector) following a polyline — recessed panel lines and seams. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Cut Groove Along Polyline"))
+	static FModelingResult CutGrooveAlongPolyline(int32 Handle, const TArray<FVector>& Points, float Width = 1.f, float Depth = 1.f, FVector UpVector = FVector::UpVector);
 };

--- a/Source/VibeUE/Public/PythonAPI/UModelingService.h
+++ b/Source/VibeUE/Public/PythonAPI/UModelingService.h
@@ -111,6 +111,57 @@ struct FModelingSplitResult
 	TArray<int32> Handles;
 };
 
+/** A point found on a mesh surface by RayCast / NearestPoint. */
+USTRUCT(BlueprintType)
+struct FModelingSurfacePoint
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	bool bFound = false;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FVector Position = FVector::ZeroVector;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	int32 TriangleID = -1;
+
+	/** Ray parameter (distance along the ray) for RayCast; distance from the query point for NearestPoint. */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	float Distance = 0.f;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FVector BaryCoords = FVector::ZeroVector;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FString Message;
+};
+
+/** Surface-to-surface distances between two session meshes (MeasureDistance). */
+USTRUCT(BlueprintType)
+struct FModelingDistanceReport
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	bool bSuccess = false;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FString Message;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	float MaxDistance = 0.f;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	float MinDistance = 0.f;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	float AverageDistance = 0.f;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	float RootMeanSquareDeviation = 0.f;
+};
+
 USTRUCT(BlueprintType)
 struct FModelingBakeResult
 {
@@ -435,9 +486,13 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Flip Normals"))
 	static FModelingResult FlipNormals(int32 Handle);
 
-	/** Assign polygroups by crease angle (needed by BevelPolygroups / PatchBuilder on imported meshes). */
+	/** Assign polygroups. Method: "Angle" (crease angle), "UVIslands", "Components", "Polygons" (detect quads/planar polygons). Needed by BevelPolygroups / PatchBuilder / SelectByPolygroup on imported meshes. */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Compute Polygroups"))
-	static FModelingResult ComputePolygroups(int32 Handle, float CreaseAngleDeg = 15.f, int32 MinGroupSize = 2);
+	static FModelingResult ComputePolygroups(int32 Handle, const FString& Method = TEXT("Angle"), float CreaseAngleDeg = 15.f, int32 MinGroupSize = 2);
+
+	/** Move every triangle with FromMaterialID to ToMaterialID. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Remap Material ID"))
+	static FModelingResult RemapMaterialID(int32 Handle, int32 FromMaterialID, int32 ToMaterialID);
 
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Set Material ID"))
 	static FModelingResult SetMaterialID(int32 Handle, const FString& SelectionName, int32 MaterialID);
@@ -499,4 +554,93 @@ public:
 	/** Place a StaticMesh asset in the current level as a StaticMeshActor. */
 	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Spawn Static Mesh Actor"))
 	static FModelingResult SpawnStaticMeshActor(const FString& AssetPath, FTransform Transform, const FString& ActorLabel = TEXT(""));
+
+	// =====================================================================
+	// More primitives
+	// =====================================================================
+
+	/** Spiral / curved staircase around the +Z axis. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Curved Stairs"))
+	static FModelingResult AppendCurvedStairs(int32 Handle, FTransform Transform, float StepWidth = 100.f, float StepHeight = 20.f, float InnerRadius = 150.f,
+		float CurveAngle = 90.f, int32 NumSteps = 8, bool bFloating = false, int32 MaterialID = 0);
+
+	/** Sphere built from a subdivided cube (even quads — better for booleans and UVs than a lat-long sphere). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Sphere Box"))
+	static FModelingResult AppendSphereBox(int32 Handle, FTransform Transform, float Radius = 50.f, int32 Steps = 6, const FString& Origin = TEXT("Center"), int32 MaterialID = 0);
+
+	/** Sweep a 2D profile (XY, open polyline) along a path of transforms: pipes, rails, cables, trim. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Sweep Polyline"))
+	static FModelingResult AppendSweepPolyline(int32 Handle, FTransform Transform, const TArray<FVector2D>& ProfilePoints, const TArray<FTransform>& SweepPath,
+		bool bLoop = false, float StartScale = 1.f, float EndScale = 1.f, int32 MaterialID = 0);
+
+	// =====================================================================
+	// More simplification
+	// =====================================================================
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Simplify To Vertex Count"))
+	static FModelingResult SimplifyToVertexCount(int32 Handle, int32 VertexCount, bool bAllowSeamCollapse = true);
+
+	/** Collapse coplanar triangles only — lossless cleanup for boolean / voxel output. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Simplify Planar"))
+	static FModelingResult SimplifyPlanar(int32 Handle, float AngleThresholdDeg = 0.001f);
+
+	// =====================================================================
+	// Spatial queries and sampling
+	// =====================================================================
+
+	/** First hit of a ray against the mesh (MaxDistance 0 = unlimited). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Ray Cast"))
+	static FModelingSurfacePoint RayCast(int32 Handle, FVector Origin, FVector Direction, float MaxDistance = 0.f);
+
+	/** Closest point on the surface to a query point (MaxDistance 0 = unlimited). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Nearest Point"))
+	static FModelingSurfacePoint NearestPoint(int32 Handle, FVector Point, float MaxDistance = 0.f);
+
+	/** Winding-number containment test — the mesh should be closed. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Is Point Inside"))
+	static bool IsPointInside(int32 Handle, FVector Point);
+
+	/** Poisson-disc samples on the surface (position + surface-aligned rotation), for scattering props/foliage/decals. MaxSamples 0 = no cap. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Sample Surface Points"))
+	static TArray<FTransform> SampleSurfacePoints(int32 Handle, float SamplingRadius = 10.f, int32 MaxSamples = 0);
+
+	/** Bounding box of a selection. Returns false when the selection is empty. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Selection Bounds"))
+	static bool SelectionBounds(int32 Handle, const FString& SelectionName, FVector& OutMin, FVector& OutMax);
+
+	/** Select every triangle in one polygroup (see ComputePolygroups / GetMeshInfo). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Select By Polygroup"))
+	static int32 SelectByPolygroup(int32 Handle, const FString& SelectionName, int32 PolygroupID);
+
+	// =====================================================================
+	// Hulls and comparison
+	// =====================================================================
+
+	/** Convex hull of the mesh as a NEW handle (SimplifyToFaceCount 0 = exact). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Convex Hull"))
+	static FModelingResult ConvexHull(int32 Handle, int32 SimplifyToFaceCount = 0);
+
+	/** Approximate the mesh with NumHulls convex pieces, returned merged as a NEW handle (collision proxies, blockout simplification). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Convex Decomposition"))
+	static FModelingResult ConvexDecomposition(int32 Handle, int32 NumHulls = 2);
+
+	/** Hull swept along ProjectionFrame's Z axis (2D outline extruded through the mesh) as a NEW handle. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Swept Hull"))
+	static FModelingResult SweptHull(int32 Handle, FTransform ProjectionFrame);
+
+	/** Surface distances between two meshes — verify a LOD / simplified copy against its source. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Measure Distance"))
+	static FModelingDistanceReport MeasureDistance(int32 HandleA, int32 HandleB);
+
+	// =====================================================================
+	// More skeletal
+	// =====================================================================
+
+	/** Recompute smooth skin weights against a skeleton after transfer or edits. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Smooth Bone Weights"))
+	static FModelingResult SmoothBoneWeights(int32 Handle, const FString& SkeletonPath, float Stiffness = 0.2f, int32 MaxInfluences = 5);
+
+	/** Remove bones (comma-separated names) from the skin weights, renormalizing the rest. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Prune Bone Weights"))
+	static FModelingResult PruneBoneWeights(int32 Handle, const FString& BoneNames);
 };

--- a/Source/VibeUE/Public/PythonAPI/UModelingService.h
+++ b/Source/VibeUE/Public/PythonAPI/UModelingService.h
@@ -1,0 +1,502 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "ToolsetRegistry/ToolsetDefinition.h"
+#include "UModelingService.generated.h"
+
+class UDynamicMesh;
+
+/**
+ * Outcome of a modeling operation. Handle echoes the mesh the call acted on (or the one it
+ * created), TriangleCount / VertexCount describe that mesh afterwards, AssetPath is set by the
+ * asset-writing calls.
+ */
+USTRUCT(BlueprintType)
+struct FModelingResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	bool bSuccess = false;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FString Message;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	int32 Handle = -1;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	int32 TriangleCount = 0;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	int32 VertexCount = 0;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FString AssetPath;
+};
+
+/** Diagnostic snapshot of a session mesh — read it between stages instead of trusting a green result. */
+USTRUCT(BlueprintType)
+struct FModelingMeshInfo
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	bool bSuccess = false;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FString Message;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	int32 Handle = -1;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	int32 TriangleCount = 0;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	int32 VertexCount = 0;
+
+	/** Watertight (no open border edges). Booleans and voxel ops want this true. */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	bool bIsClosed = false;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	int32 OpenBorderEdges = 0;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	int32 ConnectedComponents = 0;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FVector BoundsMin = FVector::ZeroVector;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FVector BoundsMax = FVector::ZeroVector;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	float SurfaceArea = 0.f;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	float Volume = 0.f;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	int32 NumUVLayers = 0;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	bool bHasVertexColors = false;
+
+	/** Distinct material IDs in use (empty when the mesh has no material attribute). */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	TArray<int32> MaterialIDs;
+
+	/** Named selections currently stored on this handle. */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	TArray<FString> Selections;
+};
+
+USTRUCT(BlueprintType)
+struct FModelingSplitResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	bool bSuccess = false;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FString Message;
+
+	/** One new session handle per connected component, largest first. */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	TArray<int32> Handles;
+};
+
+USTRUCT(BlueprintType)
+struct FModelingBakeResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	bool bSuccess = false;
+
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	FString Message;
+
+	/** Saved Texture2D asset paths, in the order of the requested bake types. */
+	UPROPERTY(BlueprintReadWrite, Category = "VibeUE|Modeling")
+	TArray<FString> TexturePaths;
+};
+
+/**
+ * Programmatic mesh modeling — the operator half of Unreal's Modeling Mode, driven without a
+ * viewport. Meshes live in an in-editor session as integer handles wrapping a UDynamicMesh:
+ * create or load one, chain operations on it, save it as a StaticMesh / SkeletalMesh asset,
+ * release it. Operations that act on part of a mesh take a named selection made on the same
+ * handle (pass "" for the whole mesh). Everything is built on GeometryScript, so the long tail
+ * is one call away: GetDynamicMesh(handle) hands the UDynamicMesh to any
+ * unreal.GeometryScript_* function in the same Python script.
+ *
+ * Python: unreal.ModelingService.<snake_case>(...). See the `modeling` skill for the workflow.
+ */
+UCLASS(BlueprintType)
+class VIBEUE_API UModelingService : public UToolsetDefinition
+{
+	GENERATED_BODY()
+
+public:
+	// =====================================================================
+	// Session
+	// =====================================================================
+
+	/** Create an empty session mesh. Result.Handle is the new handle. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Create Mesh"))
+	static FModelingResult CreateMesh();
+
+	/** Load a StaticMesh asset's LOD into a new session mesh (materials become material IDs by section). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Load Mesh From Static Mesh"))
+	static FModelingResult LoadMeshFromStaticMesh(const FString& AssetPath, int32 LODIndex = 0);
+
+	/** Load a SkeletalMesh asset's LOD (with bone weights) into a new session mesh. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Load Mesh From Skeletal Mesh"))
+	static FModelingResult LoadMeshFromSkeletalMesh(const FString& AssetPath, int32 LODIndex = 0);
+
+	/** Load the static mesh of a level actor (by label) into a new session mesh; bWorldSpace bakes the actor transform in. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Load Mesh From Actor"))
+	static FModelingResult LoadMeshFromActor(const FString& ActorLabel, bool bWorldSpace = false, int32 LODIndex = 0);
+
+	/** Duplicate a session mesh into a new handle. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Copy Mesh"))
+	static FModelingResult CopyMesh(int32 Handle);
+
+	/** Free one session mesh (and its selections). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Release Mesh"))
+	static bool ReleaseMesh(int32 Handle);
+
+	/** Free every session mesh. Returns how many were released. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Release All Meshes"))
+	static int32 ReleaseAllMeshes();
+
+	/** Handles currently alive in the session. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "List Meshes"))
+	static TArray<int32> ListMeshes();
+
+	/** Counts, bounds, closedness, components, UV layers, material IDs, stored selections. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Get Mesh Info"))
+	static FModelingMeshInfo GetMeshInfo(int32 Handle);
+
+	/** The UDynamicMesh behind a handle, for direct use with unreal.GeometryScript_* libraries (Python only). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (DisplayName = "Get Dynamic Mesh"))
+	static UDynamicMesh* GetDynamicMesh(int32 Handle);
+
+	// =====================================================================
+	// Primitives (appended into an existing handle; Transform places them)
+	// =====================================================================
+
+	/** Origin: "Base" (sits on Z=0) or "Center". Steps subdivide the faces. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Box"))
+	static FModelingResult AppendBox(int32 Handle, FTransform Transform, float DimensionX = 100.f, float DimensionY = 100.f, float DimensionZ = 100.f,
+		int32 StepsX = 0, int32 StepsY = 0, int32 StepsZ = 0, const FString& Origin = TEXT("Base"), int32 MaterialID = 0);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Sphere"))
+	static FModelingResult AppendSphere(int32 Handle, FTransform Transform, float Radius = 50.f, int32 StepsPhi = 10, int32 StepsTheta = 16,
+		const FString& Origin = TEXT("Center"), int32 MaterialID = 0);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Cylinder"))
+	static FModelingResult AppendCylinder(int32 Handle, FTransform Transform, float Radius = 50.f, float Height = 100.f, int32 RadialSteps = 12,
+		int32 HeightSteps = 0, bool bCapped = true, const FString& Origin = TEXT("Base"), int32 MaterialID = 0);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Cone"))
+	static FModelingResult AppendCone(int32 Handle, FTransform Transform, float BaseRadius = 50.f, float TopRadius = 5.f, float Height = 100.f,
+		int32 RadialSteps = 12, int32 HeightSteps = 4, bool bCapped = true, const FString& Origin = TEXT("Base"), int32 MaterialID = 0);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Capsule"))
+	static FModelingResult AppendCapsule(int32 Handle, FTransform Transform, float Radius = 30.f, float LineLength = 75.f, int32 HemisphereSteps = 5,
+		int32 CircleSteps = 8, const FString& Origin = TEXT("Base"), int32 MaterialID = 0);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Torus"))
+	static FModelingResult AppendTorus(int32 Handle, FTransform Transform, float MajorRadius = 50.f, float MinorRadius = 25.f, int32 MajorSteps = 16,
+		int32 MinorSteps = 8, const FString& Origin = TEXT("Base"), int32 MaterialID = 0);
+
+	/** Flat rectangle in the XY plane. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Rectangle"))
+	static FModelingResult AppendRectangle(int32 Handle, FTransform Transform, float DimensionX = 100.f, float DimensionY = 100.f, int32 StepsWidth = 0,
+		int32 StepsHeight = 0, int32 MaterialID = 0);
+
+	/** Flat disc / ring / arc in the XY plane. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Disc"))
+	static FModelingResult AppendDisc(int32 Handle, FTransform Transform, float Radius = 50.f, int32 AngleSteps = 16, int32 SpokeSteps = 0,
+		float StartAngle = 0.f, float EndAngle = 360.f, float HoleRadius = 0.f, int32 MaterialID = 0);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Stairs"))
+	static FModelingResult AppendStairs(int32 Handle, FTransform Transform, float StepWidth = 100.f, float StepHeight = 20.f, float StepDepth = 30.f,
+		int32 NumSteps = 8, bool bFloating = false, int32 MaterialID = 0);
+
+	/** Extrude a closed 2D polygon (XY, counter-clockwise) along +Z. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Extrude Polygon"))
+	static FModelingResult AppendExtrudePolygon(int32 Handle, FTransform Transform, const TArray<FVector2D>& PolygonPoints, float Height = 100.f,
+		int32 HeightSteps = 0, bool bCapped = true, const FString& Origin = TEXT("Base"), int32 MaterialID = 0);
+
+	/** Revolve a 2D profile (X = radius offset, Y = height) around the Z axis: lathe shapes, rings, vases. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Revolve Polygon"))
+	static FModelingResult AppendRevolvePolygon(int32 Handle, FTransform Transform, const TArray<FVector2D>& ProfilePoints, float Radius = 100.f,
+		int32 Steps = 16, float RevolveDegrees = 360.f, int32 MaterialID = 0);
+
+	/** Append another session mesh (transformed) into this one — no boolean, just merged geometry. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Append Mesh"))
+	static FModelingResult AppendMesh(int32 Handle, int32 OtherHandle, FTransform Transform);
+
+	// =====================================================================
+	// Booleans
+	// =====================================================================
+
+	/** Operation: "Union", "Subtract", "Intersection". ToolTransform places the tool mesh relative to the target. Both should be closed. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Boolean"))
+	static FModelingResult Boolean(int32 TargetHandle, int32 ToolHandle, const FString& Operation, FTransform ToolTransform,
+		bool bFillHoles = true, bool bSimplifyOutput = true);
+
+	/** Union a mesh with itself — merges overlapping kitbash pieces into one shell. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Self Union"))
+	static FModelingResult SelfUnion(int32 Handle, bool bFillHoles = true, bool bTrimFlaps = true);
+
+	/** Cut away everything on the +Z side of CutFrame (its Z axis is the plane normal). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Plane Cut"))
+	static FModelingResult PlaneCut(int32 Handle, FTransform CutFrame, bool bFillHoles = true, bool bFlipCutSide = false);
+
+	/** Mirror across MirrorFrame's XY plane (optionally cutting the source side first and welding the seam). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Mirror"))
+	static FModelingResult Mirror(int32 Handle, FTransform MirrorFrame, bool bApplyPlaneCut = true, bool bWeldAlongPlane = true, bool bFlipCutSide = false);
+
+	// =====================================================================
+	// Selections (named, stored per handle; "" means the whole mesh)
+	// =====================================================================
+
+	/** SelectionType: "Triangles" (default), "Vertices", "Edges", "Polygroups". Returns the element count. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Select All"))
+	static int32 SelectAll(int32 Handle, const FString& SelectionName, const FString& SelectionType = TEXT("Triangles"));
+
+	/** Triangles whose normal is within MaxAngleDeg of Normal (e.g. (0,0,1) + 5 = the top faces). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Select By Normal Angle"))
+	static int32 SelectByNormalAngle(int32 Handle, const FString& SelectionName, FVector Normal, float MaxAngleDeg = 1.f, bool bInvert = false);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Select In Box"))
+	static int32 SelectInBox(int32 Handle, const FString& SelectionName, FVector BoxMin, FVector BoxMax, bool bInvert = false);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Select In Sphere"))
+	static int32 SelectInSphere(int32 Handle, const FString& SelectionName, FVector Center, float Radius = 100.f, bool bInvert = false);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Select By Material ID"))
+	static int32 SelectByMaterialID(int32 Handle, const FString& SelectionName, int32 MaterialID);
+
+	/** Grow (or shrink with bContract) a selection by N rings of neighbours; stores it under NewSelectionName. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Expand Contract Selection"))
+	static int32 ExpandContractSelection(int32 Handle, const FString& SelectionName, const FString& NewSelectionName, int32 Iterations = 1, bool bContract = false);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Invert Selection"))
+	static int32 InvertSelection(int32 Handle, const FString& SelectionName, const FString& NewSelectionName);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Selection Count"))
+	static int32 SelectionCount(int32 Handle, const FString& SelectionName);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Clear Selections"))
+	static bool ClearSelections(int32 Handle);
+
+	// =====================================================================
+	// Poly-edit operations (Modeling Mode's PolyEdit / Offset / Bevel)
+	// =====================================================================
+
+	/** Extrude selected faces. Zero Direction = along each face's average normal; otherwise a fixed world direction. Negative distance recesses. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Extrude Faces"))
+	static FModelingResult ExtrudeFaces(int32 Handle, const FString& SelectionName, float Distance = 10.f, FVector Direction = FVector::ZeroVector);
+
+	/** Offset selected faces along their normals (parallel face offset). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Offset Faces"))
+	static FModelingResult OffsetFaces(int32 Handle, const FString& SelectionName, float Distance = 10.f);
+
+	/** Inset selected faces (panel lines, frames). Softness rounds the inset boundary. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Inset Faces"))
+	static FModelingResult InsetFaces(int32 Handle, const FString& SelectionName, float Distance = 5.f, float Softness = 0.f);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Outset Faces"))
+	static FModelingResult OutsetFaces(int32 Handle, const FString& SelectionName, float Distance = 5.f, float Softness = 0.f);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Delete Faces"))
+	static FModelingResult DeleteFaces(int32 Handle, const FString& SelectionName);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Translate Selection"))
+	static FModelingResult TranslateSelection(int32 Handle, const FString& SelectionName, FVector Delta);
+
+	/** Bevel the edges between polygroups (run ComputePolygroups first on imported meshes). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Bevel Polygroups"))
+	static FModelingResult BevelPolygroups(int32 Handle, float Distance = 1.f, int32 Subdivisions = 0, float RoundWeight = 1.f);
+
+	/** Offset the whole surface along its normals (inflate / deflate). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Offset Mesh"))
+	static FModelingResult OffsetMesh(int32 Handle, float Distance = 1.f);
+
+	/** Turn an open surface into a solid shell of the given thickness. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Shell Mesh"))
+	static FModelingResult ShellMesh(int32 Handle, float Thickness = 1.f);
+
+	// =====================================================================
+	// Mesh processing
+	// =====================================================================
+
+	/** Uniform remesh to a triangle count, or to an edge length when EdgeLength > 0. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Remesh"))
+	static FModelingResult Remesh(int32 Handle, int32 TargetTriangleCount = 5000, float EdgeLength = 0.f, bool bReprojectToInput = true);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Simplify To Triangle Count"))
+	static FModelingResult SimplifyToTriangleCount(int32 Handle, int32 TriangleCount, bool bAllowSeamCollapse = true);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Simplify To Tolerance"))
+	static FModelingResult SimplifyToTolerance(int32 Handle, float Tolerance = 0.5f, bool bAllowSeamCollapse = true);
+
+	/** Method: "PN" (curved, smooth normals), "Uniform" (flat split), "CatmullClark" (polygroup SubD), "Loop" (triangle SubD). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Subdivide"))
+	static FModelingResult Subdivide(int32 Handle, int32 Level = 1, const FString& Method = TEXT("PN"));
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Smooth"))
+	static FModelingResult Smooth(int32 Handle, const FString& SelectionName, int32 Iterations = 5, float Alpha = 0.2f);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Fill Holes"))
+	static FModelingResult FillHoles(int32 Handle);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Weld Edges"))
+	static FModelingResult WeldEdges(int32 Handle, float Tolerance = 0.001f);
+
+	/** Repair degenerate triangles, drop tiny floating pieces, compact — the standard cleanup after imports and booleans. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Repair"))
+	static FModelingResult Repair(int32 Handle, float MinComponentVolume = 0.0001f, int32 MinComponentTriangles = 1);
+
+	/** Remove triangles that cannot be seen from outside (kitbash interiors). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Remove Hidden Triangles"))
+	static FModelingResult RemoveHiddenTriangles(int32 Handle);
+
+	/** Split into connected components, each becoming a new session handle. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Split By Components"))
+	static FModelingSplitResult SplitByComponents(int32 Handle);
+
+	// =====================================================================
+	// Deformation
+	// =====================================================================
+
+	/** Bend around the frame's Y axis by Angle degrees within Extent of its origin. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Bend"))
+	static FModelingResult Bend(int32 Handle, FTransform Orientation, float AngleDeg = 45.f, float Extent = 50.f, bool bBidirectional = true);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Twist"))
+	static FModelingResult Twist(int32 Handle, FTransform Orientation, float AngleDeg = 45.f, float Extent = 50.f, bool bBidirectional = true);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Flare"))
+	static FModelingResult Flare(int32 Handle, FTransform Orientation, float PercentX = 20.f, float PercentY = 20.f, float Extent = 50.f);
+
+	/** Perlin displacement along normals (rock, damage, organic wobble). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Noise"))
+	static FModelingResult Noise(int32 Handle, const FString& SelectionName, float Magnitude = 5.f, float Frequency = 0.25f, int32 RandomSeed = 0);
+
+	/** Displace along normals by a texture sampled through a UV layer (height maps). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Displace From Texture"))
+	static FModelingResult DisplaceFromTexture(int32 Handle, const FString& SelectionName, const FString& TexturePath, float Magnitude = 10.f, int32 UVLayer = 0);
+
+	// =====================================================================
+	// Voxel operations
+	// =====================================================================
+
+	/** Rebuild as a watertight voxel-derived surface (fixes any topology; loses UVs). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Voxel Solidify"))
+	static FModelingResult VoxelSolidify(int32 Handle, int32 GridResolution = 64, float WindingThreshold = 0.5f);
+
+	/** Operation: "Dilate", "Contract", "Open", "Close" by Distance (Close welds nearby pieces, Open removes thin bits). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Voxel Morphology"))
+	static FModelingResult VoxelMorphology(int32 Handle, const FString& Operation, float Distance = 5.f, int32 GridResolution = 64);
+
+	// =====================================================================
+	// UVs, normals, groups, materials, colors
+	// =====================================================================
+
+	/** Method: "XAtlas" (general unwrap) or "PatchBuilder" (hard-surface, respects groups). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Auto UV"))
+	static FModelingResult AutoUV(int32 Handle, const FString& Method = TEXT("XAtlas"), int32 UVLayer = 0);
+
+	/** Method: "Planar", "Box", "Cylinder"; the transform positions/scales the projector. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Project UV"))
+	static FModelingResult ProjectUV(int32 Handle, const FString& Method, FTransform ProjectorTransform, int32 UVLayer = 0, const FString& SelectionName = TEXT(""));
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Repack UV"))
+	static FModelingResult RepackUV(int32 Handle, int32 UVLayer = 0, int32 TextureResolution = 1024);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Set Num UV Layers"))
+	static FModelingResult SetNumUVLayers(int32 Handle, int32 NumLayers);
+
+	/** HardAngleDeg < 0 = fully smooth; otherwise edges sharper than the angle get split normals. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Recompute Normals"))
+	static FModelingResult RecomputeNormals(int32 Handle, float HardAngleDeg = 30.f);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Flip Normals"))
+	static FModelingResult FlipNormals(int32 Handle);
+
+	/** Assign polygroups by crease angle (needed by BevelPolygroups / PatchBuilder on imported meshes). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Compute Polygroups"))
+	static FModelingResult ComputePolygroups(int32 Handle, float CreaseAngleDeg = 15.f, int32 MinGroupSize = 2);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Set Material ID"))
+	static FModelingResult SetMaterialID(int32 Handle, const FString& SelectionName, int32 MaterialID);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Set Vertex Color"))
+	static FModelingResult SetVertexColor(int32 Handle, const FString& SelectionName, FLinearColor Color);
+
+	// =====================================================================
+	// Transform
+	// =====================================================================
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Transform Mesh"))
+	static FModelingResult TransformMesh(int32 Handle, FTransform Transform);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Translate Mesh"))
+	static FModelingResult TranslateMesh(int32 Handle, FVector Translation);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Rotate Mesh"))
+	static FModelingResult RotateMesh(int32 Handle, FRotator Rotation, FVector Origin = FVector::ZeroVector);
+
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Scale Mesh"))
+	static FModelingResult ScaleMesh(int32 Handle, FVector Scale, FVector Origin = FVector::ZeroVector);
+
+	/** Mode: "Bounds" (bounds center to origin) or "Base" (XY center to origin, bottom to Z=0). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Recenter Mesh"))
+	static FModelingResult RecenterMesh(int32 Handle, const FString& Mode = TEXT("Base"));
+
+	// =====================================================================
+	// Assets, collision, LODs, baking, placement
+	// =====================================================================
+
+	/** Write the mesh to a StaticMesh asset (created, or LOD0 replaced when it exists and bReplaceExisting). Saves the package. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Save Mesh To Static Mesh"))
+	static FModelingResult SaveMeshToStaticMesh(int32 Handle, const FString& AssetPath, bool bReplaceExisting = true, bool bEnableCollision = true,
+		bool bEnableNanite = false, bool bSaveAsset = true);
+
+	/** Write the mesh (with its bone weights) to a SkeletalMesh asset bound to SkeletonPath. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Save Mesh To Skeletal Mesh"))
+	static FModelingResult SaveMeshToSkeletalMesh(int32 Handle, const FString& AssetPath, const FString& SkeletonPath, bool bReplaceExisting = true, bool bSaveAsset = true);
+
+	/** Copy skin weights from a SkeletalMesh asset onto this mesh by closest surface point (re-skin a modified body). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Transfer Bone Weights"))
+	static FModelingResult TransferBoneWeights(int32 Handle, const FString& SourceSkeletalMeshPath, int32 SourceLODIndex = 0);
+
+	/** Method: "MinVolumeShapes", "ConvexHulls", "AlignedBoxes", "OrientedBoxes", "MinimalSpheres", "Capsules", "SweptHulls". Acts on the asset. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Generate Collision"))
+	static FModelingResult GenerateCollision(const FString& AssetPath, const FString& Method = TEXT("MinVolumeShapes"), int32 MaxConvexHulls = 1,
+		int32 ConvexHullTargetFaceCount = 25, bool bSaveAsset = true);
+
+	/** Rebuild the asset's LOD chain: one entry per LOD as a fraction of LOD0 triangles (LOD0 first, e.g. [1.0, 0.5, 0.25]). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Set LODs", ScriptName = "set_lods;set_lo_ds"))
+	static FModelingResult SetLODs(const FString& AssetPath, const TArray<float>& PercentTrianglesPerLOD, bool bAutoComputeScreenSize = true, bool bSaveAsset = true);
+
+	/** Bake maps from SourceHandle onto TargetHandle's UVs. BakeTypes: comma list of "TangentNormal", "ObjectNormal", "AmbientOcclusion", "Curvature", "Position", "BentNormal". Resolution 16..8192 (power of two). */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Bake Textures"))
+	static FModelingBakeResult BakeTextures(int32 TargetHandle, int32 SourceHandle, const FString& BakeTypes, int32 Resolution, const FString& OutputFolder,
+		const FString& BaseName, int32 TargetUVLayer = 0, int32 SamplesPerPixel = 1);
+
+	/** Place a StaticMesh asset in the current level as a StaticMeshActor. */
+	UFUNCTION(BlueprintCallable, Category = "VibeUE|Modeling", meta = (AICallable, DisplayName = "Spawn Static Mesh Actor"))
+	static FModelingResult SpawnStaticMeshActor(const FString& AssetPath, FTransform Transform, const FString& ActorLabel = TEXT(""));
+};

--- a/Source/VibeUE/VibeUE.Build.cs
+++ b/Source/VibeUE/VibeUE.Build.cs
@@ -137,6 +137,13 @@ public class VibeUE : ModuleRules
 				"MetasoundGraphCore",     // For core MetaSound graph types
 				"MeshDescription",        // For FMeshDescription / TVertexInstanceAttributesRef (UV editing)
 				"StaticMeshDescription",  // For FStaticMeshAttributes / FStaticMeshOperations / FUVMapParameters
+				"GeometryCore",           // ModelingService: FDynamicMesh3 + attribute sets behind UDynamicMesh
+				"GeometryFramework",      // ModelingService: UDynamicMesh / UDynamicMeshPool session meshes
+				"DynamicMesh",            // ModelingService: mesh operator types used by GeometryScript
+				"GeometryScriptingCore",  // ModelingService: the Modeling Mode operators (primitives, booleans, remesh, UV, bake, collision, ...)
+				"GeometryScriptingEditor",// ModelingService: create StaticMesh / SkeletalMesh / Texture2D assets, SubD
+				"StaticMeshEditor",       // ModelingService: UStaticMeshEditorSubsystem (LOD chain generation)
+				"SkeletalMeshDescription",// ModelingService: FSkeletalMeshAttributesShared (bone-weight transfer options)
 				"ToolsetRegistry",        // UE 5.8 native AI toolset registry — exposes services as AICallable tools on Epic's MCP endpoint
 				"ModelContextProtocol",   // UE 5.8 native MCP server — VibeUE's dynamic tools are bridged onto Epic's endpoint
 				"AIModule",               // UBehaviorTree, UBlackboardData, UBTNode, blackboard key types

--- a/VibeUE.uplugin
+++ b/VibeUE.uplugin
@@ -50,6 +50,10 @@
 			"Enabled": true
 		},
 		{
+			"Name": "GeometryScripting",
+			"Enabled": true
+		},
+		{
 			"Name": "ModelViewViewModel",
 			"Enabled": true
 		},

--- a/test_prompts/modeling/modeling_tests.md
+++ b/test_prompts/modeling/modeling_tests.md
@@ -242,3 +242,15 @@ Try `inset_faces` with a selection name that does not exist and confirm the erro
 
 ## Prompt 13.1
 Delete the `ModelingTestCrate` actor, delete everything under `/Game/Developers/VibeUEModelingTests`, and release all modeling handles. Confirm `list_meshes` is empty.
+
+## Prompt 14.1 — lofted wing
+
+**Prompt:** "Loft a tapered wing section: a symmetric airfoil profile, root chord 300 at the origin, tip chord 120 four metres out along +Y and swept back 80 cm. Prove it is closed and faces outward, then save it as `/Game/Developers/Test/SM_LoftWing`."
+
+**Expected:** `append_loft` with two frames (yaw 90, scale = chord); `get_mesh_info` shows `is_closed` and a positive volume; a saved static mesh. No manual `fill_holes` / `flip_normals` needed.
+
+## Prompt 14.2 — rigged rudder
+
+**Prompt:** "Build a simple tail fin with a rudder: a fin slab, a through-slot cut along the hinge line so the rear third is a separate piece. Create a `root` bone and a `rudder` bone whose X axis runs along the hinge, bind the rudder piece to it, confirm with `list_bones` that the rudder bone owns exactly the rudder's vertices, and save it as `/Game/Developers/Test/SK_Fin` with a new skeleton."
+
+**Expected:** `boolean` Subtract for the slot → `select_connected` on a point in the rudder → `create_bones` (root, rudder) → `bind_selection_to_bone` → `list_bones` showing two bones with non-zero counts → `save_mesh_to_skeletal_mesh(..., "", ...)` producing `SK_Fin` and `SK_Fin_Skeleton`.

--- a/test_prompts/modeling/modeling_tests.md
+++ b/test_prompts/modeling/modeling_tests.md
@@ -1,0 +1,244 @@
+# Mesh Modeling Test Prompts
+
+Sequential prompts that exercise every `ModelingService` function through an agent. Each section
+names the functions it covers; the agent should call them via `execute_python_code`
+(`unreal.ModelingService`) after loading the `modeling` skill. Assets are created under
+`/Game/Developers/VibeUEModelingTests` and removed in the last section.
+
+For a no-agent check of the same surface, run `Content/Skills/modeling/scripts/exercise_all.txt`
+(calls every function and prints `RESULT: PASS`), or the automation tests `VibeUE.Modeling.*`
+(console: `Automation RunTests VibeUE.Modeling`).
+
+## Prerequisites
+
+- UE 5.8 editor with VibeUE enabled and the MCP server running.
+- No assets required; the Skeletal section needs any SkeletalMesh in the project (skip otherwise).
+
+## Test Order
+
+1. Session basics
+2. Primitives
+3. Booleans
+4. Selections and poly-edit
+5. Mesh processing
+6. Deformation and voxels
+7. UVs, normals, groups, materials, colors
+8. Transforms
+9. Queries, sampling, hulls, comparison
+10. Assets, collision, LODs, baking, placement
+11. Skeletal
+12. Error handling
+13. Cleanup
+
+---
+
+# 1. Session basics
+
+## Goal
+Handles are created, inspected, copied, listed, and released. Covers `create_mesh`, `copy_mesh`,
+`list_meshes`, `get_mesh_info`, `get_dynamic_mesh`, `release_mesh`, `release_all_meshes`.
+
+## Prompt 1.1
+Create an empty modeling mesh, append a 100 cm box to it, and tell me its handle, triangle count, vertex count, whether it is closed, and its bounds.
+
+## Prompt 1.2
+Copy that mesh to a second handle, list all live handles, then release the copy and list again. Confirm the original still reports 12 triangles.
+
+## Prompt 1.3
+Get the raw DynamicMesh for the handle and use a GeometryScript function directly on it (e.g. `unreal.GeometryScript_MeshQueries` for the bounding box) to show the long-tail path works.
+
+---
+
+# 2. Primitives
+
+## Goal
+Every primitive appends geometry. Covers `append_box`, `append_sphere`, `append_sphere_box`,
+`append_cylinder`, `append_cone`, `append_capsule`, `append_torus`, `append_rectangle`,
+`append_disc`, `append_stairs`, `append_curved_stairs`, `append_extrude_polygon`,
+`append_revolve_polygon`, `append_sweep_polyline`, `append_mesh`.
+
+## Prompt 2.1
+Into one handle, append a box, a lat-long sphere, a sphere-box, a cylinder, a cone, a capsule, and a torus, each 120 cm apart along X. Report the triangle count after each append.
+
+## Prompt 2.2
+Into a new handle append a rectangle, a disc with a 10 cm hole and a 270° arc, an 8-step straight staircase, and a 6-step curved staircase with 80 cm inner radius.
+
+## Prompt 2.3
+Extrude a 2D L-shaped polygon 15 cm along Z, and revolve a vase profile (points in X = radius, Y = height) around Z with 24 steps.
+
+## Prompt 2.4
+Sweep a small V-shaped profile along a 3-frame path that rises and turns, then append that whole handle into the handle from 2.1 offset 200 cm up.
+
+---
+
+# 3. Booleans
+
+## Goal
+Covers `boolean` (Union / Subtract / Intersection), `self_union`, `plane_cut`, `mirror`.
+
+## Prompt 3.1
+Make a 100 cm cube and a 40 cm radius sphere at one corner. Subtract the sphere from the cube, then check `get_mesh_info` still reports a closed mesh.
+
+## Prompt 3.2
+Union two overlapping boxes, run self-union to clean the overlap, then plane-cut at Z = 80 with hole filling and report open border edges (should be 0).
+
+## Prompt 3.3
+Mirror a half-model across the YZ plane with plane-cut and weld enabled, and confirm the bounds became symmetric.
+
+---
+
+# 4. Selections and poly-edit
+
+## Goal
+Covers `select_all`, `select_by_normal_angle`, `select_in_box`, `select_in_sphere`,
+`select_by_material_id`, `select_by_polygroup`, `expand_contract_selection`, `invert_selection`,
+`selection_count`, `selection_bounds`, `clear_selections`, `extrude_faces`, `offset_faces`,
+`inset_faces`, `outset_faces`, `delete_faces`, `translate_selection`, `bevel_polygroups`,
+`offset_mesh`, `shell_mesh`.
+
+## Prompt 4.1
+On a 100 cm cube select the top faces by normal (within 5°), report the count (2 triangles) and the selection bounds, inset them 6 cm, reselect the top, and extrude it -1.5 cm to make a recessed lid panel.
+
+## Prompt 4.2
+Select the +X side, offset those faces 2 cm, translate the selection 1 cm along X, set material ID 3 on it, then select by material ID 3 and confirm the count matches.
+
+## Prompt 4.3
+Compute polygroups by angle, select polygroup 1, expand the selection by one ring, invert it, and report the three counts. Then bevel the polygroup edges by 0.5 cm and recompute normals with a 30° hard angle.
+
+## Prompt 4.4
+Select the bottom faces, delete them, fill the hole, and confirm the mesh is closed again. Then clear all selections.
+
+## Prompt 4.5
+Make a flat 50 cm rectangle, shell it to 2 cm thickness, then offset the whole surface outward 1 cm.
+
+---
+
+# 5. Mesh processing
+
+## Goal
+Covers `remesh`, `simplify_to_triangle_count`, `simplify_to_vertex_count`, `simplify_to_tolerance`,
+`simplify_planar`, `subdivide` (PN / Uniform / CatmullClark / Loop), `smooth`, `fill_holes`,
+`weld_edges`, `repair`, `remove_hidden_triangles`, `split_by_components`.
+
+## Prompt 5.1
+Take a 40 cm sphere, remesh to 1500 triangles, simplify to 600 triangles, then to 250 vertices, then to a 0.5 cm tolerance; report counts after each step.
+
+## Prompt 5.2
+Subdivide a box once with each method: PN, Uniform, Loop, and — after computing polygroups with the Polygons method — CatmullClark. Then run planar simplify on the CatmullClark result.
+
+## Prompt 5.3
+Append two disjoint boxes into one handle, run repair and remove-hidden-triangles, then split by components into separate handles and report their triangle counts.
+
+---
+
+# 6. Deformation and voxels
+
+## Goal
+Covers `bend`, `twist`, `flare`, `noise`, `displace_from_texture`, `voxel_solidify`,
+`voxel_morphology`.
+
+## Prompt 6.1
+Make a 100 cm tall cylinder with 8 height steps; bend it 30°, twist it 30°, and flare it 20% about its midpoint, reporting bounds after each.
+
+## Prompt 6.2
+Apply Perlin noise (magnitude 2, frequency 0.1) to a sphere, voxel-solidify it at grid 32, then run a voxel Close of 2 cm, and confirm the result is closed.
+
+## Prompt 6.3
+Find any Texture2D in the project and displace a subdivided plane along its normals by 10 cm using that texture in UV layer 0.
+
+---
+
+# 7. UVs, normals, groups, materials, colors
+
+## Goal
+Covers `auto_uv` (XAtlas / PatchBuilder), `project_uv` (Planar / Box / Cylinder), `repack_uv`,
+`set_num_uv_layers`, `recompute_normals`, `flip_normals`, `compute_polygroups` (Angle / UVIslands /
+Components / Polygons), `set_material_id`, `remap_material_id`, `set_vertex_color`.
+
+## Prompt 7.1
+Give a box two UV layers: XAtlas-unwrap layer 0 and PatchBuilder-unwrap layer 1; then box-project layer 0 and repack it at 512.
+
+## Prompt 7.2
+Recompute normals fully smooth, then with a 30° hard angle, flip them and flip them back.
+
+## Prompt 7.3
+Compute polygroups from UV islands and from components, set material ID 2 on the whole mesh, remap 2 → 1, paint the whole mesh white and the top faces green.
+
+---
+
+# 8. Transforms
+
+## Goal
+Covers `transform_mesh`, `translate_mesh`, `rotate_mesh`, `scale_mesh`, `recenter_mesh`.
+
+## Prompt 8.1
+Translate a mesh 10 cm on X and back, rotate it 45° yaw about the origin, scale it 2× on Z, then recenter to Bounds and finally to Base; confirm the bottom sits at Z = 0.
+
+---
+
+# 9. Queries, sampling, hulls, comparison
+
+## Goal
+Covers `ray_cast`, `nearest_point`, `is_point_inside`, `sample_surface_points`, `convex_hull`,
+`convex_decomposition`, `swept_hull`, `measure_distance`.
+
+## Prompt 9.1
+On a 50 cm sphere, cast a ray from (-200,0,0) along +X and report the hit position and triangle; find the nearest surface point to (0,0,120); test whether the origin and (0,0,500) are inside.
+
+## Prompt 9.2
+Scatter Poisson-disc samples with a 15 cm radius on the sphere and report how many you got and the first three transforms.
+
+## Prompt 9.3
+Build the convex hull, a 2-hull convex decomposition, and a swept hull along Z of the boolean result from 3.1, each as new handles, and measure the distance between the sphere and its convex hull (max should be small).
+
+---
+
+# 10. Assets, collision, LODs, baking, placement
+
+## Goal
+Covers `save_mesh_to_static_mesh` (create and replace), `load_mesh_from_static_mesh`,
+`generate_collision`, `set_lods`, `spawn_static_mesh_actor`, `load_mesh_from_actor`,
+`bake_textures`.
+
+## Prompt 10.1
+Save the crate from section 4 as `/Game/Developers/VibeUEModelingTests/SM_Crate` with collision enabled and Nanite off; then save again to the same path to prove replace works, and load it back into a new handle.
+
+## Prompt 10.2
+Generate ConvexHulls collision (max 4 hulls) on that asset and set a 3-entry LOD chain (100 %, 50 %, 25 %). Report the LOD count.
+
+## Prompt 10.3
+Spawn the asset as an actor labeled `ModelingTestCrate`, take a viewport capture framed on it, then load the mesh back from the actor in world space.
+
+## Prompt 10.4
+Bake a 64 px tangent-space normal map and ambient occlusion from the noisy sphere onto the UV'd box into `/Game/Developers/VibeUEModelingTests`, and report the texture asset paths.
+
+---
+
+# 11. Skeletal (needs any SkeletalMesh in the project)
+
+## Goal
+Covers `load_mesh_from_skeletal_mesh`, `transfer_bone_weights`, `smooth_bone_weights`,
+`prune_bone_weights`, `save_mesh_to_skeletal_mesh`.
+
+## Prompt 11.1
+Find a SkeletalMesh in the project, load its LOD 0 into a handle, remesh it to 5000 triangles, transfer bone weights back from the source asset, smooth them against its skeleton, and save as `/Game/Developers/VibeUEModelingTests/SK_Remeshed` bound to the same skeleton.
+
+## Prompt 11.2
+Prune the `root` bone from the remeshed mesh's skin weights and report the result message.
+
+---
+
+# 12. Error handling
+
+## Prompt 12.1
+Call a boolean with the operation `Frobnicate` and an append on handle 999, and show me the exact error messages (they should list the valid operations and tell you how to create a mesh).
+
+## Prompt 12.2
+Try `inset_faces` with a selection name that does not exist and confirm the error names the missing selection.
+
+---
+
+# 13. Cleanup
+
+## Prompt 13.1
+Delete the `ModelingTestCrate` actor, delete everything under `/Game/Developers/VibeUEModelingTests`, and release all modeling handles. Confirm `list_meshes` is empty.

--- a/test_prompts/modeling/modeling_tests.md
+++ b/test_prompts/modeling/modeling_tests.md
@@ -254,3 +254,21 @@ Delete the `ModelingTestCrate` actor, delete everything under `/Game/Developers/
 **Prompt:** "Build a simple tail fin with a rudder: a fin slab, a through-slot cut along the hinge line so the rear third is a separate piece. Create a `root` bone and a `rudder` bone whose X axis runs along the hinge, bind the rudder piece to it, confirm with `list_bones` that the rudder bone owns exactly the rudder's vertices, and save it as `/Game/Developers/Test/SK_Fin` with a new skeleton."
 
 **Expected:** `boolean` Subtract for the slot → `select_connected` on a point in the rudder → `create_bones` (root, rudder) → `bind_selection_to_bone` → `list_bones` showing two bones with non-zero counts → `save_mesh_to_skeletal_mesh(..., "", ...)` producing `SK_Fin` and `SK_Fin_Skeleton`.
+
+## Prompt 15.1 — controlled unwrap
+
+**Prompt:** "Unwrap `/Game/Props/SM_Crate` for hand painting: one UV island per face, no overlaps, packed for a 2K texture. Report island count, coverage and texel density before and after."
+
+**Expected:** `compute_polygroups("Angle")` (or `set_polygroup` per face) → `recompute_uvs(…, "Polygroups")` → `layout_uv("Repack", 2048)` → `get_uv_stats` twice with the numbers quoted; `overlap_fraction` ≈ 0 and `num_unset_triangles` = 0 at the end.
+
+## Prompt 15.2 — masks and markings
+
+**Prompt:** "Make a walkway mask for the wing tops of `SM_F17_Fighter` (red channel), a dirt mask for everything below the wing plane (green), and draw a 6-pixel dashed stripe along the fuselage spine into a new 2K texture. Save the textures under `/Game/Mesh/Vehicles`."
+
+**Expected:** selections by normal / box → `set_vertex_color` per channel → `bake_textures(…, "VertexColor", 2048, …)`; `create_noise_texture` or an existing 8-bit texture + `world_to_uv` for the spine points + `draw_on_texture("Dots", …, spacing_px)`.
+
+## Prompt 15.3 — detail normal map
+
+**Prompt:** "Add a rivet row every 8 cm along both wing leading edges and a 1 cm recessed panel line around the canopy on a detail copy of the fighter, then bake a 4K tangent normal map and AO from it onto the game mesh."
+
+**Expected:** `copy_mesh` → small sphere/cylinder handle for the rivet → `append_mesh_along_polyline` per leading edge → `cut_groove_along_polyline` around the canopy → `bake_textures(game, detail, "TangentNormal,AmbientOcclusion", 4096, …)`; the game mesh itself is untouched.


### PR DESCRIPTION
## Summary
- New `unreal.ModelingService` (`VibeUE.ModelingService` on the MCP endpoint — 100 Python functions / ~95 AICallable tools): the programmatic half of Modeling Mode, driven without a viewport.
- Session model: meshes are integer handles wrapping `UDynamicMesh`; chain operations, then save to `StaticMesh` / `SkeletalMesh` assets. Named selections (all / normal angle / box / sphere / material id / polygroup / expand-contract / invert) drive the poly-edit ops and are refused once stale.
- Coverage: primitives (box, sphere, sphere-box, cylinder, cone, capsule, torus, rectangle, disc, straight + curved stairs, extruded/revolved polygons, swept polylines), booleans (union/subtract/intersection/self-union/plane cut/mirror), extrude/offset/inset/outset/delete faces, polygroup bevel, offset/shell, remesh, simplify (tris/verts/tolerance/planar), subdivide (PN/Uniform/CatmullClark/Loop), smooth, fill holes, weld, repair, hidden-triangle removal, split by components, bend/twist/flare/noise/texture displacement, voxel solidify/morphology, auto-UV (XAtlas/PatchBuilder) + projection + repack, normals, polygroups (angle/UV islands/components/polygons), material ids + remap, vertex colors, transforms, ray cast / nearest point / containment, Poisson surface sampling, convex hull / decomposition / swept hull, mesh distance measurement, bone-weight transfer/smooth/prune, collision generation, LOD chains, texture baking, actor spawning.
- `get_dynamic_mesh(handle)` hands the mesh to any `unreal.GeometryScript_*` library for the long tail; the skill documents which GeometryScript families are wrapped and how to reach the rest.
- New `modeling` skill + `scripts/exercise_all.txt`, `test_prompts/modeling/modeling_tests.md`, an entry in the agent guide sample / README.
- Lofts, orientation and rigging (second round, driven by building and rigging a fighter): `append_loft` (closed-polygon sweep with caps, always outward-facing), `ensure_outward`, `select_connected`, `create_bones` / `bind_selection_to_bone` / `list_bones` (bones and skin weights authored on the session mesh), `save_mesh_to_skeletal_mesh` with an empty skeleton path creating `<Asset>_Skeleton` from the mesh bones, `set_asset_materials`; `bake_textures` now blocks on the async texture build.
- Texturing round: UV island control (`set_polygroup`, `recompute_uvs`, `transform_uv`, `layout_uv`, `pack_uv_per_material`, `get_uv_stats`, `world_to_uv`), mask bakes (`VertexColor`, `MaterialID`, `UVShell`, `Height`) and `bake_texture_transfer`, image tools (`import_texture`, `create_noise_texture`, `draw_on_texture`), surface-detail helpers (`append_mesh_at_transforms`, `append_mesh_along_polyline`, `cut_groove_along_polyline`).
- Build.cs: GeometryCore, GeometryFramework, DynamicMesh, GeometryScriptingCore/Editor, StaticMeshEditor, SkeletalMeshDescription; uplugin depends on GeometryScripting.

## Test plan
- [x] Builds clean under VibeUE's warnings-as-errors on UE 5.8 (PROTEUS host project).
- [x] `Content/Skills/modeling/scripts/exercise_all.txt` — calls every one of the 121 Python functions and diffs against `dir(unreal.ModelingService)`: `called 121/121 functions; failed 0 — RESULT: PASS` (includes the skeletal path against a project SkeletalMesh and a real texture displacement).
- [x] Automation: `Automation RunTests VibeUE.Modeling` — 12/12 green (Session, Primitives, Booleans, SelectionsPolyEdit, MeshOps, DeformVoxel, AttributesTransforms, QueriesHulls, Assets, Errors, LoftsRigging, UVsTexturing). Self-provisioning; write only under `/Game/Developers/VibeUEModelingTests` and delete it.
- [x] `test_prompts/modeling/modeling_tests.md` — 15 sections of agent prompts covering every function, in the repo's sequential-prompt format.
- [x] `list_toolsets` shows `VibeUE.ModelingService`; `ListSkills` shows `modeling`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

