### PR TITLE
Merge UE 5.8 updates into master

### DIFF
--- a/Source/VibeUE/Private/PythonAPI/AssetDiscoveryServiceTests.cpp
+++ b/Source/VibeUE/Private/PythonAPI/AssetDiscoveryServiceTests.cpp
@@ -1,0 +1,96 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#include "Misc/AutomationTest.h"
+
+#if WITH_AUTOMATION_TESTS
+
+#include "PythonAPI/UAssetDiscoveryService.h"
+#include "EditorAssetLibrary.h"
+#include "HAL/FileManager.h"
+#include "Misc/Base64.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeAssetReimportTest, "VibeUE.Assets.ReimportAsset",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FVibeAssetReimportTest::RunTest(const FString&)
+{
+	UFunction* Function = UAssetDiscoveryService::StaticClass()->FindFunctionByName(
+		GET_FUNCTION_NAME_CHECKED(UAssetDiscoveryService, ReimportAsset));
+	TestNotNull(TEXT("ReimportAsset is reflected"), Function);
+	if (Function)
+	{
+		TestTrue(TEXT("ReimportAsset is AICallable"), Function->HasMetaData(TEXT("AICallable")));
+	}
+
+	FString SourceFileUsed;
+	FString Error;
+	TestFalse(TEXT("missing asset is rejected"), UAssetDiscoveryService::ReimportAsset(
+		TEXT("/Game/VibeUETests/T_MissingReimportAsset"), TEXT(""), SourceFileUsed, Error));
+	TestTrue(TEXT("missing asset reports a useful error"), Error.Contains(TEXT("not found")));
+
+	const FString TestDirectory = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("VibeUE/ReimportAssetTest"));
+	const FString OriginalSource = FPaths::Combine(TestDirectory, TEXT("original.png"));
+	const FString ReplacementSource = FPaths::Combine(TestDirectory, TEXT("replacement.png"));
+	const FString AssetPackagePath = TEXT("/Game/VibeUETests/T_ReimportAssetTest");
+
+	IFileManager::Get().MakeDirectory(*TestDirectory, true);
+	if (UEditorAssetLibrary::DoesAssetExist(AssetPackagePath))
+	{
+		UEditorAssetLibrary::DeleteAsset(AssetPackagePath);
+	}
+
+	// Valid one-pixel PNG used only as a deterministic legacy texture-import fixture.
+	TArray<uint8> PngBytes;
+	const bool bDecoded = FBase64::Decode(
+		TEXT("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="),
+		PngBytes);
+	TestTrue(TEXT("PNG fixture decoded"), bDecoded);
+	TestTrue(TEXT("original PNG fixture written"), bDecoded && FFileHelper::SaveArrayToFile(PngBytes, *OriginalSource));
+	TestTrue(TEXT("replacement PNG fixture written"), bDecoded && FFileHelper::SaveArrayToFile(PngBytes, *ReplacementSource));
+
+	const FString ImportedPath = UAssetDiscoveryService::ImportAsset(
+		OriginalSource, TEXT("/Game/VibeUETests"), TEXT("T_ReimportAssetTest"), Error);
+	TestFalse(TEXT("texture fixture imported"), ImportedPath.IsEmpty());
+	if (!ImportedPath.IsEmpty())
+	{
+		SourceFileUsed.Empty();
+		Error.Empty();
+		TestTrue(TEXT("legacy texture reimports with an explicit source"),
+			UAssetDiscoveryService::ReimportAsset(ImportedPath, OriginalSource, SourceFileUsed, Error));
+		TestTrue(TEXT("explicit source is reported"), FPaths::IsSamePath(SourceFileUsed, OriginalSource));
+
+		SourceFileUsed.Empty();
+		Error.Empty();
+		TestTrue(TEXT("legacy texture reimports from its stored source"),
+			UAssetDiscoveryService::ReimportAsset(ImportedPath, TEXT(""), SourceFileUsed, Error));
+		TestTrue(TEXT("stored source is reported"), FPaths::IsSamePath(SourceFileUsed, OriginalSource));
+
+		IFileManager::Get().Delete(*OriginalSource, false, true);
+		SourceFileUsed.Empty();
+		Error.Empty();
+		TestFalse(TEXT("missing stored source is rejected without prompting"),
+			UAssetDiscoveryService::ReimportAsset(ImportedPath, TEXT(""), SourceFileUsed, Error));
+		TestTrue(TEXT("missing source error names the problem"), Error.Contains(TEXT("does not exist")));
+
+		SourceFileUsed.Empty();
+		Error.Empty();
+		TestTrue(TEXT("replacement source retargets and reimports the asset"),
+			UAssetDiscoveryService::ReimportAsset(ImportedPath, ReplacementSource, SourceFileUsed, Error));
+		TestTrue(TEXT("replacement source is reported"), FPaths::IsSamePath(SourceFileUsed, ReplacementSource));
+	}
+
+	if (UEditorAssetLibrary::DoesAssetExist(AssetPackagePath))
+	{
+		UEditorAssetLibrary::SaveAsset(AssetPackagePath, false);
+		UEditorAssetLibrary::DeleteAsset(AssetPackagePath);
+	}
+	IFileManager::Get().Delete(*OriginalSource, false, true);
+	IFileManager::Get().Delete(*ReplacementSource, false, true);
+	IFileManager::Get().DeleteDirectory(*TestDirectory, false, true);
+
+	return true;
+}
+
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/VibeUE/Private/PythonAPI/UAssetDiscoveryService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UAssetDiscoveryService.cpp
@@ -8,6 +8,7 @@
 #include "Editor.h"
 #include "AssetToolsModule.h"
 #include "IAssetTools.h"
+#include "EditorFramework/AssetImportData.h"
 #include "Engine/Texture2D.h"
 #include "HAL/PlatformFileManager.h"
 #include "ContentBrowserModule.h"
@@ -16,6 +17,7 @@
 #include "Misc/Paths.h"
 #include "Misc/FileHelper.h"
 #include "Factories/TextureFactory.h"
+#include "EditorReimportHandler.h"
 #include "UObject/Package.h"
 
 // ========== Texture Operations ==========
@@ -155,6 +157,120 @@ FString UAssetDiscoveryService::ImportAsset(
 
 	UE_LOG(LogTemp, Log, TEXT("UAssetDiscoveryService::ImportAsset: imported '%s' -> '%s'"), *SourceFilePath, *NewObj->GetPathName());
 	return NewObj->GetPathName();
+}
+
+bool UAssetDiscoveryService::ReimportAsset(
+	const FString& AssetPath,
+	const FString& NewSourcePath,
+	FString& OutSourceFileUsed,
+	FString& OutError)
+{
+	OutSourceFileUsed.Empty();
+	OutError.Empty();
+
+	if (AssetPath.IsEmpty())
+	{
+		OutError = TEXT("AssetPath is required");
+		return false;
+	}
+
+	if (!UEditorAssetLibrary::DoesAssetExist(AssetPath))
+	{
+		OutError = FString::Printf(TEXT("Asset was not found: %s"), *AssetPath);
+		return false;
+	}
+
+	UObject* Asset = UEditorAssetLibrary::LoadAsset(AssetPath);
+	if (!Asset)
+	{
+		OutError = FString::Printf(TEXT("Asset was not found or could not be loaded: %s"), *AssetPath);
+		return false;
+	}
+
+	FReimportManager* ReimportManager = FReimportManager::Instance();
+	if (!ReimportManager)
+	{
+		OutError = TEXT("Unreal's reimport manager is unavailable");
+		return false;
+	}
+
+	FString ReplacementSource;
+	if (!NewSourcePath.IsEmpty())
+	{
+		ReplacementSource = FPaths::ConvertRelativePathToFull(NewSourcePath);
+		FPaths::NormalizeFilename(ReplacementSource);
+		if (!FPaths::FileExists(ReplacementSource))
+		{
+			OutError = FString::Printf(TEXT("New source file does not exist: %s"), *ReplacementSource);
+			return false;
+		}
+
+		// Let the registered handler update the correct import-data representation. This
+		// works for both Interchange and legacy factories without asset-type branching.
+		ReimportManager->UpdateReimportPath(Asset, ReplacementSource, INDEX_NONE);
+	}
+
+	TArray<FString> SourceFiles;
+	if (!ReimportManager->CanReimport(Asset, &SourceFiles))
+	{
+		OutError = FString::Printf(
+			TEXT("No registered reimport handler supports asset '%s'%s"),
+			*AssetPath,
+			ReplacementSource.IsEmpty() ? TEXT("") : TEXT(" with the supplied source file"));
+		return false;
+	}
+
+	if (SourceFiles.IsEmpty())
+	{
+		OutError = FString::Printf(TEXT("Asset has no stored source file: %s"), *AssetPath);
+		return false;
+	}
+
+	// Report the selected source even when validation or the handler later fails. This makes
+	// failure responses actionable, especially for assets whose stored source has moved.
+	OutSourceFileUsed = ReplacementSource.IsEmpty()
+		? UAssetImportData::ResolveImportFilename(SourceFiles[0], Asset->GetOutermost())
+		: ReplacementSource;
+	FPaths::NormalizeFilename(OutSourceFileUsed);
+
+	for (const FString& SourceFile : SourceFiles)
+	{
+		if (SourceFile.IsEmpty())
+		{
+			OutError = FString::Printf(TEXT("Asset has an empty stored source file: %s"), *AssetPath);
+			return false;
+		}
+		FString ResolvedSourceFile = UAssetImportData::ResolveImportFilename(SourceFile, Asset->GetOutermost());
+		FPaths::NormalizeFilename(ResolvedSourceFile);
+		if (!FPaths::FileExists(ResolvedSourceFile))
+		{
+			OutError = FString::Printf(TEXT("Stored source file does not exist: %s"), *ResolvedSourceFile);
+			return false;
+		}
+	}
+
+	const bool bReimported = ReimportManager->Reimport(
+		Asset,
+		/*bAskForNewFileIfMissing=*/ false,
+		/*bShowNotification=*/ false,
+		/*PreferredReimportFile=*/ TEXT(""),
+		/*SpecifiedReimportHandler=*/ nullptr,
+		/*SourceFileIndex=*/ INDEX_NONE,
+		/*bForceNewFile=*/ false,
+		/*bAutomated=*/ true);
+
+	if (!bReimported)
+	{
+		OutError = FString::Printf(
+			TEXT("Reimport failed for asset '%s' using source file '%s'. See the Unreal log for handler details."),
+			*AssetPath,
+			*OutSourceFileUsed);
+		return false;
+	}
+
+	UE_LOG(LogTemp, Log, TEXT("UAssetDiscoveryService::ReimportAsset: reimported '%s' from '%s'"),
+		*AssetPath, *OutSourceFileUsed);
+	return true;
 }
 
 bool UAssetDiscoveryService::ExportTexture(const FString& AssetPath, const FString& ExportFilePath)

--- a/Source/VibeUE/Public/PythonAPI/UAssetDiscoveryService.h
+++ b/Source/VibeUE/Public/PythonAPI/UAssetDiscoveryService.h
@@ -77,6 +77,30 @@ public:
 		FString& OutError);
 
 	/**
+	 * Reimport an existing asset through the same handler used by Content Browser Reimport.
+	 *
+	 * Supports both Interchange and legacy factory imports. When NewSourcePath is supplied,
+	 * the registered reimport handler is asked to retarget the asset before reimporting it.
+	 * The operation is automated and never opens a missing-file picker or notification.
+	 *
+	 * @param AssetPath         - Content path or object path of the asset to reimport
+	 * @param NewSourcePath     - Optional replacement source file; empty uses the stored source
+	 * @param OutSourceFileUsed - Receives the resolved source file selected for reimport
+	 * @param OutError          - Receives a human-readable error message on failure
+	 * @return True when Unreal's registered reimport handler completed successfully
+	 *
+	 * Python signature:
+	 *   success, source_file, error = unreal.AssetDiscoveryService.reimport_asset(
+	 *       "/Game/Characters/SKM_Player", "D:/Source/SKM_Player.fbx")
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable, CPP_Default_NewSourcePath = ""), Category = "VibeUE|Assets")
+	static bool ReimportAsset(
+		const FString& AssetPath,
+		const FString& NewSourcePath,
+		FString& OutSourceFileUsed,
+		FString& OutError);
+
+	/**
 	 * Export a texture to the file system for external analysis.
 	 *
 	 * @param AssetPath - Path to the texture asset

--- a/Source/VibeUE/Public/PythonAPI/UAssetDiscoveryService.h
+++ b/Source/VibeUE/Public/PythonAPI/UAssetDiscoveryService.h
@@ -89,9 +89,11 @@ public:
 	 * @param OutError          - Receives a human-readable error message on failure
 	 * @return True when Unreal's registered reimport handler completed successfully
 	 *
-	 * Python signature:
-	 *   success, source_file, error = unreal.AssetDiscoveryService.reimport_asset(
+	 * Python usage (Unreal maps a false bool plus out parameters to None):
+	 *   result = unreal.AssetDiscoveryService.reimport_asset(
 	 *       "/Game/Characters/SKM_Player", "D:/Source/SKM_Player.fbx")
+	 *   if result is not None:
+	 *       source_file, error = result
 	 */
 	UFUNCTION(BlueprintCallable, meta = (AICallable, CPP_Default_NewSourcePath = ""), Category = "VibeUE|Assets")
 	static bool ReimportAsset(

--- a/Source/VibeUE/VibeUE.Build.cs
+++ b/Source/VibeUE/VibeUE.Build.cs
@@ -12,12 +12,13 @@ public class VibeUE : ModuleRules
 		IWYUSupport = IWYUSupport.None;
 		// Disable unity builds to ensure each file compiles independently
 		bUseUnity = false;
-		// Treat warnings as errors for THIS module only (adds /WX for our .cpp files,
-		// not the host project or other plugins). This promotes deprecation warnings
-		// such as C4996 to hard errors so UE-version-compat issues (e.g. deprecated
-		// engine APIs) fail the build here instead of surfacing only on contributors'
-		// clean installs. See PR #438.
-		bWarningsAsErrors = true;
+		// Do not add blanket /WX to this module. Engine patch releases can introduce
+		// deprecation warnings in engine headers included by VibeUE, and /WX turns
+		// those upstream C4996 diagnostics into plugin build failures. UnrealBuildTool
+		// still applies its curated warning-as-error policy; deprecations remain visible
+		// as warnings so supported-engine CI can identify VibeUE-owned API migrations.
+		// See issues #491 and #569.
+		bWarningsAsErrors = false;
 
 		// FabService (issue #517) talks to fab.com via the signed-in Epic account's EOS auth token,
 		// reusing the login the editor/launcher already holds. EOSSDK provides the SDK headers and the


### PR DESCRIPTION
## Summary
- merge the UE 5.8 compatibility work from `5-8` into `master`
- include the UE 5.8.2 deprecation-warning build fix from #572
- include the C++ `FReimportManager` asset-reimport support from #573

## Validation
- UE 5.8.2 Win64 `BuildPlugin`: successful
- `VibeUE.Assets.ReimportAsset` headless automation: successful
- skeletal FBX reimport validated through both Interchange and the legacy FBX factory

Closes #569
Closes #570