### PR TITLE
skills: six traps found building and rigging showcase assets

### DIFF
--- a/Content/Skills/animation-blueprint/SKILL.md
+++ b/Content/Skills/animation-blueprint/SKILL.md
@@ -403,6 +403,104 @@ Returned by `validate_state_machine()`.
 
 ---
 
+## Driving bones directly — skeletal controls, no state machine
+
+Not every AnimBP is a state machine. A spinning rotor, a windmill sail, a turret yaw, a rudder that
+follows a variable — all are a **pose piped through Modify Bone nodes**, which is a different graph
+shape and has its own traps.
+
+The chain is always: a pose source → **Local To Component** → one Modify Bone per bone →
+**Component To Local** → Output. Skeletal controls only operate in component space, and
+`connect_anim_nodes` does **not** insert the space conversions for you.
+
+```python
+import unreal
+AG, BS = unreal.AnimGraphService, unreal.BlueprintService
+PATH, G = "/Game/ABP_Windmill", "AnimGraph"
+
+REF = "SPAWN AnimGraphNode_LocalRefPose|Local Space Ref Pose"   # no sequence needed
+L2C = "SPAWN AnimGraphNode_LocalToComponentSpace|Local To Component"
+C2L = "SPAWN AnimGraphNode_ComponentToLocalSpace|Component To Local"
+
+ref = BS.create_node_by_key(PATH, G, REF, -900, -80)
+l2c = BS.create_node_by_key(PATH, G, L2C, -640, -80)
+AG.connect_anim_nodes(PATH, G, ref, "Pose", l2c, "LocalPose")
+
+mb = AG.add_modify_bone_node(PATH, G, "sails", -340, -80)
+AG.connect_anim_nodes(PATH, G, l2c, "ComponentPose", mb, "ComponentPose")
+getter = BS.create_node_by_key(PATH, G, "SPAWN K2Node_VariableGet|Get SailRotation", -400, 200)
+BS.connect_nodes(PATH, G, getter, "SailRotation", mb, "Rotation")
+
+c2l = BS.create_node_by_key(PATH, G, C2L, 0, -80)
+AG.connect_anim_nodes(PATH, G, mb, "Pose", c2l, "ComponentPose")
+AG.connect_to_output_pose(PATH, G, c2l, "Pose")
+```
+
+Pin names to remember: `LocalPose` in / `ComponentPose` out on Local To Component; `ComponentPose`
+in / `Pose` out on Modify Bone and Component To Local.
+
+### ⚠️ Modify Bone ignores its Rotation pin until you set the mode
+
+`add_modify_bone_node` creates the node with `rotation_mode`, `translation_mode` and `scale_mode` all
+set to **Ignore**. You can connect the Rotation pin, compile clean, and see *absolutely nothing move* —
+there is no warning. Set the mode on the node's inner `node` struct after creating it:
+
+```python
+for i in range(0, 12):
+    o = unreal.find_object(None, f"{PATH}.{name}:{G}.AnimGraphNode_ModifyBone_{i}")
+    if not o:
+        continue
+    n = o.get_editor_property("node")
+    n.set_editor_property("rotation_mode", unreal.BoneModificationMode.BMM_ADDITIVE)
+    n.set_editor_property("rotation_space", unreal.BoneControlSpace.BCS_COMPONENT_SPACE)
+    n.set_editor_property("translation_mode", unreal.BoneModificationMode.BMM_IGNORE)
+    n.set_editor_property("scale_mode", unreal.BoneModificationMode.BMM_IGNORE)
+    o.set_editor_property("node", n)      # write the struct back, or the change is lost
+```
+
+`BMM_ADDITIVE` and `BMM_REPLACE` behave identically when the bone is at identity in the ref pose.
+
+### ⚠️ Variable getter names differ between BP variables and C++ properties
+
+`create_node_by_key` needs the spawner key, which embeds the node's **display name**, and the two
+kinds of variable are spelled differently:
+
+| Variable lives on | Display name | Spawner key |
+|---|---|---|
+| The AnimBP itself (`add_member_variable`) | `Get SailRotation` | `SPAWN K2Node_VariableGet\|Get SailRotation` |
+| A C++ `UAnimInstance` subclass | `Get Sail Rotation` (spaced) | `SPAWN K2Node_VariableGet\|Get Sail Rotation` |
+
+Never hard-code either — `discover_nodes(PATH, "SailRotation", "", 20)` and match on `display_name`,
+which works for both.
+
+### Continuous motion without an animation asset
+
+Put the accumulator in the AnimBP's **EventGraph** on `Event Blueprint Update Animation` (its
+`DeltaTimeX` pin), write a float, and convert it to the Rotator the Modify Bone reads:
+
+```
+DeltaTimeX ─┐
+            ├─ float * float ─ float * float ─┐        (RPM → deg/sec is × 6)
+SpinRPM ────┘                    6.0 ─────────┤
+                                              ├─ float + float ─→ SET SailAngle
+SailAngle (get) ──────────────────────────────┘
+SailAngle (get) ─→ MakeRotator(Roll=) ─→ SET SailRotation
+```
+
+Float maths nodes are `FUNC KismetMathLibrary::Multiply_DoubleDouble` and `::Add_DoubleDouble`
+(display names `float * float` / `float + float`) — Blueprint "float" is a double in UE5.
+`MakeRotator` is `FUNC KismetMathLibrary::MakeRotator` with pins `Roll`, `Pitch`, `Yaw`.
+
+Verify it is actually running rather than trusting the compile: in PIE read the variable off the live
+instance, twice, in **separate** `execute_python_code` calls (see the pie-testing skill — Python
+blocks the game thread, so a sampling loop inside one call returns the same value every time).
+
+```python
+comp = actor.get_components_by_class(unreal.SkeletalMeshComponent)[0]
+ai = comp.get_anim_instance()
+print(ai.get_editor_property("SailAngle"), comp.get_socket_rotation("sails").roll)
+```
+
 ## Common Patterns
 
 ### Check if Asset is AnimBP

--- a/Content/Skills/asset-management/SKILL.md
+++ b/Content/Skills/asset-management/SKILL.md
@@ -63,6 +63,32 @@ names = unreal.DataTableFunctionLibrary.get_data_table_row_names(dt)   # row key
 
 ## Critical Rules
 
+### ⚠️ Never `delete_asset` a Blueprint you loaded or compiled this session
+
+`EditorAssetLibrary.delete_asset` on a Blueprint (Anim Blueprints especially) that is still loaded —
+which it is, if you created, compiled or read it earlier in the same script — fails inside
+`ForceDeleteObjects` and leaves the package **half-deleted and corrupt**:
+
+```
+Ensure condition failed: false [ObjectTools.cpp:4045]
+Failed to unload all packages during ForceDeleteObjects - these packages are likely corrupt.
+Consider restarting the editor, noting which assets remain and then deleting them from the
+file system manually: /Game/Path/ABP_Thing
+```
+
+Every later call against that path then times out, and the editor typically has to be killed. The
+recovery is exactly what the message says — close the editor, delete the `.uasset` from disk,
+relaunch (watch for a ZenServer stall on the way back up) — so it costs several minutes.
+
+**The rebuild-an-asset pattern**, instead of delete-then-create:
+
+- Write to a **new name** and swap references, or
+- Delete the file on disk while the editor is closed, then create it fresh, or
+- Edit the existing asset in place (clear the graph, re-add nodes) rather than recreating it.
+
+The same caution applies to any asset currently open in an editor tab or referenced by a loaded
+level. Non-Blueprint assets you never loaded (textures, meshes written by a factory) delete fine.
+
 ### ⚠️ Out-Params Become Return Values in Python — Never Pass an `AssetData` Argument
 
 `get_primary_content_browser_selection` is shaped like `bool Func(FAssetData& Out)` in C++ and is

--- a/Content/Skills/blueprints/SKILL.md
+++ b/Content/Skills/blueprints/SKILL.md
@@ -36,6 +36,30 @@ related_skills:
 
 ## Critical Rules
 
+### ⚠️ Components added with `add_component` are NOT on the CDO
+
+`add_component` creates a **SCS node template**, not an instance on the class default object. So the
+obvious way to configure it silently does nothing — `get_components_by_class` on the CDO returns an
+empty list and the loop body never runs:
+
+```python
+# WRONG - prints [], the mesh is never assigned, and nothing errors
+cdo = unreal.get_default_object(bp.generated_class())
+for c in cdo.get_components_by_class(unreal.SkeletalMeshComponent):
+    c.set_editor_property("skeletal_mesh_asset", mesh)
+
+# CORRECT - go through the service, which edits the SCS template
+BS.set_component_property(BP, "Windmill", "SkeletalMeshAsset", "/Game/X/SK_Windmill.SK_Windmill")
+BS.set_component_property(BP, "Windmill", "AnimationMode", "AnimationBlueprint")
+BS.set_component_property(BP, "Windmill", "AnimClass", "/Game/X/ABP_Windmill.ABP_Windmill_C")
+```
+
+Values are strings: an asset takes its **object path** (`/Game/X/SK.SK`), a class takes the
+`_C` path, an enum takes the entry name. Read back with `get_component_property` to confirm — it
+returns the resolved object, e.g.
+`/Script/Engine.SkeletalMesh'/Game/X/SK_Windmill.SK_Windmill'`. Components that come from the
+**parent C++ class** *are* on the CDO and can be set directly; only SCS-added ones need the service.
+
 ### Level Blueprints: pass the MAP path
 
 Every `unreal.BlueprintService.*` function that takes a `blueprint_path` also accepts a **map/world

--- a/Content/Skills/level-actors/SKILL.md
+++ b/Content/Skills/level-actors/SKILL.md
@@ -26,6 +26,36 @@ unreal_classes:
 
 ## Critical Rules
 
+### ⚠️ `unreal.Rotator(a, b, c)` is `(roll, pitch, yaw)` — always pass by keyword
+
+Python's `FRotator` constructor takes **roll, pitch, yaw** (X, Y, Z), *not* the C++
+`FRotator(Pitch, Yaw, Roll)` order. Passing a yaw positionally lands it in **pitch**, and nothing
+warns you — the call succeeds and the actor is simply wrong:
+
+```python
+# WRONG - pitches the actor onto its nose; yaw stays 0
+actor.set_actor_rotation(unreal.Rotator(0.0, yaw, 0.0), False)
+
+# CORRECT
+actor.set_actor_rotation(unreal.Rotator(roll=0.0, pitch=0.0, yaw=yaw), False)
+```
+
+Observed failures from this exact mistake: a row of enemies rolled 180° and pitched instead of
+turned to face the player, a spawned sofa upside down, and a DirectionalLight aimed at the sky so
+every viewport capture came back black. It applies equally to
+`spawn_actor_from_class(cls, location, rotation)` and `spawn_actor_from_object`.
+
+**Verify, don't assume** — read it back (`r = actor.get_actor_rotation(); r.roll/r.pitch/r.yaw`) or
+check `get_actor_bounds`: a mesh that should sit on the floor and reports a negative Z range got
+flipped. A "look at this point" camera or actor rotation is:
+
+```python
+d = target - location
+rot = unreal.Rotator(roll=0.0,
+                     pitch=math.degrees(math.atan2(d.z, math.hypot(d.x, d.y))),
+                     yaw=math.degrees(math.atan2(d.y, d.x)))
+```
+
 ### � Creating a "Basic" Level Requires `new_level_from_template`, NOT `new_level`
 
 When the user asks to **create a new level** (especially "Basic", "Default", or with a sky/floor), **always** use `new_level_from_template`:

--- a/Content/Skills/pie-testing/SKILL.md
+++ b/Content/Skills/pie-testing/SKILL.md
@@ -154,6 +154,17 @@ unreal.PerformanceService.set_background_throttling(True)    # after
 
 ## Gotchas
 
+- **Python blocks the game thread, so you cannot sample a value over time in one call.** A loop with `time.sleep()` between reads returns the *same* number every iteration — the world never ticks while your script holds the thread. This makes a working animation look frozen and a stuck one look identical to a healthy one. Take each sample in a **separate** `execute_python_code` call and compare across them:
+
+  ```python
+  # WRONG - three identical readings, proves nothing
+  for i in range(3):
+      print(ai.get_editor_property("SailAngle")); time.sleep(0.4)
+
+  # CORRECT - one reading per call; the elapsed wall-clock between calls is real tick time
+  print(ai.get_editor_property("SailAngle"))
+  ```
+  Convert the difference into the engineering unit you expect and check it: 306° → 709° across ~8 s is 48°/s, which is exactly the 8 RPM that was configured — that is a pass, "the number changed" is not.
 - **PIE start is asynchronous.** `StartPIE` returns immediately after `RequestPlaySession` is queued. The world isn't actually playing until the editor processes the request on its next tick. If you need to act inside the running world, give it a tick or poll `IsPIERunning`.
 - **Already-running is treated as success.** `StartPIE` succeeds if a PIE session already exists — it does NOT restart. Stop first if you need a fresh session.
 - **`StopPIE` tears down the world** via `RequestEndPlayMap`. Spawned PIE widget instances should be removed with `WidgetService.remove_widget_from_pie(handle)` before stopping.

--- a/Content/Skills/viewport/SKILL.md
+++ b/Content/Skills/viewport/SKILL.md
@@ -57,6 +57,26 @@ keywords:
 
 ## Critical Rules
 
+### ⚠️ A black capture usually means no lighting, not a broken mesh
+
+The most common cause of an all-black (or blown-out white) capture is the **level**, not the camera
+and not the asset you just built. Two things to check before you start debugging geometry:
+
+1. **A level made with `new_level()` has no lighting at all** — no sun, no sky, no atmosphere. Use
+   `new_level_from_template(path, "/Engine/Maps/Templates/Template_Default")` instead (see the
+   `level-actors` skill). If you must light an empty level by hand you need a DirectionalLight that
+   genuinely points **down** — `unreal.Rotator(roll=0, pitch=-48, yaw=125)`, and note the argument
+   order is (roll, pitch, yaw), so a positionally-passed pitch aims the sun at the sky and the scene
+   stays black — plus a SkyLight with `real_time_capture`, and a SkyAtmosphere.
+2. **Auto-exposure lies about colour.** With adaptation on, a dark material renders near-white and a
+   bright one renders grey, so you cannot judge a material from a capture. Add an unbound
+   PostProcessVolume with `auto_exposure_method = AEM_MANUAL`; then `auto_exposure_bias` is a
+   brightness stop — **higher is brighter**, and the usable window is narrow (0 was pitch black and
+   13.5 blown out in one scene; 7.5 was correct). Tune it by capturing, not by reasoning.
+
+Keep the volume out of frame (move it far below the set) — an unbound volume still applies globally
+but its bounds box draws in the editor viewport.
+
 ### ⚠️ Valid View Types for `set_viewport_type`
 
 Only these exact strings are accepted (case-insensitive):


### PR DESCRIPTION
Six skill updates, all from traps hit while building five props and a rigged, animated windmill with Vibe3D in a single session. Every one of them fails **silently** — the call succeeds, the Blueprint compiles, and the result is just wrong — so they cost real rework rather than showing up as errors.

Docs only; no code, no behaviour change.

| Skill | What was added |
|---|---|
| `animation-blueprint` | New **"Driving bones directly"** section. The skill was entirely state machines, but a rotor / windmill sail / turret is a pose piped through Modify Bone — a different graph shape. Covers the ref pose → Local To Component → Modify Bone → Component To Local → Output chain (`connect_anim_nodes` does *not* insert the space conversions), the pin names, and continuous motion from `Event Blueprint Update Animation`. |
| `asset-management` | `delete_asset` on a still-loaded Blueprint fails inside `ForceDeleteObjects` and leaves a **corrupt package**; later calls against that path time out and the editor has to be killed. Recovery + rebuild-without-deleting patterns. |
| `blueprints` | Components added with `add_component` are SCS templates and are **not on the CDO**, so the natural `get_components_by_class` loop iterates an empty list and assigns nothing. Use `set_component_property`. |
| `level-actors` | `unreal.Rotator(a, b, c)` is **(roll, pitch, yaw)**, not the C++ `(Pitch, Yaw, Roll)`. A positional yaw lands in pitch. |
| `pie-testing` | Python **blocks the game thread**, so sampling a value in a loop inside one call returns the same number every iteration — a working animation looks frozen and a broken one looks identical. Sample across separate calls and check the *rate*. |
| `viewport` | A black capture is usually the level, not the mesh: `new_level()` has no lighting, and auto-exposure makes materials unjudgeable. Points at `new_level_from_template` and manual exposure. |

### Two worth calling out

**Modify Bone is a silent no-op by default.** `add_modify_bone_node` creates the node with `rotation_mode`, `translation_mode` and `scale_mode` all `Ignore`. You can wire the Rotation pin, compile clean, and nothing moves. It also needs the inner `node` struct written back after editing, or the change is dropped.

**Rotator order caused four separate defects in one session** — enemies rolled 180° and pitched instead of turned, a sofa spawned upside down, a mug handle built as a horizontal donut, and a DirectionalLight aimed at the sky so every capture came back black and looked like a broken asset.

### Verification
`VibeUE.ReloadSkills` registers all 88 skills cleanly with the edits in place.