### PR TITLE
Fix BuildPlugin.bat skipping .uplugin detection when an engine path is passed

### DIFF
--- a/BuildPlugin.bat
+++ b/BuildPlugin.bat
@@ -25,23 +25,11 @@ REM Get plugin directory (where this script is located)
 set "PLUGIN_DIR=%~dp0"
 set "PLUGIN_DIR=%PLUGIN_DIR:~0,-1%"
 
-REM Check if UE path was provided as parameter
-set "UE_PATH="
-if not "%~1"=="" (
-    echo Checking provided Unreal Engine path...
-    if exist "%~1\Engine\Build\BatchFiles\RunUAT.bat" (
-        set "UE_PATH=%~1"
-        echo Using provided UE path: !UE_PATH!
-        goto :ue_found
-    ) else (
-        echo WARNING: Provided path is not a valid Unreal Engine installation.
-        echo Expected to find: %~1\Engine\Build\BatchFiles\RunUAT.bat
-        echo Falling back to automatic detection...
-        echo.
-    )
-)
-
 REM Find .uplugin file
+REM NOTE: this must run BEFORE the UE path check below. When an engine path is
+REM passed as %1, that check ends in "goto :ue_found", which jumps past this
+REM block. UPLUGIN_PATH then stays empty and RunUAT is invoked as "-Plugin=",
+REM failing with: System.ArgumentException: The path is empty. (Parameter 'path')
 set "UPLUGIN_PATH="
 for %%F in ("%PLUGIN_DIR%\*.uplugin") do (
     set "UPLUGIN_PATH=%%F"
@@ -57,6 +45,22 @@ exit /b 1
 :uplugin_found
 for %%F in ("%UPLUGIN_PATH%") do set "PLUGIN_NAME=%%~nF"
 echo Found plugin: %PLUGIN_NAME%
+
+REM Check if UE path was provided as parameter
+set "UE_PATH="
+if not "%~1"=="" (
+    echo Checking provided Unreal Engine path...
+    if exist "%~1\Engine\Build\BatchFiles\RunUAT.bat" (
+        set "UE_PATH=%~1"
+        echo Using provided UE path: !UE_PATH!
+        goto :ue_found
+    ) else (
+        echo WARNING: Provided path is not a valid Unreal Engine installation.
+        echo Expected to find: %~1\Engine\Build\BatchFiles\RunUAT.bat
+        echo Falling back to automatic detection...
+        echo.
+    )
+)
 
 REM Search for Unreal Engine installation using registry (standard method)
 echo Searching for Unreal Engine installation...


### PR DESCRIPTION
## Problem

Passing an engine path as the first argument makes `BuildPlugin.bat` fail before any build starts:

```
Parsing command line: BuildPlugin -Plugin= -Package="C:\...\Packaged" -CreateSubFolder -TargetPlatforms=Win64
System.ArgumentException: The path is empty. (Parameter 'path')
   at EpicGames.Core.FileReference..ctor(String inPath)
   at BuildPlugin.ExecuteBuild()
AutomationTool exiting with ExitCode=1 (Error_Unknown)
```

`-Plugin=` is empty, and `Found plugin: <name>` never appears in the output.

## Cause

The UE path check ends in `goto :ue_found`, which jumps to a label placed *after* the `.uplugin` detection block:

```bat
if not "%~1"=="" (
    if exist "%~1\Engine\Build\BatchFiles\RunUAT.bat" (
        set "UE_PATH=%~1"
        goto :ue_found        <-- jumps past the block below
    )
)

REM Find .uplugin file        <-- never runs when %1 is given
set "UPLUGIN_PATH="
...
```

So `UPLUGIN_PATH` is never assigned and RunUAT receives an empty `-Plugin=`.

This is worse than it first looks: the script is unusable in *both* modes on engines the automatic detection cannot find — installs outside the hardcoded `Epic Games\UE_x.y` paths and without an `HKLM\SOFTWARE\EpicGames\Unreal Engine\<ver>` registry entry (e.g. `D:\EpicGames\UE_5.8`). Without the argument it cannot locate the engine; with the argument it cannot locate the plugin.

## Fix

Move the `.uplugin` detection above the engine path check so it always runs. Ordering change only — no logic change. A comment records why the order matters, so the block does not drift back below the `goto`.

## Verification

UE 5.8, engine at `D:\EpicGames\UE_5.8` (not auto-detectable), plugin outside any project.

Before — fails in under a second:
```
Plugin:
System.ArgumentException: The path is empty. (Parameter 'path')
```

After:
```
Found plugin: VibeUE
Parsing command line: BuildPlugin -Plugin="C:\...\VibeUE\VibeUE.uplugin" ...
[93/93] WriteMetadata UnrealEditor.target
BUILD SUCCESSFUL
AutomationTool executed for 0h 6m 9s
```

The resulting packaged plugin was installed to `Engine/Plugins/Marketplace/VibeUE` and loads correctly: 35 VibeUE toolsets and 38 skills register through the MCP server.
