### PR TITLE
capture_image: refuse minimized windows instead of risking a Slate crash

### DIFF
--- a/Source/VibeUE/Private/Tools/CaptureTools.cpp
+++ b/Source/VibeUE/Private/Tools/CaptureTools.cpp
@@ -41,6 +41,32 @@ namespace
 		return Out;
 	}
 
+	// A minimized window has no valid Slate paint state: TakeScreenshot against it usually
+	// fails gracefully but can null-deref inside Slate (two EXCEPTION_ACCESS_VIOLATION
+	// editor crashes with all-Slate callstacks while an automation client drove a
+	// minimized editor, 2026-09-01). Refuse with an actionable error instead — callers
+	// can restore the window (ShowWindow/AppActivate) and retry.
+	bool EnsureWindowCapturable(const TSharedPtr<SWindow>& Window, FString& OutError)
+	{
+		if (!Window.IsValid())
+		{
+			OutError = TEXT("No window found for the capture target.");
+			return false;
+		}
+		if (Window->IsWindowMinimized())
+		{
+			OutError = TEXT("The editor window is minimized — Slate cannot capture a minimized window (and may crash trying). Restore the window (e.g. ShowWindow/AppActivate from the client) and retry.");
+			return false;
+		}
+		const FVector2D WindowSize = Window->GetSizeInScreen();
+		if (WindowSize.X < 1.0f || WindowSize.Y < 1.0f)
+		{
+			OutError = TEXT("The editor window has zero size — nothing to capture.");
+			return false;
+		}
+		return true;
+	}
+
 	bool CaptureGameViewport(TArray<FColor>& OutPixels, FIntPoint& OutSize, FString& OutError)
 	{
 		if (!GEngine || !GEngine->GameViewport)
@@ -52,6 +78,10 @@ namespace
 		if (!ViewportWidget.IsValid() || !FSlateApplication::IsInitialized())
 		{
 			OutError = TEXT("Game viewport widget unavailable.");
+			return false;
+		}
+		if (!EnsureWindowCapturable(FSlateApplication::Get().FindWidgetWindow(ViewportWidget.ToSharedRef()), OutError))
+		{
 			return false;
 		}
 		FIntVector Size;
@@ -80,6 +110,10 @@ namespace
 		if (!Window.IsValid())
 		{
 			OutError = TEXT("No editor window available to capture.");
+			return false;
+		}
+		if (!EnsureWindowCapturable(Window, OutError))
+		{
 			return false;
 		}
 		FIntVector Size;


### PR DESCRIPTION
## Problem

`FSlateApplication::TakeScreenshot` against a widget whose window is **minimized** usually fails gracefully, but can null-deref inside Slate. Two editor crashes on 2026-09-01 (EXCEPTION_ACCESS_VIOLATION reading 0x0, all-Slate callstacks) while an automation client drove a minimized PROTEUS editor through `capture_image`.

## Fix

New `EnsureWindowCapturable` guard on both Slate capture paths (game viewport via `FindWidgetWindow`, active/root window directly): a minimized or zero-size window returns a clean, actionable error telling the client to restore the window (`ShowWindow`/`AppActivate`) and retry, without ever entering `TakeScreenshot`. The editor-viewport path (`ReadPixels`) is unaffected.

## Verification

Live against the PROTEUS editor (UE 5.8):
- Minimized editor -> `CAPTURE_FAILED` with the new message, no crash
- Restored editor -> capture works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)