### PR TITLE
AnimSequenceService writes NumFrames+1 keys; AssetDiscoveryService gains a dialog-free delete

### DIFF
--- a/Content/Skills/animsequence/api-reference.md
+++ b/Content/Skills/animsequence/api-reference.md
@@ -171,7 +171,7 @@ Use `AnimSequenceService` for animation sequence operations.
 # Create static animation from reference pose
 anim_path = AnimSequenceService.create_from_pose(skeleton_path, anim_name, save_path, duration) -> str
 
-# Create animation with custom keyframes
+# Create animation with custom keyframes ("" = failed; an empty clip is never left behind)
 anim_path = AnimSequenceService.create_anim_sequence(skeleton_path, anim_name, save_path, duration, frame_rate, bone_tracks) -> str
 
 # Get reference pose keyframe for a bone

--- a/Content/Skills/animsequence/workflows.md
+++ b/Content/Skills/animsequence/workflows.md
@@ -263,6 +263,13 @@ if anim_path:
 
 Use `create_anim_sequence` to create an animation with custom bone tracks and keyframes.
 
+> ✅ Fixed 2026-09-02: the service used to hand the data model one key too few (NumFrames instead
+> of NumFrames + 1), so every track was silently rejected and the "created" asset had no
+> animation (`get_animated_bones` empty, `get_animation_frame_count` -1). It now writes one key
+> per frame boundary and REFUSES (returns "" and discards the asset) when no track accepted its
+> keys, so an empty string means "look at the log", never "an empty clip is on disk". Always
+> read back `get_animated_bones(anim_path)` after creating a clip.
+
 **IMPORTANT: Keyframe transforms are ABSOLUTE local-space values, NOT deltas from reference pose.**
 - `position` - Absolute local position relative to parent bone
 - `rotation` - Absolute local rotation as quaternion

--- a/Content/Skills/asset-management/SKILL.md
+++ b/Content/Skills/asset-management/SKILL.md
@@ -63,6 +63,25 @@ names = unreal.DataTableFunctionLibrary.get_data_table_row_names(dt)   # row key
 
 ## Critical Rules
 
+### ⚠️ `delete_asset` on a REFERENCED asset opens a modal dialog that wedges an unattended editor
+
+`EditorAssetLibrary.delete_asset` asks "this asset is referenced, force delete?" through a modal
+window when anything points at the asset (a data asset holding the montage you are replacing, a
+Blueprint default, a level). Nobody answers it from MCP: the game thread stalls (308 s observed),
+every later call hangs, and the process has to be force-killed with the files removed from disk.
+Use the plugin's dialog-free delete instead:
+
+```python
+# Refuses when referenced and tells you who (returns None on refusal -> read the out params):
+result = unreal.AssetDiscoveryService.delete_asset_unattended("/Game/Anim/AM_Old", False)
+# Delete anyway and null every reference (what the dialog's Force Delete does):
+result = unreal.AssetDiscoveryService.delete_asset_unattended("/Game/Anim/AM_Old", True)
+```
+
+A `False` return maps to `None` in Python; the `(referencers, error)` tuple comes back on success
+too, so you always see what pointed at the asset. Prefer creating the replacement under a NEW name
+and repointing references over force-deleting.
+
 ### ⚠️ Never `delete_asset` a Blueprint you loaded or compiled this session
 
 `EditorAssetLibrary.delete_asset` on a Blueprint (Anim Blueprints especially) that is still loaded —
@@ -111,7 +130,7 @@ if asset:
 |-----------|-----|
 | Search / find / list assets | engine **`AssetTools`** toolset via `call_tool`, or `unreal.AssetRegistryHelpers.get_asset_registry()` |
 | Load / save / save-all | `unreal.EditorAssetLibrary.load_asset` / `save_asset` / `save_directory`, or `AssetTools` |
-| Move / rename / duplicate / delete | `unreal.EditorAssetLibrary.rename_asset` (move), `duplicate_asset`, `delete_asset`, or `AssetTools` |
+| Move / rename / duplicate / delete | `unreal.EditorAssetLibrary.rename_asset` (move), `duplicate_asset`, `delete_asset` (unreferenced only — see the modal warning above), or `AssetTools`; `unreal.AssetDiscoveryService.delete_asset_unattended` for anything that may be referenced |
 | Existence check | `unreal.EditorAssetLibrary.does_asset_exist(path)` |
 | Referencers / dependencies | `unreal.AssetRegistryHelpers.get_asset_registry().get_referencers(...)` |
 | Open an asset / list ALL open editors | Epic `EditorAppToolset` via `call_tool` (see below) |

--- a/Source/VibeUE/Private/PythonAPI/AnimSequenceServiceTests.cpp
+++ b/Source/VibeUE/Private/PythonAPI/AnimSequenceServiceTests.cpp
@@ -1,0 +1,131 @@
+// Copyright Buckley Builds LLC 2026 All Rights Reserved.
+
+#include "Misc/AutomationTest.h"
+
+#if WITH_AUTOMATION_TESTS
+
+#include "PythonAPI/UAnimSequenceService.h"
+#include "PythonAPI/UAssetDiscoveryService.h"
+#include "Animation/AnimSequence.h"
+#include "Animation/AnimData/IAnimationDataModel.h"
+#include "Animation/Skeleton.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "AssetRegistry/IAssetRegistry.h"
+#include "EditorAssetLibrary.h"
+
+namespace
+{
+	/** Any skeleton the project has: the test authors a throwaway clip against it. */
+	FString FindAnySkeletonPath()
+	{
+		FAssetRegistryModule& Registry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+		TArray<FAssetData> Skeletons;
+		Registry.Get().GetAssetsByClass(USkeleton::StaticClass()->GetClassPathName(), Skeletons, true);
+		for (const FAssetData& Data : Skeletons)
+		{
+			const FString Path = Data.GetObjectPathString();
+			if (Path.StartsWith(TEXT("/Game/")) || Path.StartsWith(TEXT("/Engine/")))
+			{
+				return Path;
+			}
+		}
+		return FString();
+	}
+}
+
+// create_anim_sequence used to hand the data model NumFrames keys where it wants NumFrames + 1
+// (one per frame boundary), so every track was rejected and the saved asset had no animation.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeAnimSequenceCreateWritesKeysTest, "VibeUE.Animation.CreateAnimSequence.WritesKeys",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FVibeAnimSequenceCreateWritesKeysTest::RunTest(const FString&)
+{
+	const FString SkeletonPath = FindAnySkeletonPath();
+	if (SkeletonPath.IsEmpty())
+	{
+		AddInfo(TEXT("No skeleton asset available; skipping"));
+		return true;
+	}
+	USkeleton* Skeleton = Cast<USkeleton>(UEditorAssetLibrary::LoadAsset(SkeletonPath));
+	if (!Skeleton || Skeleton->GetReferenceSkeleton().GetNum() == 0)
+	{
+		AddInfo(TEXT("Skeleton has no bones; skipping"));
+		return true;
+	}
+	const FString BoneName = Skeleton->GetReferenceSkeleton().GetBoneName(0).ToString();
+	const FString AssetName = TEXT("AS_VibeUETest_CreateWritesKeys");
+	const FString SavePath = TEXT("/Game/VibeUETests");
+	const FString AssetPath = SavePath / AssetName;
+
+	TArray<FString> Referencers;
+	FString Error;
+	UAssetDiscoveryService::DeleteAssetUnattended(AssetPath, true, Referencers, Error); // leftovers from an earlier run
+
+	// Two keys: identity at 0 s, a quarter turn about Y at the end
+	const float Duration = 0.5f;
+	const float FrameRate = 30.f;
+	FBoneTrackData Track;
+	Track.BoneName = BoneName;
+	FAnimKeyframe Start;
+	Start.Time = 0.f;
+	FAnimKeyframe End;
+	End.Time = Duration;
+	End.Frame = FMath::RoundToInt(Duration * FrameRate);
+	End.Rotation = FQuat(FVector::YAxisVector, FMath::DegreesToRadians(90.f));
+	Track.Keyframes = { Start, End };
+
+	const FString Created = UAnimSequenceService::CreateAnimSequence(SkeletonPath, AssetName, SavePath, Duration, FrameRate, { Track });
+	TestFalse(TEXT("create_anim_sequence returns a path"), Created.IsEmpty());
+	if (Created.IsEmpty())
+	{
+		return false;
+	}
+
+	UAnimSequence* Sequence = Cast<UAnimSequence>(UEditorAssetLibrary::LoadAsset(Created));
+	TestNotNull(TEXT("created asset loads as an AnimSequence"), Sequence);
+	if (Sequence)
+	{
+		const IAnimationDataModel* Model = Sequence->GetDataModel();
+		TestNotNull(TEXT("data model exists"), Model);
+		if (Model)
+		{
+			const int32 ExpectedFrames = FMath::RoundToInt(Duration * FrameRate);
+			TestEqual(TEXT("frame count matches duration x rate"), Model->GetNumberOfFrames(), ExpectedFrames);
+			TestEqual(TEXT("one key per frame boundary"), Model->GetNumberOfKeys(), ExpectedFrames + 1);
+			TArray<FName> TrackNames;
+			Model->GetBoneTrackNames(TrackNames);
+			TestTrue(TEXT("the requested bone has a track"), TrackNames.Contains(FName(*BoneName)));
+			// The last key must carry the authored rotation, not the reference pose
+			const FTransform LastKey = Model->GetBoneTrackTransform(FName(*BoneName), FFrameNumber(ExpectedFrames));
+			TestTrue(TEXT("last key is the authored quarter turn"), LastKey.GetRotation().Equals(End.Rotation, 0.01f));
+		}
+	}
+
+	// Cleanup through the unattended delete (also exercises its unreferenced path)
+	TestTrue(TEXT("unattended delete removes the test clip"), UAssetDiscoveryService::DeleteAssetUnattended(AssetPath, false, Referencers, Error));
+	TestFalse(TEXT("asset is gone"), UEditorAssetLibrary::DoesAssetExist(AssetPath));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVibeDeleteAssetUnattendedTest, "VibeUE.Assets.DeleteAssetUnattended",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FVibeDeleteAssetUnattendedTest::RunTest(const FString&)
+{
+	UFunction* Function = UAssetDiscoveryService::StaticClass()->FindFunctionByName(
+		GET_FUNCTION_NAME_CHECKED(UAssetDiscoveryService, DeleteAssetUnattended));
+	TestNotNull(TEXT("DeleteAssetUnattended is reflected"), Function);
+	if (Function)
+	{
+		TestTrue(TEXT("DeleteAssetUnattended is AICallable"), Function->HasMetaData(TEXT("AICallable")));
+	}
+
+	TArray<FString> Referencers;
+	FString Error;
+	TestFalse(TEXT("missing asset is refused"), UAssetDiscoveryService::DeleteAssetUnattended(TEXT("/Game/VibeUETests/AS_DoesNotExist"), false, Referencers, Error));
+	TestTrue(TEXT("missing asset reports not found"), Error.Contains(TEXT("not found")));
+	TestFalse(TEXT("empty path is refused"), UAssetDiscoveryService::DeleteAssetUnattended(TEXT(""), false, Referencers, Error));
+	return true;
+}
+
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/VibeUE/Private/PythonAPI/UAnimSequenceService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UAnimSequenceService.cpp
@@ -33,6 +33,7 @@
 #include "IImageWrapperModule.h"
 #include "Modules/ModuleManager.h"
 #include "Utils/VibeUEPaths.h"
+#include "ObjectTools.h"
 
 // ============================================================================
 // PRIVATE HELPERS
@@ -760,18 +761,21 @@ FString UAnimSequenceService::CreateAnimSequence(
 		TArray<FQuat4f> RotationalKeys;
 		TArray<FVector3f> ScalingKeys;
 
-		// For proper animation, we need keys for every frame
-		// Interpolate between the provided keyframes
-		PositionalKeys.SetNum(NumFrames);
-		RotationalKeys.SetNum(NumFrames);
-		ScalingKeys.SetNum(NumFrames);
+		// The data model wants one key per frame BOUNDARY: NumFrames + 1 keys (frame 0 .. NumFrames).
+		// Handing it NumFrames keys made SetBoneTrackKeys reject every track, which left a saved
+		// asset with a track and no keys — the caller got a path back and an animation that
+		// reported no animated bones and a frame count of -1.
+		const int32 NumKeys = NumFrames + 1;
+		PositionalKeys.SetNum(NumKeys);
+		RotationalKeys.SetNum(NumKeys);
+		ScalingKeys.SetNum(NumKeys);
 
 		// Sort keyframes by time
 		TArray<FAnimKeyframe> SortedKeyframes = TrackData.Keyframes;
 		SortedKeyframes.Sort([](const FAnimKeyframe& A, const FAnimKeyframe& B) { return A.Time < B.Time; });
 
-		// Interpolate keyframes to fill all frames
-		for (int32 FrameIdx = 0; FrameIdx < NumFrames; ++FrameIdx)
+		// Interpolate keyframes to fill every key
+		for (int32 FrameIdx = 0; FrameIdx < NumKeys; ++FrameIdx)
 		{
 			float FrameTime = (float)FrameIdx / FrameRate;
 
@@ -834,6 +838,17 @@ FString UAnimSequenceService::CreateAnimSequence(
 	// Close bracket to finalize all changes
 	Controller.CloseBracket();
 
+	// Tracks were requested but none took: do not leave an empty animation on disk behind a
+	// success path. Delete the fresh (unreferenced) asset without any dialog and fail loudly.
+	if (BoneTracks.Num() > 0 && TracksAdded == 0)
+	{
+		UE_LOG(LogTemp, Error, TEXT("UAnimSequenceService::CreateAnimSequence: no bone track accepted its keys (%d requested) - discarding %s"), BoneTracks.Num(), *FullPath);
+		TArray<UObject*> Discard;
+		Discard.Add(NewAnimSeq);
+		ObjectTools::ForceDeleteObjects(Discard, /*bShowConfirmation*/ false);
+		return FString();
+	}
+
 	// Mark as modified and save
 	NewAnimSeq->MarkPackageDirty();
 	if (!UEditorAssetLibrary::SaveAsset(FullPath))
@@ -842,7 +857,7 @@ FString UAnimSequenceService::CreateAnimSequence(
 		return FString();
 	}
 
-	UE_LOG(LogTemp, Log, TEXT("UAnimSequenceService::CreateAnimSequence: Created animation: %s with %d bone tracks"), *FullPath, TracksAdded);
+	UE_LOG(LogTemp, Log, TEXT("UAnimSequenceService::CreateAnimSequence: Created animation: %s with %d bone tracks (%d keys each)"), *FullPath, TracksAdded, NumFrames + 1);
 	return FullPath;
 }
 

--- a/Source/VibeUE/Private/PythonAPI/UAssetDiscoveryService.cpp
+++ b/Source/VibeUE/Private/PythonAPI/UAssetDiscoveryService.cpp
@@ -19,6 +19,8 @@
 #include "Factories/TextureFactory.h"
 #include "EditorReimportHandler.h"
 #include "UObject/Package.h"
+#include "ObjectTools.h"
+#include "UObject/ReferencerFinder.h"
 
 // ========== Texture Operations ==========
 
@@ -381,4 +383,90 @@ bool UAssetDiscoveryService::IsAssetOpen(const FString& AssetPath)
 
 	UE_LOG(LogTemp, Log, TEXT("UAssetDiscoveryService::IsAssetOpen: %s is %s"), *AssetPath, bIsOpen ? TEXT("open") : TEXT("closed"));
 	return bIsOpen;
+}
+
+bool UAssetDiscoveryService::DeleteAssetUnattended(const FString& AssetPath, bool bForceEvenIfReferenced, TArray<FString>& OutReferencers, FString& OutError)
+{
+	OutReferencers.Reset();
+	OutError.Reset();
+	if (AssetPath.IsEmpty())
+	{
+		OutError = TEXT("AssetPath is empty");
+		return false;
+	}
+	if (!UEditorAssetLibrary::DoesAssetExist(AssetPath))
+	{
+		OutError = FString::Printf(TEXT("Asset not found: %s"), *AssetPath);
+		return false;
+	}
+
+	// Who points at it (the question the modal dialog would have asked the human)
+	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	const FString PackageName = FPackageName::ObjectPathToPackageName(AssetPath);
+	TArray<FName> ReferencerNames;
+	AssetRegistryModule.Get().GetReferencers(FName(*PackageName), ReferencerNames);
+	for (const FName& Referencer : ReferencerNames)
+	{
+		const FString ReferencerString = Referencer.ToString();
+		if (ReferencerString != PackageName && !ReferencerString.StartsWith(TEXT("/Temp/")) && !ReferencerString.StartsWith(TEXT("/Engine/Transient")))
+		{
+			OutReferencers.Add(ReferencerString);
+		}
+	}
+	UObject* Asset = UEditorAssetLibrary::LoadAsset(AssetPath);
+	if (!Asset)
+	{
+		OutError = FString::Printf(TEXT("Failed to load asset: %s"), *AssetPath);
+		return false;
+	}
+
+	// The registry lags a freshly saved referencer (a montage built on this clip seconds ago is
+	// not in its dependency map yet), so also ask memory: every loaded asset package that holds
+	// a pointer to this object counts. Transient / compiled-in outers are the Python wrapper and
+	// the editor itself, not references worth refusing over.
+	const TArray<UObject*> Referencees = { Asset };
+	for (UObject* Referencer : FReferencerFinder::GetAllReferencers(Referencees, nullptr))
+	{
+		UPackage* Package = Referencer ? Referencer->GetOutermost() : nullptr;
+		if (!Package || Package == Asset->GetOutermost() || Package == GetTransientPackage() || Package->HasAnyPackageFlags(PKG_CompiledIn))
+		{
+			continue;
+		}
+		const FString ReferencerPackage = Package->GetName();
+		if (ReferencerPackage.StartsWith(TEXT("/Game/")) || ReferencerPackage.StartsWith(TEXT("/Engine/")) || FPackageName::IsValidLongPackageName(ReferencerPackage))
+		{
+			if (!ReferencerPackage.StartsWith(TEXT("/Temp/")) && !ReferencerPackage.StartsWith(TEXT("/Engine/Transient")))
+			{
+				OutReferencers.AddUnique(ReferencerPackage);
+			}
+		}
+	}
+	if (OutReferencers.Num() > 0 && !bForceEvenIfReferenced)
+	{
+		OutError = FString::Printf(TEXT("%s is referenced by %d asset(s); pass bForceEvenIfReferenced to delete anyway and clear the references"), *AssetPath, OutReferencers.Num());
+		return false;
+	}
+	// Close any editor showing it first, or the delete is refused
+	if (GEditor)
+	{
+		if (UAssetEditorSubsystem* AssetEditors = GEditor->GetEditorSubsystem<UAssetEditorSubsystem>())
+		{
+			AssetEditors->CloseAllEditorsForAsset(Asset);
+		}
+	}
+
+	TArray<UObject*> Objects;
+	Objects.Add(Asset);
+	// Always the force path, with no confirmation: the asset-registry check above is the real
+	// "is anything on disk pointing at it" gate. The plain DeleteObjects refuses (returns 0, or
+	// would ask) over IN-MEMORY references — the Python variable that just created or loaded the
+	// asset is enough — which is exactly the case an unattended session is always in.
+	const int32 Deleted = ObjectTools::ForceDeleteObjects(Objects, /*bShowConfirmation*/ false);
+	if (Deleted <= 0)
+	{
+		OutError = FString::Printf(TEXT("Force delete of %s returned 0 (is it open in an editor, or a Blueprint still loaded this session? see the asset-management skill)"), *AssetPath);
+		return false;
+	}
+	UE_LOG(LogTemp, Log, TEXT("UAssetDiscoveryService::DeleteAssetUnattended: deleted %s (%d referencer(s) cleared)"), *AssetPath, OutReferencers.Num());
+	return true;
 }

--- a/Source/VibeUE/Public/PythonAPI/UAssetDiscoveryService.h
+++ b/Source/VibeUE/Public/PythonAPI/UAssetDiscoveryService.h
@@ -95,6 +95,32 @@ public:
 	 *   if result is not None:
 	 *       source_file, error = result
 	 */
+	/**
+	 * Delete an asset with NO dialog, for unattended agent sessions. The engine's
+	 * EditorAssetLibrary.delete_asset pops a modal "asset is referenced" dialog when anything
+	 * points at the asset, and an MCP-driven editor cannot answer it: the game thread stalls
+	 * until someone force-kills the process. This function never asks. With
+	 * bForceEvenIfReferenced it force-deletes and nulls every reference (the same thing the
+	 * dialog's Force Delete button does); without it, a referenced asset is refused and the
+	 * referencers are returned so the caller can decide.
+	 *
+	 * @param AssetPath              - Package path of the asset (/Game/Folder/Asset)
+	 * @param bForceEvenIfReferenced - True: delete anyway and clear references; false: refuse if referenced
+	 * @param OutReferencers         - Package paths that referenced the asset (filled on refusal AND on force)
+	 * @param OutError               - Human-readable reason when the delete did not happen
+	 * @return True when the asset is gone
+	 *
+	 * Python usage:
+	 *   result = unreal.AssetDiscoveryService.delete_asset_unattended("/Game/Anim/AS_Temp", True)
+	 *   if result is not None: referencers, error = result   # a false return maps to None
+	 */
+	UFUNCTION(BlueprintCallable, meta = (AICallable, CPP_Default_bForceEvenIfReferenced = "false"), Category = "VibeUE|Assets")
+	static bool DeleteAssetUnattended(
+		const FString& AssetPath,
+		bool bForceEvenIfReferenced,
+		TArray<FString>& OutReferencers,
+		FString& OutError);
+
 	UFUNCTION(BlueprintCallable, meta = (AICallable, CPP_Default_NewSourcePath = ""), Category = "VibeUE|Assets")
 	static bool ReimportAsset(
 		const FString& AssetPath,


### PR DESCRIPTION
## Summary
- `create_anim_sequence` handed the animation data model one key too few (NumFrames instead of NumFrames + 1), so every bone track was rejected and the saved asset had no animation while the caller got a success path. It now writes one key per frame boundary, and if no track accepts its keys it discards the fresh asset and returns `""` rather than leaving an empty clip on disk.
- New `AssetDiscoveryService.delete_asset_unattended(path, force)` for MCP-driven sessions: `EditorAssetLibrary.delete_asset` pops a modal "asset is referenced" dialog nobody can answer, stalling the game thread until the process is killed. The new call checks the asset registry and in-memory referencers, refuses and names them unless forced, and otherwise force-deletes with no confirmation.
- Skills: animsequence workflows/api-reference note the fix; asset-management leads with the modal warning and the new call.

## Tests
- `VibeUE.Animation.CreateAnimSequence.WritesKeys` and `VibeUE.Assets.DeleteAssetUnattended` (new), both pass headless.
- Docstring consistency test run headless.
- Verified in a live editor: a two-key clip reads back its authored rotation; delete refused while a montage referenced the clip, force-delete cleared the reference, unreferenced delete succeeded.

Found while authoring the Proteus barrel-roll clips (AB#148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)